### PR TITLE
Fixed bug showing undefined songs guessed; miscellaneous formatting fixes

### DIFF
--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -76,8 +76,9 @@ export default class LeaderboardCommand implements BaseCommand {
                     "Shows the 2nd page of the monthly scoreboard containing players with points in the current game",
             },
             {
-                example: "`,leaderboard server`",
-                explanation: "Shows the server-wide leaderboard",
+                example: "`,leaderboard songsguessed server 3`",
+                explanation:
+                    "Shows the 3rd page of the server-wide leaderboard by total songs guessed",
             },
             {
                 example: "`,leaderboard enroll`",
@@ -89,9 +90,8 @@ export default class LeaderboardCommand implements BaseCommand {
                 explanation: "Hides your name from the leaderboard",
             },
             {
-                example: "`,leaderboard songsguessed server 3`",
-                explanation:
-                    "Shows the 3rd page of the server-wide leaderboard by total songs guessed",
+                example: "`,leaderboard server`",
+                explanation: "Shows the server-wide leaderboard",
             },
             {
                 example: "`,leaderboard weekly 4`",

--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -1,4 +1,5 @@
 import Eris from "eris";
+import pluralize from "pluralize";
 import dbContext from "../../database_context";
 import BaseCommand, { CommandArgs } from "../interfaces/base_command";
 import { IPCLogger } from "../../logger";
@@ -465,7 +466,10 @@ export default class LeaderboardCommand implements BaseCommand {
                                     } else {
                                         level = `${friendlyFormattedNumber(
                                             player.level
-                                        )} levels gained`;
+                                        )} ${pluralize(
+                                            "level",
+                                            player.level
+                                        )} gained`;
                                     }
 
                                     let value: string;
@@ -489,7 +493,10 @@ export default class LeaderboardCommand implements BaseCommand {
                                         case LeaderboardType.GAMES_PLAYED: {
                                             const games = `${friendlyFormattedNumber(
                                                 player.game_count
-                                            )} games played`;
+                                            )} ${pluralize(
+                                                "game",
+                                                player.game_count
+                                            )} played`;
 
                                             value = `${games} | ${level}`;
                                             break;
@@ -498,7 +505,10 @@ export default class LeaderboardCommand implements BaseCommand {
                                         case LeaderboardType.SONGS_GUESSED: {
                                             const guesses = `${friendlyFormattedNumber(
                                                 player.songs_guessed
-                                            )} songs guessed`;
+                                            )} ${pluralize(
+                                                "song",
+                                                player.songs_guessed
+                                            )} guessed`;
 
                                             value = `${guesses} | ${level}`;
                                             break;

--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -397,7 +397,7 @@ export default class LeaderboardCommand implements BaseCommand {
                     );
 
                     topPlayersQuery = topPlayersQuery
-                        .sum("songs_guessed")
+                        .sum("songs_guessed AS songs_guessed")
                         .groupBy("player_id");
                 }
 

--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -455,6 +455,19 @@ export default class LeaderboardCommand implements BaseCommand {
                                         ? enrolledPlayer.display_name
                                         : `Rank #${rank + 1}`;
 
+                                    let level: string;
+                                    if (permanentLb) {
+                                        level = `Level ${friendlyFormattedNumber(
+                                            player.level
+                                        )} (${getRankNameByLevel(
+                                            player.level
+                                        )})`;
+                                    } else {
+                                        level = `${friendlyFormattedNumber(
+                                            player.level
+                                        )} levels gained`;
+                                    }
+
                                     let value: string;
                                     switch (type) {
                                         case LeaderboardType.EXP:
@@ -463,21 +476,11 @@ export default class LeaderboardCommand implements BaseCommand {
                                                     player.exp
                                                 )} EXP`;
 
-                                                const level = `Level ${friendlyFormattedNumber(
-                                                    player.level
-                                                )} (${getRankNameByLevel(
-                                                    player.level
-                                                )})`;
-
                                                 value = `${exp} | ${level}`;
                                             } else {
                                                 const expGained = `+${friendlyFormattedNumber(
                                                     player.exp
                                                 )} EXP`;
-
-                                                const level = `${friendlyFormattedNumber(
-                                                    player.level
-                                                )} levels gained`;
 
                                                 value = `${expGained} | ${level}`;
                                             }
@@ -488,19 +491,6 @@ export default class LeaderboardCommand implements BaseCommand {
                                                 player.game_count
                                             )} games played`;
 
-                                            let level: string;
-                                            if (permanentLb) {
-                                                level = `Level ${friendlyFormattedNumber(
-                                                    player.level
-                                                )} (${getRankNameByLevel(
-                                                    player.level
-                                                )})`;
-                                            } else {
-                                                level = `${friendlyFormattedNumber(
-                                                    player.level
-                                                )} levels gained`;
-                                            }
-
                                             value = `${games} | ${level}`;
                                             break;
                                         }
@@ -509,19 +499,6 @@ export default class LeaderboardCommand implements BaseCommand {
                                             const guesses = `${friendlyFormattedNumber(
                                                 player.songs_guessed
                                             )} songs guessed`;
-
-                                            let level: string;
-                                            if (permanentLb) {
-                                                level = `Level ${friendlyFormattedNumber(
-                                                    player.level
-                                                )} (${getRankNameByLevel(
-                                                    player.level
-                                                )})`;
-                                            } else {
-                                                level = `${friendlyFormattedNumber(
-                                                    player.level
-                                                )} levels gained`;
-                                            }
 
                                             value = `${guesses} | ${level}`;
                                             break;


### PR DESCRIPTION
* Extract leaderboard level string out of case statement
* Corrected undefined songs guessed on temporary lb
* Moved up songs guessed example command in lb help
* Pluralize levels gained, songs guessed, games played