### PR TITLE
Add support for larger scoreboard, refactor scoreboard OOP

### DIFF
--- a/src/commands/game_commands/begin.ts
+++ b/src/commands/game_commands/begin.ts
@@ -24,7 +24,7 @@ export default class BeginCommand implements BaseCommand {
             }
         } else if (gameSession.gameType === GameType.TEAMS) {
             const teamScoreboard = gameSession.scoreboard as TeamScoreboard;
-            if (Object.keys(teamScoreboard.getTeams()).length === 0) {
+            if (teamScoreboard.getNumTeams() === 0) {
                 sendErrorMessage(messageContext, { title: "Begin ignored", description: "Create a team using `,join [team name]` before you can start the game." });
                 return false;
             }

--- a/src/commands/game_commands/hint.ts
+++ b/src/commands/game_commands/hint.ts
@@ -70,16 +70,16 @@ export default class HintCommand implements BaseCommand {
             let hint: string;
             switch (guessMode) {
                 case GuessModeType.ARTIST:
-                    hint = `Artist Name: ${gameRound.hints.artistHint}`;
+                    hint = `Artist Name: ${codeLine(gameRound.hints.artistHint)}`;
                     break;
                 case GuessModeType.SONG_NAME:
                 case GuessModeType.BOTH:
                 default:
-                    hint = `Song Name: ${gameRound.hints.songHint}`;
+                    hint = `Song Name: ${codeLine(gameRound.hints.songHint)}`;
             }
             logger.info(`${getDebugLogHeader(message)} | Hint majority received.`);
             gameRound.hintUsed = true;
-            sendInfoMessage(MessageContext.fromMessage(message), { title: "Hint", description: codeLine(hint), thumbnailUrl: KmqImages.READING_BOOK });
+            sendInfoMessage(MessageContext.fromMessage(message), { title: "Hint", description: hint, thumbnailUrl: KmqImages.READING_BOOK });
         } else {
             logger.info(`${getDebugLogHeader(message)} | Hint request received.`);
             sendHintNotification(message, gameSession);

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -58,7 +58,7 @@ export default class PlayCommand implements BaseCommand {
                 name: "lives",
                 type: "number" as const,
                 minValue: 1,
-                maxValue: 500,
+                maxValue: 10000,
             },
         ],
     };

--- a/src/events/client/messageCreate.ts
+++ b/src/events/client/messageCreate.ts
@@ -42,7 +42,7 @@ export default async function messageCreateHandler(message: Eris.Message) {
             return;
         }
         const guildPreference = await getGuildPreference(message.guildID);
-        sendOptionsMessage(MessageContext.fromMessage(message), guildPreference, null, `Psst. Your bot prefix is ${process.env.BOT_PREFIX}`);
+        sendOptionsMessage(MessageContext.fromMessage(message), guildPreference, null, `Psst. The bot prefix is ${process.env.BOT_PREFIX}`);
         return;
     }
 

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -25,7 +25,7 @@ export const EMBED_SUCCESS_BONUS_COLOR = 0xFFD700; // GOLD
 const EMBED_FIELDS_PER_PAGE = 20;
 const REQUIRED_TEXT_PERMISSIONS = ["addReactions" as const, "embedLinks" as const];
 const REQUIRED_VOICE_PERMISSIONS = ["viewChannel" as const, "voiceConnect" as const, "voiceSpeak" as const];
-const SCOREBOARD_FIELD_CUTOFF = 9;
+const SCOREBOARD_FIELD_CUTOFF = 12;
 const MAX_SCOREBOARD_PLAYERS = 30;
 
 /**
@@ -179,9 +179,10 @@ export async function sendEndRoundMessage(messageContext: MessageContext,
         }
     }
     const uniqueSongMessage = (uniqueSongCounter && uniqueSongCounter.uniqueSongsPlayed > 0) ? `\n${codeLine(`${uniqueSongCounter.uniqueSongsPlayed}/${uniqueSongCounter.totalSongs}`)} unique songs played.` : "";
-    const description = `${correctGuess ? correctDescription : "Nobody got it."}\n\nhttps://youtu.be/${gameRound.videoID}${uniqueSongMessage} ${!scoreboard.isEmpty() ? "\n\n**Scoreboard**" : ""}`;
+    const useLargerScoreboard = scoreboard.getNumPlayers() > SCOREBOARD_FIELD_CUTOFF;
+    const description = `${correctGuess ? correctDescription : "Nobody got it."}\n\nhttps://youtu.be/${gameRound.videoID}${uniqueSongMessage} ${!scoreboard.isEmpty() && !useLargerScoreboard ? "\n\n**Scoreboard**" : ""}`;
     let fields: Array<{ name: string, value: string, inline: boolean }>;
-    if (scoreboard.getNumPlayers() > SCOREBOARD_FIELD_CUTOFF) {
+    if (useLargerScoreboard) {
         fields = scoreboard.getScoreboardEmbedTwoFields(MAX_SCOREBOARD_PLAYERS);
     } else {
         fields = scoreboard.getScoreboardEmbedFields();
@@ -353,7 +354,8 @@ export async function sendEndGameMessage(textChannelID: string, gameSession: Gam
     } else {
         const winners = gameSession.scoreboard.getWinners();
         let fields: Array<{ name: string, value: string, inline: boolean }>;
-        if (gameSession.scoreboard.getNumPlayers() > SCOREBOARD_FIELD_CUTOFF) {
+        const useLargerScoreboard = gameSession.scoreboard.getNumPlayers() > SCOREBOARD_FIELD_CUTOFF;
+        if (useLargerScoreboard) {
             fields = gameSession.scoreboard.getScoreboardEmbedTwoFields(MAX_SCOREBOARD_PLAYERS);
         } else {
             fields = gameSession.scoreboard.getScoreboardEmbedFields();
@@ -371,7 +373,7 @@ export async function sendEndGameMessage(textChannelID: string, gameSession: Gam
         }
         await sendInfoMessage(new MessageContext(textChannelID), {
             color: gameSession.gameType !== GameType.TEAMS && state.bonusUsers.has(winners[0].id) ? EMBED_SUCCESS_BONUS_COLOR : EMBED_SUCCESS_COLOR,
-            description: "**Scoreboard**",
+            description: !useLargerScoreboard ? "**Scoreboard**" : null,
             thumbnailUrl: winners[0].getAvatarURL(),
             title: `🎉 ${gameSession.scoreboard.getWinnerMessage()} 🎉`,
             fields,

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -183,7 +183,7 @@ export async function sendEndRoundMessage(messageContext: MessageContext,
     const description = `${correctGuess ? correctDescription : "Nobody got it."}\n\nhttps://youtu.be/${gameRound.videoID}${uniqueSongMessage} ${!scoreboard.isEmpty() && !useLargerScoreboard ? "\n\n**Scoreboard**" : ""}`;
     let fields: Array<{ name: string, value: string, inline: boolean }>;
     if (useLargerScoreboard) {
-        fields = scoreboard.getScoreboardEmbedTwoFields(MAX_SCOREBOARD_PLAYERS);
+        fields = scoreboard.getScoreboardEmbedThreeFields(MAX_SCOREBOARD_PLAYERS);
     } else {
         fields = scoreboard.getScoreboardEmbedFields();
     }
@@ -356,7 +356,7 @@ export async function sendEndGameMessage(textChannelID: string, gameSession: Gam
         let fields: Array<{ name: string, value: string, inline: boolean }>;
         const useLargerScoreboard = gameSession.scoreboard.getNumPlayers() > SCOREBOARD_FIELD_CUTOFF;
         if (useLargerScoreboard) {
-            fields = gameSession.scoreboard.getScoreboardEmbedTwoFields(MAX_SCOREBOARD_PLAYERS);
+            fields = gameSession.scoreboard.getScoreboardEmbedThreeFields(MAX_SCOREBOARD_PLAYERS);
         } else {
             fields = gameSession.scoreboard.getScoreboardEmbedFields();
         }

--- a/src/structures/elimination_player.ts
+++ b/src/structures/elimination_player.ts
@@ -1,28 +1,27 @@
 import Player from "./player";
 
 export default class EliminationPlayer extends Player {
-    /** The number of lives the player has remaining */
-    private lives: number;
-
-    constructor(name: string, id: string, avatarURL: string, points: number, lives: number) {
-        super(name, id, avatarURL, points);
-        this.lives = lives;
-    }
+    // this.score => the player's lives
 
     /** @returns the number of lives the player has remaining */
     getLives(): number {
-        return this.lives;
+        return this.score;
     }
 
     /** Decreases the amount of lives the player has remaining */
     decrementLives(): void {
-        if (this.lives > 0) {
-            this.lives--;
+        if (this.score > 0) {
+            this.score--;
         }
     }
 
     /** @returns whether the player has ran out of lives */
     isEliminated(): boolean {
-        return this.lives === 0;
+        return this.score === 0;
+    }
+
+    /** @returns the lives of the player formatted for the scoreboard */
+    getDisplayedScore(): string {
+        return !this.isEliminated() ? `❤️ x ${this.getLives()}` : "☠️";
     }
 }

--- a/src/structures/elimination_scoreboard.ts
+++ b/src/structures/elimination_scoreboard.ts
@@ -24,22 +24,8 @@ export default class EliminationScoreboard extends Scoreboard {
      * @param avatarUrl - The player's Discord avatar URL
      */
     addPlayer(userID: string, tag: string, avatarUrl: string, lives?: number): EliminationPlayer {
-        this.players[userID] = new EliminationPlayer(tag, userID, avatarUrl, 0, lives === undefined || lives === null ? this.startingLives : lives);
+        this.players[userID] = new EliminationPlayer(tag, userID, avatarUrl, lives ?? this.startingLives);
         return this.players[userID];
-    }
-
-    /** @returns An array of DiscordEmbed fields representing each participant's lives */
-    getScoreboardEmbedFields(): Array<{ name: string, value: string, inline: boolean }> {
-        return Object.values(this.players)
-            .sort((a, b) => b.getLives() - a.getLives())
-            .map((x) => {
-                const lives = !x.isEliminated() ? `❤️ x ${x.getLives()}` : "☠️";
-                return {
-                    name: x.getName(),
-                    value: lives,
-                    inline: true,
-                };
-            });
     }
 
     /**

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -8,7 +8,7 @@ import {
     getDebugLogHeader, getSqlDateString, sendErrorMessage, sendEndRoundMessage, sendInfoMessage, getNumParticipants, checkBotIsAlone, getVoiceChannelFromMessage,
 } from "../helpers/discord_utils";
 import { ensureVoiceConnection, getGuildPreference, selectRandomSong, getFilteredSongList, endSession } from "../helpers/game_utils";
-import { delay, getOrdinalNum, isPowerHour, isWeekend, setDifference } from "../helpers/utils";
+import { delay, getOrdinalNum, isPowerHour, isWeekend, setDifference, bold, codeLine } from "../helpers/utils";
 import state from "../kmq";
 import _logger from "../logger";
 import { QueriedSong, GuildTextableMessage, PlayerRoundResult, GameType } from "../types";
@@ -284,7 +284,7 @@ export default class GameSession {
 
         // send level up message
         if (leveledUpPlayers.length > 0) {
-            let levelUpMessages = leveledUpPlayers.map((leveledUpPlayer) => `\`${this.scoreboard.getPlayerName(leveledUpPlayer.userID)}\` has leveled from \`${leveledUpPlayer.startLevel}\` to \`${leveledUpPlayer.endLevel} (${getRankNameByLevel(leveledUpPlayer.endLevel)})\``);
+            let levelUpMessages = leveledUpPlayers.map((leveledUpPlayer) => `${bold(this.scoreboard.getPlayerName(leveledUpPlayer.userID))} has leveled from ${codeLine(String(leveledUpPlayer.startLevel))} to ${codeLine(String(leveledUpPlayer.endLevel))} (${codeLine(getRankNameByLevel(leveledUpPlayer.endLevel))})`);
             if (levelUpMessages.length > 10) {
                 levelUpMessages = levelUpMessages.slice(0, 10);
                 levelUpMessages.push("and many others...");

--- a/src/structures/player.ts
+++ b/src/structures/player.ts
@@ -1,4 +1,5 @@
 import { getUserTag } from "../helpers/discord_utils";
+import { roundDecimal } from "../helpers/utils";
 import state from "../kmq";
 
 export default class Player {
@@ -8,11 +9,11 @@ export default class Player {
     /** The Discord user ID of the player */
     public readonly id: string;
 
+    /** The player's current score */
+    protected score: number;
+
     /** The player's avatar URL */
     private readonly avatarURL: string;
-
-    /** The player's current score */
-    private score: number;
 
     /** The player's EXP gain */
     private expGain: number;
@@ -38,6 +39,11 @@ export default class Player {
     /** @returns the player's current score */
     getScore(): number {
         return this.score;
+    }
+
+    /** @returns what to display as the score in the scoreboard for the player */
+    getDisplayedScore(): string {
+        return Number.isInteger(roundDecimal(this.getScore(), 1)) ? roundDecimal(this.getScore(), 1).toString() : this.getScore().toFixed(1);
     }
 
     /** @returns the player's EXP gain */

--- a/src/structures/player.ts
+++ b/src/structures/player.ts
@@ -3,7 +3,7 @@ import { roundDecimal } from "../helpers/utils";
 import state from "../kmq";
 
 export default class Player {
-    /** The Discord tag of the player */
+    /** The Discord tag of the player, of the format "Player#1234" */
     public readonly name: string;
 
     /** The Discord user ID of the player */
@@ -35,6 +35,19 @@ export default class Player {
     getName(): string {
         return this.name;
     }
+    /**
+     * Prints the tag (including the discriminator) in the smaller scoreboard, but only
+     * the username in the larger scoreboard
+     * @param largerScoreboard - Whether the name format is for the larger scoreboard
+     * @param duplicateName - Whether another user shares the same name
+     * @returns what to display as the name of the player in the scoreboard
+     */
+    getDisplayedName(largerScoreboard: boolean, duplicateName?: boolean): string {
+        if (largerScoreboard && !duplicateName) {
+            return this.name.slice(0, -5);
+        }
+        return this.name;
+    }
 
     /** @returns the player's current score */
     getScore(): number {
@@ -56,7 +69,7 @@ export default class Player {
         return this.id;
     }
 
-    /** returns the player's avatar URL */
+    /** @returns the player's avatar URL */
     getAvatarURL(): string {
         return this.avatarURL;
     }

--- a/src/structures/scoreboard.ts
+++ b/src/structures/scoreboard.ts
@@ -58,7 +58,7 @@ export default class Scoreboard {
             .sort((a, b) => b.getScore() - a.getScore())
             .map((x, index) => (
                 {
-                    name: `${index + 1}. ${x.getName()}`,
+                    name: `${index + 1}. ${x.getDisplayedName(false)}`,
                     value: x.getDisplayedScore(),
                     inline: true,
                 }));
@@ -74,13 +74,16 @@ export default class Scoreboard {
         const players = Object.values(this.players)
             .sort((a, b) => b.getScore() - a.getScore())
             .slice(0, cutoff)
-            .map((x, index) => `${index + 1}. ${bold(x.getName())}: ${x.getDisplayedScore()}`);
+            .map((x, index, arr) => {
+                const duplicateName = arr.filter((y) => y.getName().slice(0, -5) === x.getName().slice(0, -5)).length > 1;
+                return `${bold(`${index + 1}. ${x.getDisplayedName(true, duplicateName)}`)}: ${x.getDisplayedScore()}`;
+            });
         if (this.getNumPlayers() > cutoff) {
-            players.push("and many others...");
+            players.push("\nand many others...");
         }
         return [
             {
-                name: ZERO_WIDTH_SPACE,
+                name: "**Scoreboard**",
                 value: players.slice(0, Math.ceil(players.length / 2)).join("\n"),
                 inline: true,
             },

--- a/src/structures/scoreboard.ts
+++ b/src/structures/scoreboard.ts
@@ -67,9 +67,9 @@ export default class Scoreboard {
     /**
      * Separates scoreboard players into two fields for large games
      * @param cutoff - How many players to include before truncating the scoreboard
-     * @returns An array of 2 DiscordEmbed fields containing each player and their score, separated by newline
+     * @returns An array of 3 DiscordEmbed fields containing each player and their score, separated by newline
      */
-    getScoreboardEmbedTwoFields(cutoff: number): Array<{ name: string, value: string, inline: boolean }> {
+    getScoreboardEmbedThreeFields(cutoff: number): Array<{ name: string, value: string, inline: boolean }> {
         const ZERO_WIDTH_SPACE = "​";
         const players = Object.values(this.players)
             .sort((a, b) => b.getScore() - a.getScore())
@@ -84,12 +84,17 @@ export default class Scoreboard {
         return [
             {
                 name: "**Scoreboard**",
-                value: players.slice(0, Math.ceil(players.length / 2)).join("\n"),
+                value: players.slice(0, Math.ceil(players.length / 3)).join("\n"),
                 inline: true,
             },
             {
                 name: ZERO_WIDTH_SPACE,
-                value: players.slice(Math.ceil(players.length / 2)).join("\n"),
+                value: players.slice(Math.ceil(players.length / 3), Math.ceil((2 * players.length) / 3)).join("\n"),
+                inline: true,
+            },
+            {
+                name: ZERO_WIDTH_SPACE,
+                value: players.slice(Math.ceil((2 * players.length) / 3)).join("\n"),
                 inline: true,
             },
         ];

--- a/src/structures/team.ts
+++ b/src/structures/team.ts
@@ -14,6 +14,16 @@ export default class Team extends Player {
         return this.getPlayers().reduce((totalScore, player) => totalScore + player.getScore(), 0);
     }
 
+    /** @returns the displayed name of the team, without prepending "Team" */
+    getNameWithoutTeam(): string {
+        return super.getName();
+    }
+
+    /** @returns the displayed name of the team */
+    getName(): string {
+        return `Team ${this.getNameWithoutTeam()}`;
+    }
+
     /**
      * @param player - The player to add
      * Adds player to this team

--- a/src/structures/team.ts
+++ b/src/structures/team.ts
@@ -14,14 +14,16 @@ export default class Team extends Player {
         return this.getPlayers().reduce((totalScore, player) => totalScore + player.getScore(), 0);
     }
 
-    /** @returns the displayed name of the team, without prepending "Team" */
-    getNameWithoutTeam(): string {
-        return super.getName();
+    /** @returns the name of the team */
+    getName(): string {
+        return this.name;
     }
 
-    /** @returns the displayed name of the team */
-    getName(): string {
-        return `Team ${this.getNameWithoutTeam()}`;
+    /**
+     * @returns what to display as the name of the team in the scoreboard
+     */
+    getDisplayedName(_largerScoreboard: boolean, _duplicateName?: boolean): string {
+        return `Team ${this.getName()}`;
     }
 
     /**

--- a/src/structures/team_scoreboard.ts
+++ b/src/structures/team_scoreboard.ts
@@ -17,12 +17,6 @@ export default class TeamScoreboard extends Scoreboard {
     */
     protected players: TeamMap;
 
-    /** @returns An array of DiscordEmbed fields representing each participant's score */
-    getScoreboardEmbedFields(): Array<{ name: string, value: string, inline: boolean }> {
-        if (this.isEmpty()) return [];
-        return super.getScoreboardEmbedFields().map((x) => ({ name: `Team ${x.name}`, value: x.value, inline: x.inline }));
-    }
-
     /**
      * Updates the scoreboard with information about correct guessers
      * @param guessResults - Objects containing the user ID, points earned, and EXP gain
@@ -69,6 +63,13 @@ export default class TeamScoreboard extends Scoreboard {
      */
     getTeams(): TeamMap {
         return this.players;
+    }
+
+    /**
+     * @returns the number of teams
+     */
+    getNumTeams(): number {
+        return super.getNumPlayers();
     }
 
     /**

--- a/src/test/ci/elimination_player.test.ts
+++ b/src/test/ci/elimination_player.test.ts
@@ -5,7 +5,7 @@ let player: EliminationPlayer;
 describe("decrement lives", () => {
     describe("player has a non-zero number of lives", () => {
         it("should decrement their lives by 1", () => {
-            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 0, 5);
+            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 5);
             player.decrementLives();
             assert.strictEqual(player.getLives(), 4);
         });
@@ -13,7 +13,7 @@ describe("decrement lives", () => {
 
     describe("player has zero lives", () => {
         it("should not change their number of lives", () => {
-            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 0, 0);
+            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 0);
             player.decrementLives();
             assert.strictEqual(player.getLives(), 0);
         });
@@ -23,13 +23,13 @@ describe("decrement lives", () => {
 describe("eliminated", () => {
     describe("the player has non-zero lives", () => {
         it("should return false", () => {
-            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 0, 5);
+            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 5);
             assert.strictEqual(player.isEliminated(), false);
         });
     });
     describe("the player has zero lives", () => {
         it("should return true", () => {
-            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 0, 0);
+            player = new EliminationPlayer("miyeon#7489", "12345", "someurl", 0);
             assert.strictEqual(player.isEliminated(), true);
         });
     });

--- a/src/test/ci/team_scoreboard.test.ts
+++ b/src/test/ci/team_scoreboard.test.ts
@@ -26,8 +26,8 @@ describe("add a team", () => {
 
         assert.strictEqual(scoreboard.hasTeam(SECOND_TEAM_NAME), false);
         const secondTeam = scoreboard.addTeam(SECOND_TEAM_NAME, player);
-        assert.deepStrictEqual(scoreboard.getTeam(secondTeam.getName()), secondTeam);
-        assert.strictEqual(scoreboard.hasTeam(secondTeam.getName()), true);
+        assert.deepStrictEqual(scoreboard.getTeam(secondTeam.getNameWithoutTeam()), secondTeam);
+        assert.strictEqual(scoreboard.hasTeam(secondTeam.getNameWithoutTeam()), true);
         assert.deepStrictEqual(Object.values(scoreboard.getTeams()), [firstTeam, secondTeam]);
     });
 });

--- a/src/test/ci/team_scoreboard.test.ts
+++ b/src/test/ci/team_scoreboard.test.ts
@@ -26,8 +26,8 @@ describe("add a team", () => {
 
         assert.strictEqual(scoreboard.hasTeam(SECOND_TEAM_NAME), false);
         const secondTeam = scoreboard.addTeam(SECOND_TEAM_NAME, player);
-        assert.deepStrictEqual(scoreboard.getTeam(secondTeam.getNameWithoutTeam()), secondTeam);
-        assert.strictEqual(scoreboard.hasTeam(secondTeam.getNameWithoutTeam()), true);
+        assert.deepStrictEqual(scoreboard.getTeam(secondTeam.getName()), secondTeam);
+        assert.strictEqual(scoreboard.hasTeam(secondTeam.getName()), true);
         assert.deepStrictEqual(Object.values(scoreboard.getTeams()), [firstTeam, secondTeam]);
     });
 });


### PR DESCRIPTION
* Raise scoreboard player capacity from 15 to 30
* Refactor OOP design of elimination and teams scoreboard
* Set maximum lives to 10000
* Mention "The bot prefix" instead of "Your bot prefix"
* Updated formatting for hint and level up message