### PR TITLE
Prevent ,cutoff from double underline on ,reset

### DIFF
--- a/src/structures/guild_preference.ts
+++ b/src/structures/guild_preference.ts
@@ -920,6 +920,9 @@ export default class GuildPreference {
             (option) => !_.isEqual(oldOptions[option[0]], option[1])
         );
 
-        return updatedOptions.map((x) => x[0] as GameOption);
+        return _.uniqBy(
+            updatedOptions.map((x) => x[0] as GameOption),
+            "option"
+        );
     }
 }


### PR DESCRIPTION
If a beginning and end cutoff are set, then cutoff is underlined twice. Solved by removing duplicate options on `resetToDefault()`.