### PR TITLE
Correctly compare first_play in store-daily-stats

### DIFF
--- a/src/scripts/store-daily-stats.ts
+++ b/src/scripts/store-daily-stats.ts
@@ -20,7 +20,7 @@ const storeDailyStats = async (serverCount: number) => {
         .count("* as count"))[0].count;
 
     const newPlayers = (await dbContext.kmq("player_stats")
-        .where("first_play", "=", dateThreshold)
+        .where("first_play", ">=", dateThreshold)
         .count("* as count"))[0].count;
 
     logger.info("Inserting today's stats into db...");


### PR DESCRIPTION
I was comparing the date, but forgot to take into account that it'll also compare the time portion of the date. Thus, new players weren't correctly being counted.