### PR TITLE
Workaround for bug where delay between songs continuously increased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -678,7 +678,7 @@
       }
     },
     "erlpack": {
-      "version": "github:discordapp/erlpack#c514d36ec81a7a61ef90b75df261025ab046574d",
+      "version": "github:discordapp/erlpack#ff0139045ca4cc457462e5a1a88f6a0bc5c27c4b",
       "from": "github:discordapp/erlpack",
       "requires": {
         "bindings": "^1.5.0",

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -16,13 +16,13 @@ class PlayCommand implements BaseCommand {
             logger.warn(`${getDebugContext(message)} | User not in voice channel`);
         }
         else {
-            const channel = message.channel as TextChannel;
             if (!gameSessions[message.guild.id]) {
-                gameSessions[message.guild.id] = new GameSession(channel);
-                await sendInfoMessage(message, `Game starting in #${channel.name}`, "Listen to the song and type your guess!");
-                logger.info(`${getDebugContext(message)} | Game session created`);
+                const textChannel = message.channel as TextChannel;
+                const voiceChannel = message.member.voiceChannel;
+                gameSessions[message.guild.id] = new GameSession(textChannel, voiceChannel);
+                await sendInfoMessage(message, `Game starting in #${textChannel.name} in 🔊 ${voiceChannel.name}`, "Listen to the song and type your guess!");
             }
-            startGame(gameSessions[message.guild.id], guildPreference, db, message, client, message.member.voiceChannel);
+            startGame(gameSessions, guildPreference, db, message, client);
         }
     }
     aliases = ["random"]

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -30,7 +30,7 @@ class SkipCommand implements BaseCommand {
             await sendSkipMessage(message, gameSession);
             await sendSongMessage(message, gameSession, true);
             gameSession.endRound(false);
-            startGame(gameSession, guildPreference, db, message, client);
+            startGame(gameSessions, guildPreference, db, message, client);
             logger.info(`${getDebugContext(message)} | Skip majority achieved.`);
         }
         else {

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,9 +1,11 @@
 import BaseCommand, { CommandArgs } from "./base_command";
 import { sendInfoMessage } from "../helpers/discord_utils";
+import { getGuildPreference } from "../helpers/game_utils";
 
 class StopCommand implements BaseCommand {
-    async call({ message }: CommandArgs) {
-        await sendInfoMessage(message, "Command Deprecated", "This command is no longer supported. Please use `,end` when ending a game instead.");
+    async call({ message, db }: CommandArgs) {
+        const guildPreference = await getGuildPreference(db, message.guild.id);
+        await sendInfoMessage(message, "Command Deprecated", `This command is no longer supported. Please use \`${guildPreference.getBotPrefix()}end\` when ending a game instead.`);
     }
     help = {
         name: "stop",

--- a/src/kmq.ts
+++ b/src/kmq.ts
@@ -86,13 +86,6 @@ client.on("voiceStateUpdate", async (oldState, newState) => {
                 return;
             }
         }
-        // Bot was disconnected voice channel (either via a kick by an admin or the situation handled above)
-        if (oldState.user === client.user && !oldUserChannel.members.has(client.user.id)) {
-            if (gameSession) {
-                logger.info(`gid: ${oldUserChannel.guild.id} | Bot disconnected.`)
-                await gameSessions[newState.guild.id].endSession(gameSessions, db);
-            }
-        }
     }
 });
 

--- a/src/models/game_session.ts
+++ b/src/models/game_session.ts
@@ -1,5 +1,5 @@
 import Scoreboard from "./scoreboard";
-import { StreamDispatcher, VoiceConnection, TextChannel, Message } from "discord.js"
+import { StreamDispatcher, VoiceConnection, TextChannel, Message, VoiceChannel } from "discord.js"
 import _logger from "../logger";
 import { Databases } from "types";
 import GameRound from "./game_round";
@@ -16,13 +16,15 @@ export default class GameSession {
     public finished: boolean;
     public lastActive: number;
     public textChannel: TextChannel;
+    public voiceChannel: VoiceChannel;
     public gameRound: GameRound;
-
+    public roundsPlayed: number;
+    
     private guessTimes: Array<number>;
     private participants: Set<string>;
-    private roundsPlayed: number;
 
-    constructor(textChannel: TextChannel) {
+
+    constructor(textChannel: TextChannel, voiceChannel: VoiceChannel) {
         this.scoreboard = new Scoreboard();
         this.lastActive = Date.now();
         this.sessionInitialized = false;
@@ -33,6 +35,7 @@ export default class GameSession {
         this.dispatcher = null;
         this.connection = null;
         this.finished = false;
+        this.voiceChannel = voiceChannel;
         this.textChannel = textChannel;
         this.gameRound = null;
     }


### PR DESCRIPTION
Increasing delay between `voiceConnection.play()` calls resets every time we re-join the voice connection. GameSession automatically leaves and rejoins the channel every 15 seconds as a workaround.