### PR TITLE
Recreate available songs table in a transaction

### DIFF
--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -32,14 +32,14 @@ export async function playCorrectGuessSong(gameSession: GameSession) {
 async function getFilteredSongList(guildPreference: GuildPreference, ignoredVideoIds?: Array<string>): Promise<{ songs: QueriedSong[], countBeforeLimit: number }> {
     let result: Array<QueriedSong>;
     if (guildPreference.getGroupIds() === null) {
-        result = await dbContext.kpopVideos("available_songs")
+        result = await dbContext.kmq("available_songs")
             .select(["song_name as name", "artist_name as artist", "link as youtubeLink"])
             .whereIn("members", guildPreference.getSQLGender().split(","))
             .andWhere("publishedon", ">=", `${guildPreference.getBeginningCutoffYear()}-01-01`)
             .andWhere("publishedon", "<=", `${guildPreference.getEndCutoffYear()}-12-31`)
             .orderBy("views", "DESC");
     } else {
-        result = await dbContext.kpopVideos("available_songs")
+        result = await dbContext.kmq("available_songs")
             .select(["song_name as name", "artist_name as artist", "link as youtubeLink"])
             .whereIn("id_artist", guildPreference.getGroupIds())
             .andWhere("publishedon", ">=", `${guildPreference.getBeginningCutoffYear()}-01-01`)

--- a/src/scripts/download-new-songs.ts
+++ b/src/scripts/download-new-songs.ts
@@ -199,7 +199,7 @@ async function downloadAndConvertSongs(limit?: number) {
 
     await clearPartiallyCachedSongs();
     await downloadNewSongs(limit);
-    convertToOpus();
+    await convertToOpus();
     await dbContext.destroy();
 }
 

--- a/src/seed/create_available_songs_table.sql
+++ b/src/seed/create_available_songs_table.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS available_songs;
-CREATE TABLE available_songs (
+DROP TABLE IF EXISTS available_songs_temp;
+CREATE TABLE available_songs_temp (
 	song_name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
 	link VARCHAR(255) NOT NULL,
 	artist_name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
@@ -9,7 +9,17 @@ CREATE TABLE available_songs (
 	id_artist INT(11) NOT NULL
 );
 
-INSERT INTO available_songs 
+CREATE TABLE IF NOT EXISTS available_songs (
+	song_name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+	link VARCHAR(255) NOT NULL,
+	artist_name VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+	members ENUM('female','male','coed') NOT NULL,
+	views BIGINT NOT NULL,
+	publishedon DATE NOT NULL,
+	id_artist INT(11) NOT NULL
+);
+
+INSERT INTO available_songs_temp 
 SELECT nome AS song_name, vlink AS link, kpop_videos.app_kpop_group.name AS artist_name, kpop_videos.app_kpop_group.members as members, kpop_videos.app_kpop.views AS views, publishedon, kpop_videos.app_kpop_group.id as id_artist
 FROM kpop_videos.app_kpop 
 JOIN kpop_videos.app_kpop_group ON kpop_videos.app_kpop.id_artist = kpop_videos.app_kpop_group.id
@@ -17,3 +27,6 @@ WHERE vlink NOT IN (SELECT vlink FROM kmq.not_downloaded)
 AND dead = 'n'
 AND vtype = 'main'
 ORDER BY kpop_videos.app_kpop.views DESC;
+
+RENAME TABLE available_songs TO old, available_songs_temp TO available_songs;
+DROP TABLE old;

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -126,7 +126,7 @@ process.on("SIGINT", () => {
         logger.info("Downloading new songs");
         await downloadNewSongs();
         logger.info("Re-creating available songs view");
-        execSync(`mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} ${process.env.DB_KPOP_DATA_TABLE_NAME} < ./src/seed/create_available_songs_table.sql`);
+        execSync(`mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} ${process.env.DB_KMQ_SETTINGS_TABLE_NAME} < ./src/seed/create_available_songs_table.sql`);
     } catch (e) {
         logger.error(`Error: ${e}`);
     }


### PR DESCRIPTION
Store `available_songs` in `kmq` database so it doesn't get deleted upon seed. Use temporary table and atomic swap to ensure no downtime

Closes #348 