### PR TITLE
Always call joinVoiceChannel

### DIFF
--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -89,10 +89,6 @@ async function getFilteredSongList(guildPreference: GuildPreference, ignoredVide
 export async function ensureVoiceConnection(gameSession: GameSession): Promise<void> {
     const { client } = state;
     return new Promise(async (resolve, reject) => {
-        if (gameSession.connection) {
-            resolve();
-            return;
-        }
         try {
             const connection = await client.joinVoiceChannel(gameSession.voiceChannel.id, { opusOnly: true });
             // deafen self


### PR DESCRIPTION
`joinVoiceChannel()` is a no-op if already in a voice channel, but handles re-connection if the connection disconnects