### PR TITLE
Update activity timestamp on `,play`, `,stop`, `,skip`, and guess [#198]

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -18,6 +18,7 @@ class PlayCommand implements BaseCommand {
             let channel = message.channel as TextChannel;
             if (!gameSessions[message.guild.id]) {
                 gameSessions[message.guild.id] = new GameSession(channel);
+                // GameSession constructor sets lastActive to current time during constructor
                 logger.info(`${getDebugContext(message)} | Game session created`);
             }
             await sendInfoMessage(message, `Game starting in #${channel.name}`, "Listen to the song and type your guess!");

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -18,7 +18,6 @@ class PlayCommand implements BaseCommand {
             let channel = message.channel as TextChannel;
             if (!gameSessions[message.guild.id]) {
                 gameSessions[message.guild.id] = new GameSession(channel);
-                // GameSession constructor sets lastActive to current time during constructor
                 logger.info(`${getDebugContext(message)} | Game session created`);
             }
             await sendInfoMessage(message, `Game starting in #${channel.name}`, "Listen to the song and type your guess!");

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -31,6 +31,7 @@ class SkipCommand implements BaseCommand {
             await gameSession.endRound();
             startGame(gameSession, guildPreference, db, message, client);
             logger.info(`${getDebugContext(message)} | Skip majority achieved.`);
+            gameSession.lastActive = Date.now();
         }
         else {
             await sendSkipNotification(message, gameSession);

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -31,12 +31,12 @@ class SkipCommand implements BaseCommand {
             await gameSession.endRound();
             startGame(gameSession, guildPreference, db, message, client);
             logger.info(`${getDebugContext(message)} | Skip majority achieved.`);
-            gameSession.lastActive = Date.now();
         }
         else {
             await sendSkipNotification(message, gameSession);
             logger.info(`${getDebugContext(message)} | Skip vote received.`);
         }
+        gameSession.lastActiveNow();
     }
     help = {
         name: "skip",

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -10,6 +10,7 @@ class StopCommand implements BaseCommand {
             logger.info(`${getDebugContext(message)} | Game round ended: ${gameSession.getDebugSongDetails()}`);
             await sendSongMessage(message, gameSession, true);
             await gameSession.endRound();
+            gameSession.lastActive = Date.now();
         }
     }
     help = {

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -10,7 +10,7 @@ class StopCommand implements BaseCommand {
             logger.info(`${getDebugContext(message)} | Game round ended: ${gameSession.getDebugSongDetails()}`);
             await sendSongMessage(message, gameSession, true);
             await gameSession.endRound();
-            gameSession.lastActive = Date.now();
+            gameSession.lastActiveNow();
         }
     }
     help = {

--- a/src/kmq.ts
+++ b/src/kmq.ts
@@ -61,8 +61,9 @@ client.on("message", async (message: Discord.Message) => {
         }
     }
     else {
-        if (gameSessions[message.guild.id]) {
+        if (gameSessions[message.guild.id] && gameSessions[message.guild.id].gameInSession()) {
             guessSong({ client, message, gameSessions, guildPreference, db });
+            gameSessions[message.guild.id].lastActive = Date.now();
         }
     }
 });

--- a/src/kmq.ts
+++ b/src/kmq.ts
@@ -63,7 +63,7 @@ client.on("message", async (message: Discord.Message) => {
     else {
         if (gameSessions[message.guild.id] && gameSessions[message.guild.id].gameInSession()) {
             guessSong({ client, message, gameSessions, guildPreference, db });
-            gameSessions[message.guild.id].lastActive = Date.now();
+            gameSessions[message.guild.id].lastActiveNow();
         }
     }
 });

--- a/src/models/game_session.ts
+++ b/src/models/game_session.ts
@@ -40,7 +40,6 @@ export default class GameSession {
         this.videoID = link;
         this.inSession = true;
         this.skipAchieved = false;
-        this.lastActive = Date.now();
     }
 
     endRound(): Promise<void> {
@@ -50,7 +49,6 @@ export default class GameSession {
             this.videoID = null;
             this.inSession = false;
             this.skippers.clear();
-            this.lastActive = Date.now();
             if (this.dispatcher) {
                 this.dispatcher.removeAllListeners();
                 this.dispatcher.end();

--- a/src/models/game_session.ts
+++ b/src/models/game_session.ts
@@ -89,4 +89,8 @@ export default class GameSession {
     getDebugSongDetails(): string {
         return `${this.song}:${this.artist}:${this.videoID}`;
     }
+
+    lastActiveNow(): void {
+        this.lastActive = Date.now();
+    }
 };


### PR DESCRIPTION
- Don't need to update on `,end` since GameSession gets destroyed anyway
- Now we only process guesses when game is in session, not processing when game is stopped

Closes #198 