### PR TITLE
No longer hardcap limit based on number of filtered songs [#215]

### DIFF
--- a/src/commands/limit.ts
+++ b/src/commands/limit.ts
@@ -8,10 +8,6 @@ const DEFAULT_LIMIT = 500;
 class LimitCommand implements BaseCommand {
     async call({ message, parsedMessage, guildPreference, db }: CommandArgs) {
         guildPreference.setLimit(parseInt(parsedMessage.components[0]), db);
-        let songCount = await getSongCount(guildPreference, db);
-        if (guildPreference.getLimit() > songCount) {
-            guildPreference.setLimit(songCount, db);
-        }
         await sendOptionsMessage(message, guildPreference, db, GameOptions.LIMIT);
         logger.info(`${getDebugContext(message)} | Limit set to ${guildPreference.getLimit()}`);
     }


### PR DESCRIPTION
This check was originally used to fix the `,options` message to prevent cases like "Now playing 500 out of 200 songs." The `,options` message now has proper logic to show this correctly, without modifying the internal guild preference limit. This will prevent unintended limit changes 

Closes #215