### PR TITLE
Fix flaky EXP calculation tests

### DIFF
--- a/src/test/ci/exp.test.ts
+++ b/src/test/ci/exp.test.ts
@@ -272,6 +272,7 @@ describe("calculateRoundExpMultiplier", () => {
     let gameRound: GameRound;
     beforeEach(() => {
         gameRound = new GameRound("x", "x", "x", "x", new Date(), 1);
+        gameRound.bonusModifier = 1;
         guildPreference = GuildPreference.fromGuild("123");
         sandbox.stub(guildPreference, "updateGuildPreferences");
     });


### PR DESCRIPTION
Game round bonus modifier is randomly set to higher value with low probability in constructor. Manually set it to 1 here