### PR TITLE
Fix shell-command-injection-from-environment vulnerability in preset migration script call

### DIFF
--- a/src/migrations/20210518215005_remove_guild_preference_json.js
+++ b/src/migrations/20210518215005_remove_guild_preference_json.js
@@ -2,7 +2,7 @@ const { execSync } = require("child_process");
 const path = require("path");
 
 exports.up = function(knex) {
-    execSync(`ts-node ${path.join(__dirname, "../scripts/json-presets-to-new-format.ts")}`, { stdio: "inherit" });
+    execSync("ts-node", [`${path.join(__dirname, "../scripts/json-presets-to-new-format.ts")}`], { stdio: "inherit" });
     return knex.schema.table("guild_preferences", function (table) {
         table.dropColumn("guild_preference");
     });


### PR DESCRIPTION
Absolute path with spaces can cause issues if there is a space in the path