### PR TITLE
Fix seed scripts

### DIFF
--- a/src/seed/bootstrap.ts
+++ b/src/seed/bootstrap.ts
@@ -38,11 +38,8 @@ async function needsBootstrap(db: DatabaseContext) {
     return (await Promise.all([kmqDatabaseExists(db), kpopDataDatabaseExists(db), songThresholdReached(db)])).some((x) => x === false);
 }
 
-function updateAvailableSongProcedure() {
-    execSync(`mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} -h ${process.env.DB_HOST} kmq < ./src/seed/create_available_songs_table_procedure.sql`);
-}
-
 function generateAvailableSongsView() {
+    execSync(`mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} -h ${process.env.DB_HOST} kmq < ./src/seed/create_available_songs_table_procedure.sql`);
     logger.info("Re-creating available songs view...");
     execSync(`mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} -h ${process.env.DB_HOST} kmq -e "CALL CreateAvailableSongsTable;"`);
 }
@@ -68,16 +65,14 @@ async function bootstrapDatabases() {
             await db.agnostic.raw("CREATE DATABASE IF NOT EXISTS kmq");
             performMigrations();
         }
-        updateAvailableSongProcedure();
         if (!(await songThresholdReached(db))) {
             logger.info(`Downloading minimum threshold (${SONG_DOWNLOAD_THRESHOLD}) songs`);
             await downloadAndConvertSongs(SONG_DOWNLOAD_THRESHOLD);
         }
     } else {
-        updateAvailableSongProcedure();
         performMigrations();
+        generateAvailableSongsView();
     }
-    generateAvailableSongsView();
     await db.destroy();
 }
 

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -11,7 +11,6 @@ import _logger from "../logger";
 import removeRedunantAliases from "../scripts/remove-redunant-aliases";
 import { downloadAndConvertSongs } from "../scripts/download-new-songs";
 import dbContext, { DatabaseContext, getDatabaseAgnosticContext } from "../database_context";
-import { generateAvailableSongsView } from "./bootstrap";
 
 config({ path: path.resolve(__dirname, "../../.env") });
 const fileUrl = "http://kpop.aoimirai.net/download.php";
@@ -22,7 +21,8 @@ const overridesFilePath = path.join(__dirname, "./kpop_videos_overrides.sql");
 program
     .option("-p, --force-pull", "Force re-pull of AoiMirai database dump", false)
     .option("-r, --force-reseed", "Force drop/create of kpop_videos database", false)
-    .option("-d, --skip-download", "Skip download/encode of videos in database", false);
+    .option("-d, --skip-download", "Skip download/encode of videos in database", false)
+    .option("--limit <limit>", "Limit the number of songs to download", (x) => parseInt(x, 10));
 
 program.parse();
 const options = program.opts();
@@ -108,7 +108,6 @@ async function updateKpopDatabase() {
     if (options.forceReseed) {
         await seedDb(db);
     }
-    generateAvailableSongsView();
     await db.destroy();
 }
 
@@ -126,7 +125,7 @@ async function seedAndDownloadNewSongs() {
     await updateGroupList();
     await removeRedunantAliases();
     if (!options.skipDownload) {
-        await downloadAndConvertSongs();
+        await downloadAndConvertSongs(options.limit);
     }
     logger.info("Finishing seeding and downloading new songs");
 }


### PR DESCRIPTION
- Fix bug where calling `downloadNewSongs` with limit did not populate `not_downloaded` table correctly
- Add `limit` option to our `npm run seed` script
- Fix bug where `CreateAvailableSongsTable` procedure was being called before `kmq` table was created