### PR TITLE
Avoid exposing db credentials via exec

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -117,6 +117,15 @@
         ],
         "import/order": [
             "warn"
+        ],
+        "@typescript-eslint/brace-style": [
+            "warn"
+        ],
+        "no-empty": [
+            "warn"
+        ],
+        "no-multi-spaces": [
+            "warn"
         ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "docker-dev": "cd docker/ && START_TYPE=dev docker-compose up --build kmq",
     "docker-prod": "cd docker/ && START_TYPE=prod docker-compose up --build kmq",
     "backup": "ts-node src/scripts/backup-kmq-database",
-    "import": "ts-node src/scripts/backup-kmq-database --import",
     "test": "NODE_ENV=test mocha -r ts-node/register 'src/test/**/*.ts'",
     "test_ci": "NODE_ENV=test mocha -- --forbid-only -r ts-node/register 'src/test/**/*.ts'"
   },
@@ -41,6 +40,7 @@
     "log4js": "^6.3.0",
     "moment-timezone": "^0.5.32",
     "mysql": "^2.18.1",
+    "mysqldump": "^3.2.0",
     "node-schedule": "^1.3.3",
     "node-stream-zip": "^1.13.2",
     "sodium-native": "^3.2.1",

--- a/sql/create_kmq_data_tables_procedure.sql
+++ b/sql/create_kmq_data_tables_procedure.sql
@@ -1,6 +1,4 @@
-DELIMITER //
-
-DROP PROCEDURE IF EXISTS CreateKmqDataTables //
+DROP PROCEDURE IF EXISTS CreateKmqDataTables;
 CREATE PROCEDURE CreateKmqDataTables()
 BEGIN
 	/* update available_songs table */
@@ -45,5 +43,4 @@ BEGIN
 	RENAME TABLE kmq.kpop_groups TO old, kmq.kpop_groups_temp TO kmq.kpop_groups;
 	DROP TABLE old;
 
-END //
-DELIMITER ;
+END

--- a/src/config/knexfile_agnostic.js
+++ b/src/config/knexfile_agnostic.js
@@ -4,7 +4,7 @@ require('dotenv').config({path: resolve(__dirname, "../../.env")});
 module.exports = {
   client: 'mysql',
   connection: {
-    user: process.env.DB_USER, password: process.env.DB_PASS, host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT)
+    user: process.env.DB_USER, password: process.env.DB_PASS, host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT), multipleStatements: true
   },
   pool: {
     min: 0,

--- a/src/config/knexfile_kmq.js
+++ b/src/config/knexfile_kmq.js
@@ -4,7 +4,7 @@ require('dotenv').config({path: resolve(__dirname, "../../.env")});
 module.exports = {
   client: 'mysql',
   connection: {
-    user: process.env.DB_USER, password: process.env.DB_PASS, database: "kmq", host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT)
+    user: process.env.DB_USER, password: process.env.DB_PASS, database: "kmq", host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT), multipleStatements: true
   },
   pool: {
     min: 0,

--- a/src/config/knexfile_kmq_test.js
+++ b/src/config/knexfile_kmq_test.js
@@ -4,7 +4,7 @@ require('dotenv').config({path: resolve(__dirname, "../../.env")});
 module.exports = {
   client: 'mysql',
   connection: {
-    user: process.env.DB_USER, password: process.env.DB_PASS, database: "kmq_test", host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT)
+    user: process.env.DB_USER, password: process.env.DB_PASS, database: "kmq_test", host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT), multipleStatements: true
   },
   pool: {
     min: 0,

--- a/src/config/knexfile_kpop_videos.js
+++ b/src/config/knexfile_kpop_videos.js
@@ -4,7 +4,7 @@ require('dotenv').config({path: resolve(__dirname, "../../.env")});
 module.exports = {
   client: 'mysql',
   connection: {
-    user: process.env.DB_USER, password: process.env.DB_PASS, database: "kpop_videos", host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT)
+    user: process.env.DB_USER, password: process.env.DB_PASS, database: "kpop_videos", host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT), multipleStatements: true
   },
   pool: {
     min: 0,

--- a/src/config/knexfile_kpop_videos_validation.js
+++ b/src/config/knexfile_kpop_videos_validation.js
@@ -1,0 +1,13 @@
+const resolve = require("path").resolve;
+require('dotenv').config({path: resolve(__dirname, "../../.env")});
+
+module.exports = {
+  client: 'mysql',
+  connection: {
+    user: process.env.DB_USER, password: process.env.DB_PASS, database: "kpop_videos_validation", host: process.env.DB_HOST, charset: "utf8mb4", port: parseInt(process.env.DB_PORT), multipleStatements: true
+  },
+  pool: {
+    min: 0,
+    max: 1
+  }
+}

--- a/src/database_context.ts
+++ b/src/database_context.ts
@@ -3,6 +3,7 @@ import kmqKnexConfig from "./config/knexfile_kmq";
 import kpopVideosKnexConfig from "./config/knexfile_kpop_videos";
 import agnosticKnexConfig from "./config/knexfile_agnostic";
 import kmqTestKnexConfig from "./config/knexfile_kmq_test";
+import kpopVideosKnexValidationConfig from "./config/knexfile_kpop_videos_validation";
 import _logger from "./logger";
 import { EnvType } from "./types";
 
@@ -11,6 +12,7 @@ const logger = _logger("database_context");
 export class DatabaseContext {
     public kmq: Knex;
     public kpopVideos: Knex;
+    public kpopVideosValidation: Knex;
     public agnostic: Knex;
 
     constructor() {
@@ -24,6 +26,7 @@ export class DatabaseContext {
         }
         this.kpopVideos = Knex(kpopVideosKnexConfig);
         this.agnostic = Knex(agnosticKnexConfig);
+        this.kpopVideosValidation = Knex(kpopVideosKnexValidationConfig);
     }
 
     async destroy() {
@@ -35,6 +38,9 @@ export class DatabaseContext {
         }
         if (this.agnostic) {
             await this.agnostic.destroy();
+        }
+        if (this.kpopVideosValidation) {
+            await this.kpopVideosValidation.destroy();
         }
     }
 }

--- a/src/scripts/download-new-songs.ts
+++ b/src/scripts/download-new-songs.ts
@@ -169,8 +169,6 @@ const downloadNewSongs = async (db: DatabaseContext, limit?: number) => {
     // update current list of non-downloaded songs
     await updateNotDownloaded(db, allSongs);
 
-
-
     for (const song of songsToDownload) {
         logger.info(`Downloading song: '${song.name}' by ${song.artist} | ${song.youtubeLink} (${downloadCount + 1}/${songsToDownload.length})`);
         try {
@@ -211,7 +209,7 @@ export async function downloadAndConvertSongs(limit?: number) {
 
         await clearPartiallyCachedSongs();
         await downloadNewSongs(db, limit);
-        generateKmqDataTables();
+        await generateKmqDataTables(db);
     } finally {
         await db.destroy();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,6 +821,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
+  integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
+
 define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -854,6 +859,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+denque@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
+  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
 detect-file@^1.0.0:
   version "1.0.0"
@@ -1459,6 +1469,13 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+generate-function@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
+  dependencies:
+    is-property "^1.0.2"
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -1651,6 +1668,13 @@ http-proxy-agent@^4.0.1:
     "@tootallnate/once" "1"
     agent-base "6"
     debug "4"
+
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -1892,6 +1916,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-property@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-regex@^1.1.2:
   version "1.1.2"
@@ -2171,6 +2200,11 @@ long-timeout@0.1.1:
   resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
   integrity sha1-lyHXiLR+C8taJMLivuGg2lXatRQ=
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -2178,6 +2212,14 @@ loud-rejection@^1.0.0:
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
+
+lru-cache@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -2386,6 +2428,20 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mysql2@^2.1.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-2.2.5.tgz#72624ffb4816f80f96b9c97fedd8c00935f9f340"
+  integrity sha512-XRqPNxcZTpmFdXbJqb+/CtYVLCx14x1RTeNMD4954L331APu75IC74GDqnZMEt1kwaXy6TySo55rF2F3YJS78g==
+  dependencies:
+    denque "^1.4.1"
+    generate-function "^2.3.1"
+    iconv-lite "^0.6.2"
+    long "^4.0.0"
+    lru-cache "^6.0.0"
+    named-placeholders "^1.1.2"
+    seq-queue "^0.0.5"
+    sqlstring "^2.3.2"
+
 mysql@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.18.1.tgz#2254143855c5a8c73825e4522baf2ea021766717"
@@ -2395,6 +2451,23 @@ mysql@^2.18.1:
     readable-stream "2.3.7"
     safe-buffer "5.1.2"
     sqlstring "2.3.1"
+
+mysqldump@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mysqldump/-/mysqldump-3.2.0.tgz#780abaf82f5c3f216d4e16db585092389d2a5497"
+  integrity sha512-hS4jUk23BT+qZEwp668eGwyFhmsDFHkIDYANLFeNXlvPK1AhOMLV+SGoKpAk8290sUhtUAIG16R3YrNhHmZ+zQ==
+  dependencies:
+    deepmerge "^3.2.0"
+    mysql2 "^2.1.0"
+    sql-formatter "^2.3.2"
+    sqlstring "^2.3.1"
+
+named-placeholders@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/named-placeholders/-/named-placeholders-1.1.2.tgz#ceb1fbff50b6b33492b5cf214ccf5e39cef3d0e8"
+  integrity sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==
+  dependencies:
+    lru-cache "^4.1.3"
 
 nan@^2.14.0:
   version "2.14.2"
@@ -2807,6 +2880,11 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -3020,6 +3098,11 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 sax@^1.1.3, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -3041,6 +3124,11 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+seq-queue@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/seq-queue/-/seq-queue-0.0.5.tgz#d56812e1c017a6e4e7c3e3a37a1da6d78dd3c93e"
+  integrity sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4=
 
 serialize-javascript@5.0.1:
   version "5.0.1"
@@ -3222,10 +3310,22 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+sql-formatter@^2.3.2:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-2.3.4.tgz#85ff9a946d8157e3917c0b1db514ca8184a1b6f1"
+  integrity sha512-CajWtvzYoBJbD5PQeVe3E7AOHAIYvRQEPOKgF9kfKNeY8jtjBiiA6pDzkMuAID8jJMluoPvyKveLigSaA5tKQQ==
+  dependencies:
+    lodash "^4.17.20"
+
 sqlstring@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
   integrity sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=
+
+sqlstring@^2.3.1, sqlstring@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.2.tgz#cdae7169389a1375b18e885f2e60b3e460809514"
+  integrity sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -3696,6 +3796,11 @@ y18n@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
   integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
No way of avoiding it for `npm run import`, removed the script. Infrequently used, can be done manually when needed.  