### PR TITLE
Use client ID as guild ID in debug server

### DIFF
--- a/src/commands/game_commands/join.ts
+++ b/src/commands/game_commands/join.ts
@@ -162,7 +162,11 @@ export default class JoinCommand implements BaseCommand {
 
             if (
                 !state.client.guilds
-                    .get(message.guildID)
+                    .get(
+                        message.guildID !== state.client.user.id
+                            ? message.guildID
+                            : process.env.DEBUG_SERVER_ID
+                    )
                     .emojis.map((e) => e.id)
                     .includes(emojiID)
             ) {

--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -641,7 +641,11 @@ export default class LeaderboardCommand implements BaseCommand {
                                             {
                                                 serverName:
                                                     state.client.guilds.get(
-                                                        messageContext.guildID
+                                                        messageContext.guildID !==
+                                                            state.client.user.id
+                                                            ? messageContext.guildID
+                                                            : process.env
+                                                                  .DEBUG_SERVER_ID
                                                     ).name,
                                             }
                                         );

--- a/src/events/client/interactionCreate.ts
+++ b/src/events/client/interactionCreate.ts
@@ -24,7 +24,12 @@ export default async function interactionCreateHandler(
         | Eris.UnknownInteraction
 ): Promise<void> {
     if (interaction instanceof Eris.ComponentInteraction) {
-        const gameSession = state.gameSessions[interaction.guildID];
+        const guildID =
+            interaction.guildID === process.env.DEBUG_SERVER_ID
+                ? state.client.user.id
+                : interaction.guildID;
+
+        const gameSession = state.gameSessions[guildID];
         if (!gameSession || !gameSession.gameRound) {
             tryInteractionAcknowledge(interaction);
             return;
@@ -38,7 +43,7 @@ export default async function interactionCreateHandler(
                 interaction.member.avatarURL,
                 interaction.member.id
             ),
-            interaction.guildID
+            guildID
         );
 
         gameSession.handleMultipleChoiceInteraction(
@@ -46,6 +51,11 @@ export default async function interactionCreateHandler(
             messageContext
         );
     } else if (interaction instanceof Eris.CommandInteraction) {
+        const guildID =
+            interaction.guildID === process.env.DEBUG_SERVER_ID
+                ? state.client.user.id
+                : interaction.guildID;
+
         if (
             interaction.data.type ===
             Eris.Constants.ApplicationCommandTypes.USER
@@ -61,12 +71,12 @@ export default async function interactionCreateHandler(
             Eris.Constants.ApplicationCommandTypes.MESSAGE
         ) {
             if (interaction.data.name === BOOKMARK_COMMAND_NAME) {
-                const gameSession = state.gameSessions[interaction.guildID];
+                const gameSession = state.gameSessions[guildID];
                 if (!gameSession) {
                     tryCreateInteractionErrorAcknowledgement(
                         interaction,
                         state.localizer.translate(
-                            interaction.guildID,
+                            guildID,
                             "misc.failure.interaction.bookmarkOutsideGame"
                         )
                     );

--- a/src/events/client/messageCreate.ts
+++ b/src/events/client/messageCreate.ts
@@ -50,12 +50,18 @@ export default async function messageCreateHandler(
 
     const parsedMessage = parseMessage(message.content) || null;
     const textChannel = message.channel as Eris.TextChannel;
+    const guildID =
+        message.guildID === process.env.DEBUG_SERVER_ID
+            ? state.client.user.id
+            : message.guildID;
+
+    message.guildID = guildID;
     if (
         message.mentions.includes(state.client.user) &&
         message.content.split(" ").length === 1
     ) {
         // Any message that mentions the bot sends the current options
-        const guildPreference = await getGuildPreference(message.guildID);
+        const guildPreference = await getGuildPreference(guildID);
         sendOptionsMessage(
             MessageContext.fromMessage(message),
             guildPreference,
@@ -86,12 +92,12 @@ export default async function messageCreateHandler(
                 parsedMessage,
                 invokedCommand.validations,
                 typeof invokedCommand.help === "function"
-                    ? invokedCommand.help(message.guildID).usage
+                    ? invokedCommand.help(guildID).usage
                     : null
             )
         ) {
             const { gameSessions } = state;
-            const gameSession = gameSessions[message.guildID];
+            const gameSession = gameSessions[guildID];
             if (invokedCommand.preRunChecks) {
                 for (const precheck of invokedCommand.preRunChecks) {
                     if (
@@ -127,19 +133,19 @@ export default async function messageCreateHandler(
 
                 sendErrorMessage(MessageContext.fromMessage(message), {
                     title: state.localizer.translate(
-                        message.guildID,
+                        guildID,
                         "misc.failure.command.title"
                     ),
                     description: state.localizer.translate(
-                        message.guildID,
+                        guildID,
                         "misc.failure.command.description",
                         { debugId }
                     ),
                 });
             }
         }
-    } else if (state.gameSessions[message.guildID]?.gameRound) {
-        const gameSession = state.gameSessions[message.guildID];
+    } else if (state.gameSessions[guildID]?.gameRound) {
+        const gameSession = state.gameSessions[guildID];
         gameSession.guessSong(
             MessageContext.fromMessage(message),
             message.content

--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -11,7 +11,11 @@ export default function voiceChannelLeaveHandler(
     member: Eris.Member,
     oldChannel: Eris.VoiceChannel
 ): void {
-    const guildID = oldChannel.guild.id;
+    const guildID =
+        oldChannel.guild.id === process.env.DEBUG_SERVER_ID
+            ? state.client.user.id
+            : oldChannel.guild.id;
+
     const gameSession = state.gameSessions[guildID];
     if (!gameSession) {
         return;

--- a/src/events/client/voiceChannelSwitch.ts
+++ b/src/events/client/voiceChannelSwitch.ts
@@ -13,7 +13,11 @@ export default async function voiceChannelSwitchHandler(
     newChannel: Eris.VoiceChannel,
     oldChannel: Eris.VoiceChannel
 ): Promise<void> {
-    const guildID = oldChannel.guild.id;
+    const guildID =
+        oldChannel.guild.id === process.env.DEBUG_SERVER_ID
+            ? state.client.user.id
+            : oldChannel.guild.id;
+
     const gameSession = state.gameSessions[guildID];
     if (!gameSession) {
         return;

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1443,7 +1443,11 @@ export async function sendScoreboardMessage(
  * @param message - The Message object
  */
 export function disconnectVoiceConnection(message: GuildTextableMessage): void {
-    state.client.closeVoiceConnection(message.guildID);
+    state.client.closeVoiceConnection(
+        message.guildID !== state.client.user.id
+            ? message.guildID
+            : process.env.DEBUG_SERVER_ID
+    );
 }
 
 /**
@@ -1453,7 +1457,12 @@ export function disconnectVoiceConnection(message: GuildTextableMessage): void {
 export function getVoiceConnection(
     message: Eris.Message
 ): Eris.VoiceConnection {
-    const voiceConnection = state.client.voiceConnections.get(message.guildID);
+    const voiceConnection = state.client.voiceConnections.get(
+        message.guildID !== state.client.user.id
+            ? message.guildID
+            : process.env.DEBUG_SERVER_ID
+    );
+
     return voiceConnection;
 }
 
@@ -1465,7 +1474,9 @@ export function areUserAndBotInSameVoiceChannel(
     message: Eris.Message
 ): boolean {
     const botVoiceConnection = state.client.voiceConnections.get(
-        message.guildID
+        message.guildID !== state.client.user.id
+            ? message.guildID
+            : process.env.DEBUG_SERVER_ID
     );
 
     if (!message.member.voiceState || !botVoiceConnection) {
@@ -1483,7 +1494,11 @@ export function getUserVoiceChannel(
     messageContext: MessageContext
 ): Eris.VoiceChannel {
     const member = state.client.guilds
-        .get(messageContext.guildID)
+        .get(
+            messageContext.guildID !== state.client.user.id
+                ? messageContext.guildID
+                : process.env.DEBUG_SERVER_ID
+        )
         .members.get(messageContext.author.id);
 
     const voiceChannelID = member.voiceState.channelID;
@@ -1612,7 +1627,10 @@ export function voicePermissionsCheck(message: GuildTextableMessage): boolean {
  * @returns whether the bot is alone 😔
  */
 export function checkBotIsAlone(guildID: string): boolean {
-    const voiceConnection = state.client.voiceConnections.get(guildID);
+    const voiceConnection = state.client.voiceConnections.get(
+        guildID !== state.client.user.id ? guildID : process.env.DEBUG_SERVER_ID
+    );
+
     if (!voiceConnection || !voiceConnection.channelID) return true;
     const channel = state.client.getChannel(
         voiceConnection.channelID
@@ -1643,8 +1661,9 @@ export function getDebugChannel(): Promise<Eris.TextChannel> {
  * @returns the number of users required for a majority
  */
 export function getMajorityCount(guildID: string): number {
-    const voiceChannelID =
-        state.client.voiceConnections.get(guildID)?.channelID;
+    const voiceChannelID = state.client.voiceConnections.get(
+        guildID !== state.client.user.id ? guildID : process.env.DEBUG_SERVER_ID
+    )?.channelID;
 
     if (voiceChannelID) {
         return Math.floor(getNumParticipants(voiceChannelID) * 0.5) + 1;
@@ -1852,7 +1871,9 @@ export async function tryCreateInteractionErrorAcknowledgement(
                     },
                     title: bold(
                         state.localizer.translate(
-                            interaction.guildID,
+                            interaction.guildID === state.client.user.id
+                                ? state.client.user.id
+                                : interaction.guildID,
                             "misc.interaction.title.failure"
                         )
                     ),

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -130,7 +130,10 @@ function clearInactiveVoiceConnections(): void {
     ) as Array<string>;
 
     const activeVoiceChannelGuildIDs = Object.values(state.gameSessions).map(
-        (x) => x.guildID
+        (x) =>
+            x.guildID !== state.client.user.id
+                ? x.guildID
+                : process.env.DEBUG_SERVER_ID
     );
 
     for (const existingVoiceChannelGuildID of existingVoiceChannelGuildIDs) {

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -396,7 +396,11 @@ export default class GameSession {
             await getGuildPreference(this.guildID),
             new MessageContext(this.textChannelID, null, this.guildID)
         );
-        const voiceConnection = state.client.voiceConnections.get(this.guildID);
+        const voiceConnection = state.client.voiceConnections.get(
+            this.guildID !== state.client.user.id
+                ? this.guildID
+                : process.env.DEBUG_SERVER_ID
+        );
 
         if (this.gameType === GameType.COMPETITION) {
             // log scoreboard


### PR DESCRIPTION
TODO: create migrations to convert debug server DB entries to entries for each client (potentially a script to keep them synced)