### PR TITLE
Delay rounds played decrement to after song message on round error

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -177,7 +177,7 @@ export async function sendEndRoundMessage(messageContext: MessageContext,
         }
     }
     const uniqueSongMessage = (uniqueSongCounter && uniqueSongCounter.uniqueSongsPlayed > 0) ? `\n${codeLine(`${uniqueSongCounter.uniqueSongsPlayed}/${uniqueSongCounter.totalSongs}`)} unique songs played.` : "";
-    const description = `${correctGuess ? correctDescription : "Nobody got it."}\nhttps://youtu.be/${gameRound.videoID}${uniqueSongMessage} ${!scoreboard.isEmpty() ? "\n\n**Scoreboard**" : ""}`;
+    const description = `${correctGuess ? correctDescription : "Nobody got it."}\n\nhttps://youtu.be/${gameRound.videoID}${uniqueSongMessage} ${!scoreboard.isEmpty() ? "\n\n**Scoreboard**" : ""}`;
     const fields = scoreboard.getScoreboardEmbedFields().slice(0, 15);
     for (const [index, field] of Object.entries(fields)) {
         fields[index].name = `${Number(index) + 1}. ${field.name}`;

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -623,9 +623,9 @@ export default class GameSession {
      */
     private async errorRestartRound(guildPreference: GuildPreference) {
         const messageContext = new MessageContext(this.textChannelID);
-        this.roundsPlayed--;
         this.endRound({ correct: false }, guildPreference);
         await sendErrorMessage(messageContext, { title: "Error playing song", description: "Starting new round in 3 seconds..." });
+        this.roundsPlayed--;
         this.startRound(guildPreference, messageContext);
     }
     /**


### PR DESCRIPTION
If the user ,end's during error playing song error, this delay may prevent rounds played being decremented since endSession will likely finish before sendInfoMessage's await, preventing the off by one error. There is a high chance this won't fix the bug.

This commit also adds a newline in between the correct description and youtube link/unique songs counter.