### PR TITLE
Localize no correct guess message on MC

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -620,9 +620,7 @@ export default class GameSession {
         if (!this.gameRound) return;
         if (!this.guessEligible(messageContext)) return;
 
-        const guildPreference = await getGuildPreference(
-            messageContext.guildID
-        );
+        const guildPreference = await getGuildPreference(this.guildID);
 
         const pointsEarned = this.checkGuess(
             messageContext.author.id,
@@ -685,7 +683,7 @@ export default class GameSession {
                 await this.endRound(
                     { correct: false },
                     guildPreference,
-                    new MessageContext(this.textChannelID)
+                    new MessageContext(this.textChannelID, null, this.guildID)
                 );
 
                 this.startRound(


### PR DESCRIPTION
`endRound` sends the scoreboard message and passes this `messageContext`. It needs the `guildID` for localization