### PR TITLE
Various temporary leaderboard fixes

### DIFF
--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -161,18 +161,18 @@ export default class LeaderboardCommand implements BaseCommand {
 
         const d = date || new Date();
         switch (duration) {
-            // Give an extra 5 seconds to send temporary leaderboards to debug channel
+            // Give an extra 10 seconds to send temporary leaderboards to debug channel
             case LeaderboardDuration.DAILY:
                 topPlayersQuery = topPlayersQuery
-                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 5).getTime()));
+                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 10).getTime()));
                 break;
             case LeaderboardDuration.WEEKLY:
                 topPlayersQuery = topPlayersQuery
-                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate() - d.getDay(), 0, 0, 5).getTime()));
+                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate() - d.getDay(), 0, 0, 10).getTime()));
                 break;
             case LeaderboardDuration.MONTHLY:
                 topPlayersQuery = topPlayersQuery
-                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), 0, 0, 0, 5).getTime()));
+                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), 0, 0, 0, 10).getTime()));
                 break;
             default:
                 break;

--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -161,18 +161,18 @@ export default class LeaderboardCommand implements BaseCommand {
 
         const d = date || new Date();
         switch (duration) {
-            // Give an extra second to send temporary leaderboards to debug channel
+            // Give an extra 5 seconds to send temporary leaderboards to debug channel
             case LeaderboardDuration.DAILY:
                 topPlayersQuery = topPlayersQuery
-                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 1).getTime()));
+                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 5).getTime()));
                 break;
             case LeaderboardDuration.WEEKLY:
                 topPlayersQuery = topPlayersQuery
-                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate() - d.getDay(), 0, 0, 1).getTime()));
+                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), d.getDate() - d.getDay(), 0, 0, 5).getTime()));
                 break;
             case LeaderboardDuration.MONTHLY:
                 topPlayersQuery = topPlayersQuery
-                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), 0, 0, 0, 1).getTime()));
+                    .where("date", ">", getSqlDateString(new Date(d.getFullYear(), d.getMonth(), 0, 0, 0, 5).getTime()));
                 break;
             default:
                 break;
@@ -314,7 +314,7 @@ export default class LeaderboardCommand implements BaseCommand {
             return;
         }
 
-        if (pageOffset + 1 > pageCount) {
+        if (pageOffset > pageCount) {
             sendErrorMessage(messageContext, { title: "😐", description: "The leaderboard doesn't go this far.", thumbnailUrl: KmqImages.NOT_IMPRESSED });
             return;
         }

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -3,6 +3,7 @@
 import schedule from "node-schedule";
 import fastify from "fastify";
 import _ from "lodash";
+import { isMaster } from "cluster";
 import { IPCLogger } from "../logger";
 import { state } from "../kmq";
 import { sendInfoMessage } from "./discord_utils";
@@ -279,17 +280,24 @@ export function registerIntervals(clusterID: number) {
 
     // every first of the month at 12am UTC => 7pm EST
     schedule.scheduleJob("0 0 1 * *", async () => {
-        LeaderboardCommand.sendDebugLeaderboard(LeaderboardDuration.MONTHLY);
+        if (isMaster) {
+            LeaderboardCommand.sendDebugLeaderboard(LeaderboardDuration.MONTHLY);
+        }
     });
 
     // every sunday at 12am UTC => saturday 7pm EST
     schedule.scheduleJob("0 0 * * SUN", async () => {
-        LeaderboardCommand.sendDebugLeaderboard(LeaderboardDuration.WEEKLY);
+        if (isMaster) {
+            LeaderboardCommand.sendDebugLeaderboard(LeaderboardDuration.WEEKLY);
+        }
     });
 
     // everyday at 12am UTC => 7pm EST
     schedule.scheduleJob("0 0 * * *", async () => {
-        LeaderboardCommand.sendDebugLeaderboard(LeaderboardDuration.DAILY);
+        if (isMaster) {
+            LeaderboardCommand.sendDebugLeaderboard(LeaderboardDuration.DAILY);
+        }
+
         reloadFactCache();
     });
 


### PR DESCRIPTION
* Fix off-by-one error on pages when only 1 page
* Raise reset delay from 1s to 5s after midnight
* Only send temp leaderboard from master