### PR TITLE
Replace VC listeners with no-op instead of blindly removing all listeners

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -184,10 +184,6 @@ export default class GameSession {
      * @param messageContext - An object containing relevant parts of Eris.Message
      */
     async endRound(guessResult: GuessResult, guildPreference: GuildPreference, messageContext?: MessageContext) {
-        if (this.connection) {
-            this.connection.removeAllListeners();
-        }
-
         if (this.gameRound === null) {
             return;
         }
@@ -855,6 +851,9 @@ export default class GameSession {
 
         // song finished without being guessed
         this.connection.once("end", async () => {
+            // replace listener with no-op to catch any exceptions thrown after this event
+            this.connection.removeAllListeners("end");
+            this.connection.on("end", () => { });
             logger.info(`${getDebugLogHeader(messageContext)} | Song finished without being guessed.`);
             this.stopGuessTimeout();
 
@@ -864,6 +863,9 @@ export default class GameSession {
 
         // admin manually 'disconnected' bot from voice channel or misc error
         this.connection.once("error", async (err) => {
+            // replace listener with no-op to catch any exceptions thrown after this event
+            this.connection.removeAllListeners("error");
+            this.connection.on("error", () => { });
             if (!this.connection.channelID) {
                 logger.info(`${getDebugLogHeader(messageContext)} | Bot was kicked from voice channel`);
                 this.stopGuessTimeout();


### PR DESCRIPTION
Uncaught exception: Error 1006 occurs when the VC's underlying websocket abnormally closes. The exception is emited as an error event on the VC object. There is a race condition where if we do `this.connection.removeAllListeners();` before the error event is fired, it will trigger an uncaught exception. 

This approach replaces the listeners with no-ops to 'handle' the exceptions. 
   ```
   26 2021-11-05T07:53:57.620Z [ERROR] - Cluster 1 | uncaughtException | Cluster Uncaught Exception. Reason: Error: 1006: . Trace: Error: 1006:
   25 ┊   at WebSocket.<anonymous> (/home/kmq/prod/node_modules/eris/lib/voice/VoiceConnection.js:348:55)
   24 ┊   at WebSocket.emit (events.js:315:20)
   23 ┊   at WebSocket.emitClose (/home/kmq/prod/node_modules/ws/lib/websocket.js:243:10)
   22 ┊   at Receiver.receiverOnFinish (/home/kmq/prod/node_modules/ws/lib/websocket.js:960:20)
   21 ┊   at Receiver.emit (events.js:315:20)
   20 ┊   at finish (_stream_writable.js:646:10)
   19 ┊   at processTicksAndRejections (internal/process/task_queues.js:84:21)
   ```