### PR TITLE
Refactor of participants, ,play elimination

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -66,9 +66,6 @@
                 "noTeam": {
                     "description": "Create a team using `{{join}} [team name]` before you can start the game."
                 },
-                "notOwner": {
-                    "description": "Only the person who did {{playElimination}} ({{mentionedUser}}) can start the game."
-                },
                 "title": "Begin Ignored"
             }
         },
@@ -327,16 +324,8 @@
                     "title": "Join Error"
                 }
             },
-            "playerAlreadyJoined": {
-                "description": "{{mentionedUser}} is already in the game.",
-                "title": "Player Already Joined"
-            },
             "playerJoined": {
                 "title": "Player Joined"
-            },
-            "playerJoinedMidGame": {
-                "description": "{{mentionedUser}} has spawned with {{lives}} lives.",
-                "title": "Player Joined Mid Game"
             },
             "playerJoinedTeam": {
                 "afterGameStart": {
@@ -574,18 +563,6 @@
             }
         },
         "play": {
-            "elimination": {
-                "failure": {
-                    "alreadyJoined": {
-                        "description": "{{mentionedUser}} is already in the game.",
-                        "title": "Player Already Joined"
-                    }
-                },
-                "join": {
-                    "description": "Type {{join}} to play in the upcoming elimination game. Once all have joined, {{mentionedUser}} must send {{begin}} to start the game. Everyone begins with {{lives}} lives.",
-                    "title": "{{join}} the game and start it with {{begin}}!"
-                }
-            },
             "exp": {
                 "doubleExpForVoting": "will receive double EXP for [voting]({{link}})!",
                 "howToVote": "See {{vote}} for info on how to vote. Thanks for supporting KMQ!",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -66,9 +66,6 @@
                 "noTeam": {
                     "description": "게임을 시작하기 전에 `{{join}} [팀 이름]`을 사용하여 팀을 만드세요."
                 },
-                "notOwner": {
-                    "description": "{{playElimination}}을 한 사람, ({{mentionedUser}})만 게임을 시작할 수 있습니다."
-                },
                 "title": "게임 시작이 무시되었습니다."
             }
         },
@@ -327,16 +324,8 @@
                     "title": "가입 오류"
                 }
             },
-            "playerAlreadyJoined": {
-                "description": "{{mentionedUser}}님은 이미 게임에 참여하고 있습니다.",
-                "title": "이미 참가한 플레이어"
-            },
             "playerJoined": {
                 "title": "참가한 플레이어"
-            },
-            "playerJoinedMidGame": {
-                "description": "{{mentionedUser}}이(가) {{lives}}명의 목숨과 함께 생성되었습니다.",
-                "title": "플레이어가 게임 중반에 합류했습니다."
             },
             "playerJoinedTeam": {
                 "afterGameStart": {
@@ -574,18 +563,6 @@
             }
         },
         "play": {
-            "elimination": {
-                "failure": {
-                    "alreadyJoined": {
-                        "description": "{{mentionedUser}}님은 이미 게임에 참여하고 있습니다.",
-                        "title": "이미 참가한 플레이어입니다."
-                    }
-                },
-                "join": {
-                    "description": "곧 시작하는 제거 게임에서 플레이하려면 {{join}}을(를) 입력하세요. (모두 참여했으면 {{mentionedUser}}이(가) {{begin}}을 보내 게임을 시작해야 하며 모든 사람은 {{lives}}의 목숨으로 시작합니다.)",
-                    "title": "{{join}} 게임을 시작하고 {{begin}}(으)로 시작하세요!"
-                }
-            },
             "exp": {
                 "doubleExpForVoting": "[투표]({{link}})에 대한 경험치를 두 배로 받습니다!",
                 "howToVote": "투표 방법에 대한 정보는 {{vote}}를 참조하세요. (KMQ를 지원해주셔서 감사합니다!)",

--- a/src/commands/game_commands/begin.ts
+++ b/src/commands/game_commands/begin.ts
@@ -7,7 +7,6 @@ import {
     getDebugLogHeader,
     sendErrorMessage,
     getUserVoiceChannel,
-    getMention,
 } from "../../helpers/discord_utils";
 import { IPCLogger } from "../../logger";
 import MessageContext from "../../structures/message_context";
@@ -22,51 +21,26 @@ export default class BeginCommand implements BaseCommand {
 
     static canStart(
         gameSession: GameSession,
-        authorID: string,
         messageContext: MessageContext
     ): boolean {
-        if (
-            !gameSession ||
-            (gameSession.gameType !== GameType.ELIMINATION &&
-                gameSession.gameType !== GameType.TEAMS)
-        ) {
+        if (!gameSession || gameSession.gameType !== GameType.TEAMS) {
             return false;
         }
 
-        if (gameSession.gameType === GameType.ELIMINATION) {
-            if (gameSession.owner.id !== authorID) {
-                sendErrorMessage(messageContext, {
-                    title: state.localizer.translate(
-                        messageContext.guildID,
-                        "command.begin.ignored.title"
-                    ),
-                    description: state.localizer.translate(
-                        messageContext.guildID,
-                        "command.begin.ignored.notOwner.description",
-                        {
-                            playElimination: `\`${process.env.BOT_PREFIX}play elimination\``,
-                            mentionedUser: getMention(gameSession.owner.id),
-                        }
-                    ),
-                });
-                return false;
-            }
-        } else if (gameSession.gameType === GameType.TEAMS) {
-            const teamScoreboard = gameSession.scoreboard as TeamScoreboard;
-            if (teamScoreboard.getNumTeams() === 0) {
-                sendErrorMessage(messageContext, {
-                    title: state.localizer.translate(
-                        messageContext.guildID,
-                        "command.begin.ignored.title"
-                    ),
-                    description: state.localizer.translate(
-                        messageContext.guildID,
-                        "command.begin.ignored.noTeam.description",
-                        { join: `${process.env.BOT_PREFIX}join` }
-                    ),
-                });
-                return false;
-            }
+        const teamScoreboard = gameSession.scoreboard as TeamScoreboard;
+        if (teamScoreboard.getNumTeams() === 0) {
+            sendErrorMessage(messageContext, {
+                title: state.localizer.translate(
+                    messageContext.guildID,
+                    "command.begin.ignored.title"
+                ),
+                description: state.localizer.translate(
+                    messageContext.guildID,
+                    "command.begin.ignored.noTeam.description",
+                    { join: `${process.env.BOT_PREFIX}join` }
+                ),
+            });
+            return false;
         }
 
         return true;
@@ -77,13 +51,12 @@ export default class BeginCommand implements BaseCommand {
         gameSessions,
         channel,
     }: CommandArgs): Promise<void> => {
-        const { guildID, author } = message;
+        const { guildID } = message;
         const gameSession = gameSessions[guildID];
 
         if (
             !BeginCommand.canStart(
                 gameSession,
-                author.id,
                 MessageContext.fromMessage(message)
             )
         )
@@ -96,18 +69,12 @@ export default class BeginCommand implements BaseCommand {
                 discriminator: string;
             }>;
 
-            if (gameSession.gameType === GameType.ELIMINATION) {
-                participants = [...gameSession.participants].map((x) =>
-                    state.client.users.get(x)
-                );
-            } else if (gameSession.gameType === GameType.TEAMS) {
-                const teamScoreboard = gameSession.scoreboard as TeamScoreboard;
-                participants = teamScoreboard.getPlayers().map((player) => ({
-                    id: player.id,
-                    username: player.name.split("#")[0],
-                    discriminator: player.name.split("#")[1],
-                }));
-            }
+            const teamScoreboard = gameSession.scoreboard as TeamScoreboard;
+            participants = teamScoreboard.getPlayers().map((player) => ({
+                id: player.id,
+                username: player.name.split("#")[0],
+                discriminator: player.name.split("#")[1],
+            }));
 
             sendBeginGameMessage(
                 channel.name,
@@ -122,9 +89,7 @@ export default class BeginCommand implements BaseCommand {
             );
 
             logger.info(
-                `${getDebugLogHeader(message)} | Game session starting (${
-                    gameSession.gameType
-                } gameType)`
+                `${getDebugLogHeader(message)} | Teams game session starting)`
             );
         }
     };

--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -380,13 +380,15 @@ export default class LeaderboardCommand implements BaseCommand {
             );
         } else if (scope === LeaderboardScope.GAME) {
             const participantIDs =
-                state.gameSessions[messageContext.guildID].participants;
+                state.gameSessions[
+                    messageContext.guildID
+                ].scoreboard.getPlayerIDs();
 
             const gamePlayers = (
                 await dbContext
                     .kmq(dbTable)
                     .select("player_id")
-                    .whereIn("player_id", [...participantIDs])
+                    .whereIn("player_id", participantIDs)
             ).map((x) => x.player_id);
 
             topPlayersQuery = topPlayersQuery.whereIn("player_id", gamePlayers);
@@ -843,9 +845,11 @@ export default class LeaderboardCommand implements BaseCommand {
             }
 
             const participantIDs =
-                state.gameSessions[message.guildID].participants;
+                state.gameSessions[
+                    messageContext.guildID
+                ].scoreboard.getPlayerIDs();
 
-            if (participantIDs.size === 0) {
+            if (participantIDs.length === 0) {
                 sendErrorMessage(messageContext, {
                     title: state.localizer.translate(
                         message.guildID,

--- a/src/commands/game_options/goal.ts
+++ b/src/commands/game_options/goal.ts
@@ -79,7 +79,7 @@ export default class GoalCommand implements BaseCommand {
         const userGoal = parseInt(parsedMessage.components[0]);
         if (gameSession) {
             if (
-                !gameSession.scoreboard.isEmpty() &&
+                gameSession.scoreboard.getWinners().length > 0 &&
                 userGoal <= gameSession.scoreboard.getWinners()[0].getScore()
             ) {
                 logger.info(

--- a/src/events/client/voiceChannelJoin.ts
+++ b/src/events/client/voiceChannelJoin.ts
@@ -14,7 +14,10 @@ export default async function voiceChannelJoinHandler(
         return;
     }
 
-    if (newChannel.id !== gameSession.voiceChannelID) {
+    if (
+        newChannel.id !== gameSession.voiceChannelID ||
+        member.id === process.env.BOT_CLIENT_ID
+    ) {
         return;
     }
 

--- a/src/events/client/voiceChannelSwitch.ts
+++ b/src/events/client/voiceChannelSwitch.ts
@@ -26,9 +26,11 @@ export default async function voiceChannelSwitchHandler(
 
     if (!gameSession.finished) {
         gameSession.updateOwner();
-        gameSession.setPlayerInVC(
-            member.id,
-            newChannel.id === gameSession.voiceChannelID
-        );
+        if (member.id !== process.env.BOT_CLIENT_ID) {
+            gameSession.setPlayerInVC(
+                member.id,
+                newChannel.id === gameSession.voiceChannelID
+            );
+        }
     }
 }

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -449,7 +449,7 @@ async function sendDmMessage(
     messageContent: Eris.AdvancedMessageContent
 ): Promise<Eris.Message> {
     const { client } = state;
-    let dmChannel;
+    let dmChannel: Eris.PrivateChannel;
     try {
         dmChannel = await client.getDMChannel(userID);
     } catch (e) {
@@ -752,7 +752,7 @@ export async function sendEndRoundMessage(
         scoreboard.getNumPlayers() > SCOREBOARD_FIELD_CUTOFF;
 
     let scoreboardTitle = "";
-    if (!scoreboard.isEmpty() && !useLargerScoreboard) {
+    if (scoreboard.getWinners().length > 0 && !useLargerScoreboard) {
         scoreboardTitle = "\n\n";
         scoreboardTitle += bold(
             state.localizer.translate(
@@ -784,8 +784,8 @@ export async function sendEndRoundMessage(
     let roundResultIDs: Array<string>;
     if (scoreboard instanceof TeamScoreboard) {
         const teamScoreboard = scoreboard as TeamScoreboard;
-        roundResultIDs = playerRoundResults.map((x) =>
-            teamScoreboard.getTeamOfPlayer(x.player.id).getID()
+        roundResultIDs = playerRoundResults.map(
+            (x) => teamScoreboard.getTeamOfPlayer(x.player.id).id
         );
     } else {
         roundResultIDs = playerRoundResults.map((x) => x.player.id);
@@ -1206,7 +1206,7 @@ export async function sendEndGameMessage(
         }
     );
 
-    if (gameSession.scoreboard.isEmpty()) {
+    if (gameSession.scoreboard.getWinners().length === 0) {
         await sendInfoMessage(new MessageContext(gameSession.textChannelID), {
             title: state.localizer.translate(
                 gameSession.guildID,
@@ -1369,20 +1369,6 @@ export async function sendScoreboardMessage(
     message: GuildTextableMessage,
     gameSession: GameSession
 ): Promise<Eris.Message> {
-    if (
-        gameSession.scoreboard.isEmpty() &&
-        gameSession.gameType !== GameType.ELIMINATION
-    ) {
-        return sendInfoMessage(MessageContext.fromMessage(message), {
-            color: EMBED_SUCCESS_COLOR,
-            description: "(╯°□°）╯︵ ┻━┻",
-            title: state.localizer.translate(
-                message.guildID,
-                "command.score.scoreboardTitle"
-            ),
-        });
-    }
-
     const winnersFieldSubsets = chunkArray(
         gameSession.scoreboard.getScoreboardEmbedFields(true, true),
         EMBED_FIELDS_PER_PAGE

--- a/src/kmq_worker.ts
+++ b/src/kmq_worker.ts
@@ -55,7 +55,12 @@ export class BotWorker extends BaseClusterWorker {
                 return null;
             case "game_session_stats": {
                 const activePlayers = Object.values(state.gameSessions).reduce(
-                    (total, curr) => total + curr.participants.size,
+                    (total, curr) =>
+                        total +
+                        curr.scoreboard
+                            .getPlayers()
+                            .filter((x) => x.inVC)
+                            .map((x) => x.id).length,
                     0
                 );
 

--- a/src/structures/elimination_player.ts
+++ b/src/structures/elimination_player.ts
@@ -1,7 +1,37 @@
 import Player from "./player";
+import { getUserTag } from "../helpers/discord_utils";
+import { state } from "../kmq_worker";
+import { EnvType } from "../types";
+import { User } from "eris";
+import { DEFAULT_LIVES } from "./elimination_scoreboard";
 
 export default class EliminationPlayer extends Player {
     // this.score => the player's lives
+
+    static fromUserID(
+        userID: string,
+        score = DEFAULT_LIVES,
+        firstGameOfDay = false
+    ): EliminationPlayer {
+        const user = [EnvType.CI, EnvType.TEST].includes(
+            process.env.NODE_ENV as EnvType
+        )
+            ? ({
+                  id: userID,
+                  avatarURL: "",
+                  username: "",
+                  discriminator: "",
+              } as User)
+            : state.client.users.get(userID);
+
+        return new EliminationPlayer(
+            getUserTag(user),
+            user.id,
+            user.avatarURL,
+            score,
+            firstGameOfDay
+        );
+    }
 
     /** @returns the number of lives the player has remaining */
     getLives(): number {

--- a/src/structures/elimination_player.ts
+++ b/src/structures/elimination_player.ts
@@ -1,8 +1,6 @@
 import Player from "./player";
 import { getUserTag } from "../helpers/discord_utils";
 import { state } from "../kmq_worker";
-import { EnvType } from "../types";
-import { User } from "eris";
 import { DEFAULT_LIVES } from "./elimination_scoreboard";
 
 export default class EliminationPlayer extends Player {
@@ -13,16 +11,7 @@ export default class EliminationPlayer extends Player {
         score = DEFAULT_LIVES,
         firstGameOfDay = false
     ): EliminationPlayer {
-        const user = [EnvType.CI, EnvType.TEST].includes(
-            process.env.NODE_ENV as EnvType
-        )
-            ? ({
-                  id: userID,
-                  avatarURL: "",
-                  username: "",
-                  discriminator: "",
-              } as User)
-            : state.client.users.get(userID);
+        const user = state.client.users.get(userID);
 
         return new EliminationPlayer(
             getUserTag(user),

--- a/src/structures/elimination_scoreboard.ts
+++ b/src/structures/elimination_scoreboard.ts
@@ -22,7 +22,7 @@ export default class EliminationScoreboard extends Scoreboard {
     async updateScoreboard(
         guessResults: Array<SuccessfulGuessResult>
     ): Promise<void> {
-        const previousRoundRanking = this.getRanking();
+        const previousRoundRanking = this.getScoreToRankingMap();
         for (const player of Object.values(this.players)) {
             player.setPreviousRanking(previousRoundRanking[player.getScore()]);
         }

--- a/src/structures/elimination_scoreboard.ts
+++ b/src/structures/elimination_scoreboard.ts
@@ -1,43 +1,18 @@
 import Scoreboard, { SuccessfulGuessResult } from "./scoreboard";
 import EliminationPlayer from "./elimination_player";
-import { IPCLogger } from "../logger";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const logger = new IPCLogger("elimination_scoreboard");
+export const DEFAULT_LIVES = 10;
 
 export default class EliminationScoreboard extends Scoreboard {
+    /** The amount of lives each player starts with */
+    public readonly startingLives: number;
+
     /** Mapping of Discord user ID to EliminationPlayer */
     protected players: { [userID: string]: EliminationPlayer };
-
-    /** The amount of lives each player starts with */
-    private readonly startingLives: number;
 
     constructor(lives: number) {
         super();
         this.startingLives = lives;
-    }
-
-    /**
-     * Begins tracking a player on the game's scoreboard
-     * @param userID - The player's Discord user ID
-     * @param tag - The player's Discord tag
-     * @param avatarUrl - The player's Discord avatar URL
-     * @param lives - The number of lives the player starts with
-     * @returns the EliminationPlayer added
-     */
-    addPlayer(
-        userID: string,
-        tag: string,
-        avatarUrl: string,
-        lives?: number
-    ): EliminationPlayer {
-        this.players[userID] = new EliminationPlayer(
-            tag,
-            userID,
-            avatarUrl,
-            lives ?? this.startingLives
-        );
-        return this.players[userID];
     }
 
     /**

--- a/src/structures/elimination_scoreboard.ts
+++ b/src/structures/elimination_scoreboard.ts
@@ -22,7 +22,10 @@ export default class EliminationScoreboard extends Scoreboard {
     async updateScoreboard(
         guessResults: Array<SuccessfulGuessResult>
     ): Promise<void> {
-        this.previousRoundRanking = Scoreboard.getRanking(this.players);
+        const previousRoundRanking = this.getRanking();
+        for (const player of Object.values(this.players)) {
+            player.setPreviousRanking(previousRoundRanking[player.getScore()]);
+        }
 
         // give everybody EXP
         for (const guessResult of guessResults) {

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -1188,8 +1188,9 @@ export default class GameSession {
                 this.gameType === GameType.ELIMINATION
                     ? EliminationPlayer.fromUserID(
                           userID,
-                          (this.scoreboard as EliminationScoreboard)
-                              .startingLives
+                          (
+                              this.scoreboard as EliminationScoreboard
+                          ).getLivesOfWeakestPlayer()
                       )
                     : Player.fromUserID(userID)
             );

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -41,7 +41,7 @@ import {
 } from "../helpers/utils";
 import { state } from "../kmq_worker";
 import { IPCLogger } from "../logger";
-import { QueriedSong, PlayerRoundResult, GameType } from "../types";
+import { QueriedSong, PlayerRoundResult, GameType, EnvType } from "../types";
 import GameRound from "./game_round";
 import GuildPreference from "./guild_preference";
 import Scoreboard, { SuccessfulGuessResult } from "./scoreboard";
@@ -59,6 +59,7 @@ import { specialFfmpegArgs } from "../commands/game_options/special";
 import { AnswerType } from "../commands/game_options/answer";
 import { calculateTotalRoundExp } from "../commands/game_commands/exp";
 import SongSelector from "./song_selector";
+import Player from "../structures/player";
 
 const MULTIGUESS_DELAY = 1500;
 const logger = new IPCLogger("game_session");
@@ -127,9 +128,6 @@ export default class GameSession {
     /** The current GameRound */
     public gameRound: GameRound;
 
-    /** List of active participants in the GameSession */
-    public participants: Set<string>;
-
     /** The time the GameSession was started in epoch milliseconds */
     private readonly startedAt: number;
 
@@ -178,18 +176,9 @@ export default class GameSession {
     ) {
         this.gameType = gameType;
         this.guildID = guildID;
-        if (this.gameType === GameType.ELIMINATION) {
-            this.scoreboard = new EliminationScoreboard(eliminationLives);
-        } else if (this.gameType === GameType.TEAMS) {
-            this.scoreboard = new TeamScoreboard();
-        } else {
-            this.scoreboard = new Scoreboard();
-        }
-
         this.lastActive = Date.now();
         this.sessionInitialized = false;
         this.startedAt = Date.now();
-        this.participants = new Set();
         this.roundsPlayed = 0;
         this.correctGuesses = 0;
         this.guessTimes = [];
@@ -204,6 +193,36 @@ export default class GameSession {
         this.songMessageIDs = [];
         this.bookmarkedSongs = {};
         this.songSelector = new SongSelector();
+
+        if (this.gameType === GameType.TEAMS) {
+            this.scoreboard = new TeamScoreboard();
+            return;
+        }
+
+        if (this.gameType === GameType.ELIMINATION) {
+            this.scoreboard = new EliminationScoreboard(eliminationLives);
+        } else {
+            this.scoreboard = new Scoreboard();
+        }
+
+        if (
+            ![EnvType.CI, EnvType.TEST].includes(
+                process.env.NODE_ENV as EnvType
+            )
+        ) {
+            getCurrentVoiceMembers(this.voiceChannelID)
+                .filter((x) => x.id !== process.env.BOT_CLIENT_ID)
+                .map((x) => x.id)
+                .map((x) =>
+                    this.scoreboard.addPlayer(
+                        [GameType.CLASSIC, GameType.COMPETITION].includes(
+                            this.gameType
+                        )
+                            ? Player.fromUserID(x)
+                            : EliminationPlayer.fromUserID(x, eliminationLives)
+                    )
+                );
+        }
     }
 
     /**
@@ -407,8 +426,8 @@ export default class GameSession {
                         .getPlayers()
                         .sort((a, b) => b.getScore() - a.getScore())
                         .map((x) => ({
-                            name: x.getName(),
-                            id: x.getID(),
+                            name: x.name,
+                            id: x.id,
                             score: x.getDisplayedScore(),
                         }))
                 )
@@ -429,7 +448,7 @@ export default class GameSession {
 
         const leveledUpPlayers: Array<LevelUpResult> = [];
         // commit player stats
-        for (const participant of this.participants) {
+        for (const participant of this.scoreboard.getPlayerIDs()) {
             await this.ensurePlayerStat(participant);
             await GameSession.incrementPlayerGamesPlayed(participant);
             const playerScore = this.scoreboard.getPlayerScore(participant);
@@ -531,7 +550,8 @@ export default class GameSession {
         await dbContext.kmq("game_sessions").insert({
             start_date: new Date(this.startedAt),
             guild_id: this.guildID,
-            num_participants: this.participants.size,
+            num_participants: this.scoreboard.getPlayers().map((x) => x.inVC)
+                .length,
             avg_guess_time: averageGuessTime,
             session_length: sessionLength,
             rounds_played: this.roundsPlayed,
@@ -962,26 +982,6 @@ export default class GameSession {
         clearTimeout(this.guessTimeoutFunc);
     }
 
-    /**
-     * Adds a participant for elimination mode
-     * @param user - The user to add
-     * @param midgame - Whether or not the user is being added mid-game
-     * @returns the added elimination participant
-     */
-    addEliminationParticipant(
-        user: KmqMember,
-        midgame = false
-    ): EliminationPlayer {
-        this.participants.add(user.id);
-        const eliminationScoreboard = this.scoreboard as EliminationScoreboard;
-        return eliminationScoreboard.addPlayer(
-            user.id,
-            user.tag,
-            user.avatarUrl,
-            midgame ? eliminationScoreboard.getLivesOfWeakestPlayer() : null
-        );
-    }
-
     getRoundsPlayed(): number {
         return this.roundsPlayed;
     }
@@ -1032,9 +1032,9 @@ export default class GameSession {
             return;
         }
 
-        const participantsInVC = [...this.participants].filter((p) =>
-            voiceMemberIDs.has(p)
-        );
+        const participantsInVC = this.scoreboard
+            .getPlayerIDs()
+            .filter((p) => voiceMemberIDs.has(p));
 
         let newOwnerID: string;
         if (participantsInVC.length > 0) {
@@ -1187,6 +1187,22 @@ export default class GameSession {
      * @param inVC - Whether the player is currently in the voice channel
      */
     setPlayerInVC(userID: string, inVC: boolean): void {
+        if (
+            inVC &&
+            !this.scoreboard.getPlayerIDs().includes(userID) &&
+            this.gameType !== GameType.TEAMS
+        ) {
+            this.scoreboard.addPlayer(
+                [GameType.CLASSIC, GameType.COMPETITION].includes(this.gameType)
+                    ? Player.fromUserID(userID)
+                    : EliminationPlayer.fromUserID(
+                          userID,
+                          (this.scoreboard as EliminationScoreboard)
+                              .startingLives
+                      )
+            );
+        }
+
         this.scoreboard.setInVC(userID, inVC);
     }
 
@@ -1354,9 +1370,6 @@ export default class GameSession {
             this.gameRound.incorrectMCGuessers.has(userID)
         )
             return 0;
-        if (this.gameType !== GameType.ELIMINATION) {
-            this.participants.add(userID);
-        }
 
         const pointsAwarded = this.gameRound.checkGuess(
             guess,
@@ -1395,7 +1408,9 @@ export default class GameSession {
                 .scoreboard as EliminationScoreboard;
 
             if (
-                !this.participants.has(messageContext.author.id) ||
+                !this.scoreboard
+                    .getPlayerIDs()
+                    .includes(messageContext.author.id) ||
                 eliminationScoreboard.isPlayerEliminated(
                     messageContext.author.id
                 )

--- a/src/structures/player.ts
+++ b/src/structures/player.ts
@@ -1,3 +1,5 @@
+import { User } from "eris";
+import { EnvType } from "../types";
 import {
     ExpBonusModifier,
     ExpBonusModifierValues,
@@ -44,20 +46,29 @@ export default class Player {
         this.firstGameOfTheDay = firstGameOfTheDay;
     }
 
-    static fromUserID(userID: string, firstGameOfDay = false): Player {
-        const user = state.client.users.get(userID);
+    static fromUserID(
+        userID: string,
+        score = 0,
+        firstGameOfDay = false
+    ): Player {
+        const user = [EnvType.CI, EnvType.TEST].includes(
+            process.env.NODE_ENV as EnvType
+        )
+            ? ({
+                  id: userID,
+                  avatarURL: "",
+                  username: "",
+                  discriminator: "",
+              } as User)
+            : state.client.users.get(userID);
+
         return new Player(
             getUserTag(user),
             user.id,
             user.avatarURL,
-            0,
+            score,
             firstGameOfDay
         );
-    }
-
-    /** @returns the player's Discord tag  */
-    getName(): string {
-        return this.name;
     }
 
     /**
@@ -75,7 +86,7 @@ export default class Player {
     ): string {
         let name = this.name;
         if (mention && this.inVC) {
-            name = getMention(this.getID());
+            name = getMention(this.id);
         }
 
         if (wonRound) {
@@ -109,11 +120,6 @@ export default class Player {
     /** @returns the player's EXP gain */
     getExpGain(): number {
         return Math.floor(this.expGain);
-    }
-
-    /** @returns the player's Discord ID */
-    getID(): string {
-        return this.id;
     }
 
     /** @returns the player's avatar URL */
@@ -152,8 +158,8 @@ export default class Player {
         previousRoundRanking: Array<string>,
         inProgress: boolean
     ): string {
-        const currentRank = currentRoundRanking.indexOf(this.getID());
-        const previousRank = previousRoundRanking.indexOf(this.getID());
+        const currentRank = currentRoundRanking.indexOf(this.id);
+        const previousRank = previousRoundRanking.indexOf(this.id);
         if (!inProgress || previousRank < 0 || currentRank === previousRank) {
             return `${currentRank + 1}.`;
         }

--- a/src/structures/player.ts
+++ b/src/structures/player.ts
@@ -152,16 +152,17 @@ export default class Player {
     getRankingPrefix(currentRoundRanking: number, inProgress: boolean): string {
         const previousRank = this.previousRoundRanking;
         const currentRank = currentRoundRanking;
+        const displayedRank = `${currentRank + 1}.`;
         if (!inProgress || previousRank < 0 || currentRank === previousRank) {
-            return `${currentRank + 1}.`;
+            return displayedRank;
         }
 
         if (currentRank < previousRank) {
-            return "↑";
+            return `↑ ${displayedRank}`;
         }
 
         if (currentRank > previousRank) {
-            return "↓";
+            return `↓ ${displayedRank}`;
         }
     }
 }

--- a/src/structures/player.ts
+++ b/src/structures/player.ts
@@ -45,7 +45,7 @@ export default class Player {
         this.avatarURL = avatarURL;
         this.expGain = 0;
         this.firstGameOfTheDay = firstGameOfTheDay;
-        this.previousRoundRanking = -1;
+        this.previousRoundRanking = null;
     }
 
     static fromUserID(
@@ -153,7 +153,11 @@ export default class Player {
         const previousRank = this.previousRoundRanking;
         const currentRank = currentRoundRanking;
         const displayedRank = `${currentRank + 1}.`;
-        if (!inProgress || previousRank < 0 || currentRank === previousRank) {
+        if (
+            !inProgress ||
+            previousRank === null ||
+            currentRank === previousRank
+        ) {
             return displayedRank;
         }
 

--- a/src/structures/scoreboard.ts
+++ b/src/structures/scoreboard.ts
@@ -76,7 +76,7 @@ export default class Scoreboard {
         inProgress: boolean,
         roundWinnerIDs?: Array<string>
     ): Array<{ name: string; value: string; inline: boolean }> {
-        const currentRanking = this.getRanking();
+        const currentRanking = this.getScoreToRankingMap();
         return Object.values(this.players)
             .sort((a, b) => b.getScore() - a.getScore())
             .filter((x) => x.getScore() > 0 || x.inVC)
@@ -113,7 +113,7 @@ export default class Scoreboard {
         roundWinnerIDs?: Array<string>
     ): Array<{ name: string; value: string; inline: boolean }> {
         const ZERO_WIDTH_SPACE = "​";
-        const currentRanking = this.getRanking();
+        const currentRanking = this.getScoreToRankingMap();
         const players = Object.values(this.players)
             .sort((a, b) => b.getScore() - a.getScore())
             .filter((x) => x.getScore() > 0 || x.inVC)
@@ -177,7 +177,7 @@ export default class Scoreboard {
     async updateScoreboard(
         guessResults: Array<SuccessfulGuessResult>
     ): Promise<void> {
-        const previousRoundRanking = this.getRanking();
+        const previousRoundRanking = this.getScoreToRankingMap();
         for (const player of Object.values(this.players)) {
             player.setPreviousRanking(previousRoundRanking[player.getScore()]);
         }
@@ -291,7 +291,7 @@ export default class Scoreboard {
     /**
      * @returns a mapping of player scores to ranking
      */
-    getRanking(): { [score: number]: number } {
+    getScoreToRankingMap(): { [score: number]: number } {
         const rankingToScore = {};
         const sortedUniqueScores = [
             ...new Set(Object.values(this.players).map((x) => x.getScore())),

--- a/src/structures/scoreboard.ts
+++ b/src/structures/scoreboard.ts
@@ -202,13 +202,6 @@ export default class Scoreboard {
         }
     }
 
-    /**
-     * @returns whether the scoreboard has any players in it
-     */
-    isEmpty(): boolean {
-        return Object.keys(this.players).length === 0;
-    }
-
     /** @returns a list of the player currently in first place */
     getWinners(): Array<Player> {
         return this.firstPlace;

--- a/src/structures/scoreboard.ts
+++ b/src/structures/scoreboard.ts
@@ -206,7 +206,7 @@ export default class Scoreboard {
      * @returns whether the scoreboard has any players in it
      */
     isEmpty(): boolean {
-        return this.players === {};
+        return Object.keys(this.players).length === 0;
     }
 
     /** @returns a list of the player currently in first place */

--- a/src/structures/team.ts
+++ b/src/structures/team.ts
@@ -1,5 +1,5 @@
 import Player from "./player";
-import { bold } from "../helpers/utils";
+import { bold, chooseRandom } from "../helpers/utils";
 
 export default class Team extends Player {
     private players: { [userID: string]: Player };
@@ -86,5 +86,22 @@ export default class Team extends Player {
      */
     getNumPlayers(): number {
         return this.getPlayers().length;
+    }
+
+    /** @returns the team's EXP gain */
+    getExpGain(): number {
+        return Math.floor(
+            Object.values(this.players).reduce(
+                (total, curr) => total + curr.getExpGain(),
+                0
+            )
+        );
+    }
+
+    /** @returns a random team member's avatar URL */
+    getAvatarURL(): string {
+        return chooseRandom(
+            Object.values(this.players).map((x) => x.getAvatarURL())
+        );
     }
 }

--- a/src/structures/team.ts
+++ b/src/structures/team.ts
@@ -7,7 +7,7 @@ export default class Team extends Player {
     constructor(name: string, player: Player) {
         super(name, name, null, 0);
         this.players = {};
-        this.players[player.getID()] = player;
+        this.players[player.id] = player;
     }
 
     /** @returns the score of all the players on this team */

--- a/src/structures/team_scoreboard.ts
+++ b/src/structures/team_scoreboard.ts
@@ -24,7 +24,7 @@ export default class TeamScoreboard extends Scoreboard {
     async updateScoreboard(
         guessResults: Array<SuccessfulGuessResult>
     ): Promise<void> {
-        const previousRoundRanking = this.getRanking();
+        const previousRoundRanking = this.getScoreToRankingMap();
         for (const player of Object.values(this.players)) {
             player.setPreviousRanking(previousRoundRanking[player.getScore()]);
         }

--- a/src/structures/team_scoreboard.ts
+++ b/src/structures/team_scoreboard.ts
@@ -212,7 +212,16 @@ export default class TeamScoreboard extends Scoreboard {
     /**
      * @returns player IDs for players in every team
      */
-    getPlayersIDs(): Array<string> {
+    getPlayerIDs(): Array<string> {
         return this.getPlayers().map((x) => x.id);
+    }
+
+    /**
+     * Update whether a player is in VC
+     * @param userID - The Discord user ID of the player to update
+     * @param inVC - Whether the player is currently in the voice channel
+     */
+    setInVC(userID: string, inVC: boolean): void {
+        this.getPlayer(userID).inVC = inVC;
     }
 }

--- a/src/structures/team_scoreboard.ts
+++ b/src/structures/team_scoreboard.ts
@@ -24,7 +24,10 @@ export default class TeamScoreboard extends Scoreboard {
     async updateScoreboard(
         guessResults: Array<SuccessfulGuessResult>
     ): Promise<void> {
-        this.previousRoundRanking = Scoreboard.getRanking(this.players);
+        const previousRoundRanking = this.getRanking();
+        for (const player of Object.values(this.players)) {
+            player.setPreviousRanking(previousRoundRanking[player.getScore()]);
+        }
 
         // give everybody EXP
         for (const guessResult of guessResults) {

--- a/src/structures/team_scoreboard.ts
+++ b/src/structures/team_scoreboard.ts
@@ -121,7 +121,7 @@ export default class TeamScoreboard extends Scoreboard {
      * @param teamName - The name of the team to add the player to
      * @param player - The player to add to the team
      */
-    addPlayer(teamName: string, player: Player): void {
+    addTeamPlayer(teamName: string, player: Player): void {
         // If the user is switching teams, remove them from their existing team first
         this.removePlayer(player.id);
         this.players[teamName].addPlayer(player);
@@ -199,7 +199,7 @@ export default class TeamScoreboard extends Scoreboard {
      * @returns the player's tag
      */
     getPlayerName(userID: string): string {
-        return this.getPlayer(userID).getName();
+        return this.getPlayer(userID).name;
     }
 
     /**
@@ -207,5 +207,12 @@ export default class TeamScoreboard extends Scoreboard {
      */
     getPlayers(): Array<Player> {
         return Object.values(this.players).flatMap((team) => team.getPlayers());
+    }
+
+    /**
+     * @returns player IDs for players in every team
+     */
+    getPlayersIDs(): Array<string> {
+        return this.getPlayers().map((x) => x.id);
     }
 }

--- a/src/test/ci/begin.test.ts
+++ b/src/test/ci/begin.test.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import sinon from "sinon";
 import BeginCommand from "../../commands/game_commands/begin";
 import { GameType } from "../../types";
 import GameSession from "../../structures/game_session";
@@ -6,7 +7,9 @@ import KmqMember from "../../structures/kmq_member";
 import Player from "../../structures/player";
 import TeamScoreboard from "../../structures/team_scoreboard";
 import MessageContext from "../../structures/message_context";
+import * as discordUtils from "../../helpers/discord_utils";
 
+const sandbox = sinon.createSandbox();
 const gameStarter = new KmqMember("jisoo", "jisoo#4747", "url", "123");
 
 describe("begin command", () => {
@@ -18,6 +21,9 @@ describe("begin command", () => {
         });
 
         describe("classic game session", () => {
+            sandbox
+                .stub(discordUtils, "getCurrentVoiceMembers")
+                .callsFake((_voiceChannelID) => []);
             const gameSession = new GameSession(
                 null,
                 null,
@@ -25,6 +31,8 @@ describe("begin command", () => {
                 gameStarter,
                 GameType.CLASSIC
             );
+
+            sandbox.restore();
 
             it("should return false (classic games are not started using ,begin)", () => {
                 assert.strictEqual(
@@ -53,7 +61,6 @@ describe("begin command", () => {
                     assert.strictEqual(
                         BeginCommand.canStart(
                             gameSession,
-
                             new MessageContext("", gameStarter)
                         ),
                         false

--- a/src/test/ci/begin.test.ts
+++ b/src/test/ci/begin.test.ts
@@ -13,10 +13,7 @@ describe("begin command", () => {
     describe("can start", () => {
         describe("game session is null", () => {
             it("should return false", () => {
-                assert.strictEqual(
-                    BeginCommand.canStart(null, "123", null),
-                    false
-                );
+                assert.strictEqual(BeginCommand.canStart(null, null), false);
             });
         });
 
@@ -31,46 +28,14 @@ describe("begin command", () => {
 
             it("should return false (classic games are not started using ,begin)", () => {
                 assert.strictEqual(
-                    BeginCommand.canStart(gameSession, "123", null),
+                    BeginCommand.canStart(gameSession, null),
                     false
                 );
 
                 assert.strictEqual(
-                    BeginCommand.canStart(gameSession, "567", null),
+                    BeginCommand.canStart(gameSession, null),
                     false
                 );
-            });
-        });
-
-        describe("elimination game session", () => {
-            const gameSession = new GameSession(
-                null,
-                null,
-                null,
-                gameStarter,
-                GameType.ELIMINATION
-            );
-
-            describe("invoker is the game session's author", () => {
-                it("should return true", () => {
-                    assert.strictEqual(
-                        BeginCommand.canStart(gameSession, "123", null),
-                        true
-                    );
-                });
-            });
-
-            describe("invoker is not the game session's author", () => {
-                it("should return false", () => {
-                    assert.strictEqual(
-                        BeginCommand.canStart(
-                            gameSession,
-                            "567",
-                            new MessageContext("", gameStarter)
-                        ),
-                        false
-                    );
-                });
             });
         });
 
@@ -88,7 +53,7 @@ describe("begin command", () => {
                     assert.strictEqual(
                         BeginCommand.canStart(
                             gameSession,
-                            "1231",
+
                             new MessageContext("", gameStarter)
                         ),
                         false
@@ -105,7 +70,7 @@ describe("begin command", () => {
                     );
 
                     assert.strictEqual(
-                        BeginCommand.canStart(gameSession, "1231", null),
+                        BeginCommand.canStart(gameSession, null),
                         true
                     );
 
@@ -115,7 +80,7 @@ describe("begin command", () => {
                     );
 
                     assert.strictEqual(
-                        BeginCommand.canStart(gameSession, "1231", null),
+                        BeginCommand.canStart(gameSession, null),
                         true
                     );
                 });

--- a/src/test/ci/elimination_scoreboard.test.ts
+++ b/src/test/ci/elimination_scoreboard.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import EliminationScoreboard from "../../structures/elimination_scoreboard";
+import EliminationPlayer from "../../structures/elimination_player";
 
 const userIDs = ["12345", "23456", "34567"];
 const DEFAULT_LIVES = 10;
@@ -11,16 +12,26 @@ beforeEach(() => {
 
 describe("score/exp updating", () => {
     beforeEach(() => {
-        scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl");
-        scoreboard.addPlayer(userIDs[1], "seulgi#7854", "someurl");
-        scoreboard.addPlayer(userIDs[2], "joy#4144", "someurl");
-        scoreboard.addPlayer(userIDs[3], "wendy#4747", "someurl");
+        scoreboard.addPlayer(
+            EliminationPlayer.fromUserID(userIDs[0], DEFAULT_LIVES)
+        );
+
+        scoreboard.addPlayer(
+            EliminationPlayer.fromUserID(userIDs[1], DEFAULT_LIVES)
+        );
+
+        scoreboard.addPlayer(
+            EliminationPlayer.fromUserID(userIDs[2], DEFAULT_LIVES)
+        );
+
+        scoreboard.addPlayer(
+            EliminationPlayer.fromUserID(userIDs[3], DEFAULT_LIVES)
+        );
     });
 
     describe("single player scoreboard", () => {
         describe("user guesses correctly multiple times", () => {
             it("should not affect their lives", async () => {
-                scoreboard.addPlayer(userIDs[0], "yeonwoo#4747", "someurl");
                 for (let i = 0; i < 20; i++) {
                     await scoreboard.updateScoreboard([
                         { userID: userIDs[0], pointsEarned: 1, expGain: 0 },
@@ -144,9 +155,17 @@ describe("score/exp updating", () => {
 
 describe("winner detection", () => {
     beforeEach(() => {
-        scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl");
-        scoreboard.addPlayer(userIDs[1], "seulgi#7854", "someurl");
-        scoreboard.addPlayer(userIDs[2], "joy#4144", "someurl");
+        scoreboard.addPlayer(
+            EliminationPlayer.fromUserID(userIDs[0], DEFAULT_LIVES)
+        );
+
+        scoreboard.addPlayer(
+            EliminationPlayer.fromUserID(userIDs[1], DEFAULT_LIVES)
+        );
+
+        scoreboard.addPlayer(
+            EliminationPlayer.fromUserID(userIDs[2], DEFAULT_LIVES)
+        );
     });
 
     describe("nobody has a score yet", () => {
@@ -161,7 +180,7 @@ describe("winner detection", () => {
                 { userID: userIDs[0], pointsEarned: 10, expGain: 0 },
             ]);
             assert.strictEqual(scoreboard.getWinners().length, 1);
-            assert.strictEqual(scoreboard.getWinners()[0].getID(), userIDs[0]);
+            assert.strictEqual(scoreboard.getWinners()[0].id, userIDs[0]);
         });
     });
 
@@ -179,7 +198,7 @@ describe("winner detection", () => {
                 { userID: userIDs[1], pointsEarned: 1, expGain: 0 },
             ]);
             assert.strictEqual(scoreboard.getWinners().length, 1);
-            assert.strictEqual(scoreboard.getWinners()[0].getID(), userIDs[0]);
+            assert.strictEqual(scoreboard.getWinners()[0].id, userIDs[0]);
         });
     });
 
@@ -206,7 +225,7 @@ describe("winner detection", () => {
             ]);
             assert.strictEqual(scoreboard.getWinners().length, 2);
             assert.deepStrictEqual(
-                scoreboard.getWinners().map((x) => x.getID()),
+                scoreboard.getWinners().map((x) => x.id),
                 [userIDs[1], userIDs[2]]
             );
         });
@@ -216,34 +235,34 @@ describe("winner detection", () => {
 describe("game finished", () => {
     describe("every player is dead", () => {
         it("should return true", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl", 0);
-            scoreboard.addPlayer(userIDs[1], "seulgi#7854", "someurl", 0);
-            scoreboard.addPlayer(userIDs[2], "joy#4144", "someurl", 0);
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0], 0));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[1], 0));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[2], 0));
             assert.strictEqual(scoreboard.gameFinished(), true);
         });
     });
 
     describe("one player is left in a multiplayer game", () => {
         it("should return true", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl", 0);
-            scoreboard.addPlayer(userIDs[1], "seulgi#7854", "someurl", 0);
-            scoreboard.addPlayer(userIDs[2], "joy#4144", "someurl", 5);
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0], 0));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[1], 0));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[2], 5));
             assert.strictEqual(scoreboard.gameFinished(), true);
         });
     });
 
     describe("one player is left in a single player game", () => {
         it("should return false", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl", 5);
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0], 5));
             assert.strictEqual(scoreboard.gameFinished(), false);
         });
     });
 
     describe("multiple players are still alive", () => {
         it("should return false", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl", 5);
-            scoreboard.addPlayer(userIDs[1], "seulgi#7854", "someurl", 8);
-            scoreboard.addPlayer(userIDs[2], "joy#4144", "someurl", 2);
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0], 5));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[1], 8));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[2], 2));
             assert.strictEqual(scoreboard.gameFinished(), false);
         });
     });
@@ -252,18 +271,18 @@ describe("game finished", () => {
 describe("getLivesOfWeakestPlayer", () => {
     describe("one person is the weakest", () => {
         it("should return the weakest person's number of lives", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl", 5);
-            scoreboard.addPlayer(userIDs[1], "seulgi#7854", "someurl", 8);
-            scoreboard.addPlayer(userIDs[2], "joy#4144", "someurl", 2);
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0], 5));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[1], 8));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[2], 2));
             assert.strictEqual(scoreboard.getLivesOfWeakestPlayer(), 2);
         });
     });
 
     describe("tie for the weakest", () => {
         it("should return the number of lives", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl", 3);
-            scoreboard.addPlayer(userIDs[1], "seulgi#7854", "someurl", 2);
-            scoreboard.addPlayer(userIDs[2], "joy#4144", "someurl", 2);
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0], 3));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[1], 2));
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[2], 2));
             assert.strictEqual(scoreboard.getLivesOfWeakestPlayer(), 2);
         });
     });
@@ -272,7 +291,7 @@ describe("getLivesOfWeakestPlayer", () => {
 describe("starting lives", () => {
     describe("no explicit number of lives set for player", () => {
         it("should default to the scoreboard's default", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl");
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0]));
             assert.strictEqual(
                 scoreboard.getPlayerLives(userIDs[0]),
                 DEFAULT_LIVES
@@ -282,7 +301,7 @@ describe("starting lives", () => {
 
     describe("explicit number of lives set for player", () => {
         it("should use the explicitly set number of lives", () => {
-            scoreboard.addPlayer(userIDs[0], "irene#1234", "someurl", 17);
+            scoreboard.addPlayer(EliminationPlayer.fromUserID(userIDs[0], 17));
             assert.strictEqual(scoreboard.getPlayerLives(userIDs[0]), 17);
         });
     });

--- a/src/test/ci/exp.test.ts
+++ b/src/test/ci/exp.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import sinon, { SinonSandbox } from "sinon";
+import sinon from "sinon";
 import {
     calculateOptionsExpMultiplierInternal,
     calculateRoundExpMultiplier,
@@ -16,7 +16,7 @@ import GameRound from "../../structures/game_round";
 import GuildPreference from "../../structures/guild_preference";
 
 let guildPreference: GuildPreference;
-const sandbox: SinonSandbox = sinon.createSandbox();
+const sandbox = sinon.createSandbox();
 describe("calculateOptionsMultiplier", () => {
     beforeEach(() => {
         guildPreference = GuildPreference.fromGuild("123");

--- a/src/test/ci/game_utils.test.ts
+++ b/src/test/ci/game_utils.test.ts
@@ -13,6 +13,9 @@ import GameSession from "../../structures/game_session";
 import { OstPreference } from "../../commands/game_options/ost";
 import { ReleaseType } from "../../commands/game_options/release";
 import { mockSongs } from "../test_setup";
+import * as discordUtils from "../../helpers/discord_utils";
+
+const sandbox = sinon.createSandbox();
 
 async function getMockGuildPreference(): Promise<GuildPreference> {
     const guildPreference = new GuildPreference("test");
@@ -269,11 +272,15 @@ describe("song query", () => {
 
     describe("cleanupInactiveGameSessions", () => {
         const guildId = "123";
+        sandbox
+            .stub(discordUtils, "getCurrentVoiceMembers")
+            .callsFake((_voiceChannelID) => []);
         const gameSession = new GameSession(null, null, guildId, null, null);
-        const sandbox = sinon.createSandbox();
+        sandbox.restore();
+        const endSandbox = sinon.createSandbox();
         const endSessionStub = sandbox.stub(gameSession, "endSession");
         after(() => {
-            sandbox.restore();
+            endSandbox.restore();
         });
 
         state.gameSessions = {

--- a/src/test/ci/leaderboard.test.ts
+++ b/src/test/ci/leaderboard.test.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import sinon from "sinon";
 import { describe } from "mocha";
 import { EmbedGenerator } from "eris-pagination";
 import LeaderboardCommand, {
@@ -14,6 +15,9 @@ import GameSession from "../../structures/game_session";
 import Player from "../../structures/player";
 import { GameType } from "../../types";
 import { state } from "../../kmq_worker";
+import * as discordUtils from "../../helpers/discord_utils";
+
+const sandbox = sinon.createSandbox();
 
 const SERVER_ID = "0";
 const gameStarter = new KmqMember("jisoo", "jisoo#4747", "url", "123");
@@ -223,6 +227,9 @@ describe("getLeaderboardEmbeds", () => {
             });
 
             it("should match the number of pages and embeds", async () => {
+                sandbox
+                    .stub(discordUtils, "getCurrentVoiceMembers")
+                    .callsFake((_voiceChannelID) => []);
                 const gameSession = new GameSession(
                     "",
                     "",
@@ -230,6 +237,8 @@ describe("getLeaderboardEmbeds", () => {
                     gameStarter,
                     GameType.CLASSIC
                 );
+
+                sandbox.restore();
 
                 state.gameSessions = { [SERVER_ID]: gameSession };
                 const statsRows = [];
@@ -552,6 +561,9 @@ describe("getLeaderboardEmbeds", () => {
 
         describe("game leaderboard", () => {
             beforeEach(async () => {
+                sandbox
+                    .stub(discordUtils, "getCurrentVoiceMembers")
+                    .callsFake((_voiceChannelID) => []);
                 const gameSession = new GameSession(
                     "",
                     "",
@@ -559,6 +571,8 @@ describe("getLeaderboardEmbeds", () => {
                     gameStarter,
                     GameType.CLASSIC
                 );
+
+                sandbox.restore();
 
                 state.gameSessions = { [SERVER_ID]: gameSession };
 

--- a/src/test/ci/leaderboard.test.ts
+++ b/src/test/ci/leaderboard.test.ts
@@ -11,6 +11,7 @@ import dbContext from "../../database_context";
 import MessageContext from "../../structures/message_context";
 import KmqMember from "../../structures/kmq_member";
 import GameSession from "../../structures/game_session";
+import Player from "../../structures/player";
 import { GameType } from "../../types";
 import { state } from "../../kmq_worker";
 
@@ -234,9 +235,9 @@ describe("getLeaderboardEmbeds", () => {
                 const statsRows = [];
 
                 statsRows.push(...generatePlayerStats(INITIAL_TOTAL_ENTRIES));
-                gameSession.participants = new Set(
-                    [...Array(INITIAL_TOTAL_ENTRIES).keys()].map((i) =>
-                        String(i)
+                [...Array(INITIAL_TOTAL_ENTRIES).keys()].map((i) =>
+                    gameSession.scoreboard.addPlayer(
+                        Player.fromUserID(String(i))
                     )
                 );
 
@@ -562,9 +563,13 @@ describe("getLeaderboardEmbeds", () => {
                 state.gameSessions = { [SERVER_ID]: gameSession };
 
                 // Player with id 0 is not in game
-                for (let i = 1; i < INITIAL_TOTAL_ENTRIES; i++) {
-                    gameSession.participants.add(String(i));
-                }
+                [...Array(INITIAL_TOTAL_ENTRIES).keys()]
+                    .filter((x) => x !== 0)
+                    .map((i) =>
+                        gameSession.scoreboard.addPlayer(
+                            Player.fromUserID(String(i))
+                        )
+                    );
             });
 
             describe("daily leaderboard", () => {

--- a/src/test/ci/player.test.ts
+++ b/src/test/ci/player.test.ts
@@ -21,67 +21,6 @@ describe("increment score", () => {
             assert.strictEqual(player.getScore(), numIncrements);
         });
     });
-
-    describe("player's prefix should change based on new ranking", () => {
-        const previousRanking = ["12345", "jisoo", "ohmi"];
-        const newRanking = ["ohmi", "jisoo", "12345"];
-
-        describe("player moved ahead in ranking", () => {
-            it("should show the player has gained ranking", () => {
-                const winningPlayer = Player.fromUserID("ohmi");
-                assert.strictEqual(
-                    winningPlayer.getRankingPrefix(
-                        newRanking,
-                        previousRanking,
-                        true
-                    ),
-                    "↑"
-                );
-            });
-        });
-
-        describe("player was passed in ranking", () => {
-            it("should show the player has lost ranking", () => {
-                const losingPlayer = Player.fromUserID("12345");
-                assert.strictEqual(
-                    losingPlayer.getRankingPrefix(
-                        newRanking,
-                        previousRanking,
-                        true
-                    ),
-                    "↓"
-                );
-            });
-        });
-
-        describe("player didn't change position in ranking", () => {
-            it("should not show any ranking change", () => {
-                const samePlayer = Player.fromUserID("jisoo");
-                assert.strictEqual(
-                    samePlayer.getRankingPrefix(
-                        newRanking,
-                        previousRanking,
-                        true
-                    ),
-                    "2."
-                );
-            });
-        });
-
-        describe("the game has ended", () => {
-            it("should not show any ranking change, even if there was one", () => {
-                const winningPlayer = Player.fromUserID("ohmi");
-                assert.strictEqual(
-                    winningPlayer.getRankingPrefix(
-                        newRanking,
-                        previousRanking,
-                        false
-                    ),
-                    "1."
-                );
-            });
-        });
-    });
 });
 
 describe("increment EXP", () => {

--- a/src/test/ci/scoreboard.test.ts
+++ b/src/test/ci/scoreboard.test.ts
@@ -4,15 +4,17 @@ import Scoreboard from "../../structures/scoreboard";
 import { GameOption } from "../../types";
 import Player from "../../structures/player";
 
+const userIDs = ["12345", "23456", "34567"];
+
 let scoreboard: Scoreboard;
 beforeEach(() => {
     scoreboard = new Scoreboard();
+    userIDs.map((x) => scoreboard.addPlayer(Player.fromUserID(x)));
 });
 
 let guildPreference: GuildPreference;
 
 describe("score/exp updating", () => {
-    const userIDs = ["12345", "23456"];
     describe("single player scoreboard", () => {
         describe("user guesses correctly multiple times", () => {
             it("should increment the user's score/EXP", async () => {
@@ -133,12 +135,11 @@ describe("winner detection", () => {
                 { userID, pointsEarned: 10, expGain: 0 },
             ]);
             assert.strictEqual(scoreboard.getWinners().length, 1);
-            assert.strictEqual(scoreboard.getWinners()[0].getID(), userID);
+            assert.strictEqual(scoreboard.getWinners()[0].id, userID);
         });
     });
 
     describe("multiple players, has different scores", () => {
-        const userIDs = ["12345", "23456"];
         it("should return the player with most points", async () => {
             await scoreboard.updateScoreboard([
                 { userID: userIDs[0], pointsEarned: 10, expGain: 0 },
@@ -148,12 +149,11 @@ describe("winner detection", () => {
                 { userID: userIDs[1], pointsEarned: 15, expGain: 0 },
             ]);
             assert.strictEqual(scoreboard.getWinners().length, 1);
-            assert.strictEqual(scoreboard.getWinners()[0].getID(), userIDs[1]);
+            assert.strictEqual(scoreboard.getWinners()[0].id, userIDs[1]);
         });
     });
 
     describe("multiple players, tied score", () => {
-        const userIDs = ["12345", "23456", "34567"];
         it("should return the two tied players", async () => {
             await scoreboard.updateScoreboard([
                 { userID: userIDs[0], pointsEarned: 5, expGain: 0 },
@@ -168,7 +168,7 @@ describe("winner detection", () => {
             ]);
             assert.strictEqual(scoreboard.getWinners().length, 2);
             assert.deepStrictEqual(
-                scoreboard.getWinners().map((x) => x.getID()),
+                scoreboard.getWinners().map((x) => x.id),
                 [userIDs[1], userIDs[2]]
             );
         });
@@ -189,7 +189,6 @@ describe("game finished", () => {
     });
 
     describe("goal is set", () => {
-        const userIDs = ["12345", "23456", "34567"];
         describe("no one has a score yet", () => {
             it("should return false", () => {
                 assert.strictEqual(

--- a/src/test/ci/scoreboard.test.ts
+++ b/src/test/ci/scoreboard.test.ts
@@ -146,7 +146,7 @@ describe("score/exp updating", () => {
                         newRanking.indexOf("ohmi"),
                         true
                     ),
-                    "↑"
+                    "↑ 1."
                 );
             });
         });
@@ -163,7 +163,7 @@ describe("score/exp updating", () => {
                         newRanking.indexOf("12345"),
                         true
                     ),
-                    "↓"
+                    "↓ 3."
                 );
             });
         });

--- a/src/test/ci/scoreboard.test.ts
+++ b/src/test/ci/scoreboard.test.ts
@@ -128,6 +128,38 @@ describe("score/exp updating", () => {
                 [players["1234"].getScore()]: 2,
             });
         });
+
+        it("should return the same ranking when all players have the same score", async () => {
+            const players = {
+                ohmiID: new Player("", "ohmiID", "", 2),
+                12345: new Player("", "12345", "", 2),
+                jisooID: new Player("", "jisooID", "", 2),
+            };
+
+            const sb = new Scoreboard();
+            Object.values(players).map((x) => sb.addPlayer(x));
+
+            assert.deepStrictEqual(sb.getRanking(), {
+                2: 0,
+            });
+        });
+
+        it("should return different rankings when all players have different scores", async () => {
+            const players = {
+                ohmiID: new Player("", "ohmiID", "", 1),
+                12345: new Player("", "12345", "", 2),
+                jisooID: new Player("", "jisooID", "", 3),
+            };
+
+            const sb = new Scoreboard();
+            Object.values(players).map((x) => sb.addPlayer(x));
+
+            assert.deepStrictEqual(sb.getRanking(), {
+                [players["jisooID"].getScore()]: 0,
+                [players["12345"].getScore()]: 1,
+                [players["ohmiID"].getScore()]: 2,
+            });
+        });
     });
 
     describe("player's prefix should change based on new ranking", () => {

--- a/src/test/ci/scoreboard.test.ts
+++ b/src/test/ci/scoreboard.test.ts
@@ -109,7 +109,7 @@ describe("score/exp updating", () => {
             const sb = new Scoreboard();
             Object.values(players).map((x) => sb.addPlayer(x));
 
-            assert.deepStrictEqual(sb.getRanking(), {
+            assert.deepStrictEqual(sb.getScoreToRankingMap(), {
                 [players["jisooID"].getScore()]: 0,
 
                 // Matching score entries coalesce into one
@@ -121,7 +121,7 @@ describe("score/exp updating", () => {
             sb.addPlayer(newPlayer);
             players["1234"] = newPlayer;
 
-            assert.deepStrictEqual(sb.getRanking(), {
+            assert.deepStrictEqual(sb.getScoreToRankingMap(), {
                 [players["jisooID"].getScore()]: 0,
                 [players["12345"].getScore()]: 1,
                 [players["ohmiID"].getScore()]: 1,
@@ -139,7 +139,7 @@ describe("score/exp updating", () => {
             const sb = new Scoreboard();
             Object.values(players).map((x) => sb.addPlayer(x));
 
-            assert.deepStrictEqual(sb.getRanking(), {
+            assert.deepStrictEqual(sb.getScoreToRankingMap(), {
                 2: 0,
             });
         });
@@ -154,7 +154,7 @@ describe("score/exp updating", () => {
             const sb = new Scoreboard();
             Object.values(players).map((x) => sb.addPlayer(x));
 
-            assert.deepStrictEqual(sb.getRanking(), {
+            assert.deepStrictEqual(sb.getScoreToRankingMap(), {
                 [players["jisooID"].getScore()]: 0,
                 [players["12345"].getScore()]: 1,
                 [players["ohmiID"].getScore()]: 2,

--- a/src/test/ci/team.test.ts
+++ b/src/test/ci/team.test.ts
@@ -17,17 +17,17 @@ beforeEach(() => {
 describe("add a teammate", () => {
     describe("add a player to a team", () => {
         it("should increase the size of the team and the team should include the new player", () => {
-            assert.strictEqual(team.hasPlayer(subparPlayer.getID()), false);
+            assert.strictEqual(team.hasPlayer(subparPlayer.id), false);
             team.addPlayer(subparPlayer);
             assert.strictEqual(team.getNumPlayers(), 2);
             assert.deepStrictEqual(team.getPlayers(), [
                 subparPlayer,
                 goodPlayer,
             ]);
-            assert.strictEqual(team.hasPlayer(goodPlayer.getID()), true);
-            assert.strictEqual(team.hasPlayer(subparPlayer.getID()), true);
+            assert.strictEqual(team.hasPlayer(goodPlayer.id), true);
+            assert.strictEqual(team.hasPlayer(subparPlayer.id), true);
             assert.strictEqual(
-                team.hasPlayer(firstOnLeaderboardPlayer.getID()),
+                team.hasPlayer(firstOnLeaderboardPlayer.id),
                 false
             );
         });
@@ -38,10 +38,10 @@ describe("remove a teammate", () => {
     describe("remove a player from a team", () => {
         it("should decrease the size of the team and the team should now exclude that player", () => {
             team.addPlayer(subparPlayer);
-            assert.strictEqual(team.hasPlayer(subparPlayer.getID()), true);
+            assert.strictEqual(team.hasPlayer(subparPlayer.id), true);
             assert.strictEqual(team.getNumPlayers(), 2);
-            team.removePlayer(subparPlayer.getID());
-            assert.strictEqual(team.hasPlayer(subparPlayer.getID()), false);
+            team.removePlayer(subparPlayer.id);
+            assert.strictEqual(team.hasPlayer(subparPlayer.id), false);
             assert.strictEqual(team.getNumPlayers(), 1);
             assert.deepStrictEqual(team.getPlayers(), [goodPlayer]);
         });
@@ -102,14 +102,14 @@ describe("score after removal", () => {
             ]);
             assert.strictEqual(team.getScore(), 75);
 
-            team.removePlayer(subparPlayer.getID());
+            team.removePlayer(subparPlayer.id);
             assert.deepStrictEqual(team.getPlayers(), [
                 goodPlayer,
                 firstOnLeaderboardPlayer,
             ]);
             assert.strictEqual(team.getScore(), 50);
 
-            team.removePlayer(firstOnLeaderboardPlayer.getID());
+            team.removePlayer(firstOnLeaderboardPlayer.id);
             assert.deepStrictEqual(team.getPlayers(), [goodPlayer]);
             assert.strictEqual(team.getScore(), 25);
         });

--- a/src/test/ci/team_scoreboard.test.ts
+++ b/src/test/ci/team_scoreboard.test.ts
@@ -64,7 +64,7 @@ describe("get team of player", () => {
 
         const secondTeam = scoreboard.addTeam(SECOND_TEAM_NAME, player);
         assert.deepStrictEqual(
-            scoreboard.getTeamOfPlayer(player.getID()),
+            scoreboard.getTeamOfPlayer(player.id),
             secondTeam
         );
     });
@@ -81,11 +81,11 @@ describe("team deletion", () => {
 
         const secondTeam = scoreboard.addTeam(SECOND_TEAM_NAME, player);
         const anotherPlayer = new Player(USER_TAG, USER_IDS[2], AVATAR_URL, 0);
-        scoreboard.addPlayer(SECOND_TEAM_NAME, anotherPlayer);
+        scoreboard.addTeamPlayer(SECOND_TEAM_NAME, anotherPlayer);
         const bestPlayer = new Player(USER_TAG, USER_IDS[3], AVATAR_URL, 0);
-        scoreboard.addPlayer(FIRST_TEAM_NAME, bestPlayer);
-        scoreboard.removePlayer(bestPlayer.getID());
-        scoreboard.removePlayer(player.getID());
+        scoreboard.addTeamPlayer(FIRST_TEAM_NAME, bestPlayer);
+        scoreboard.removePlayer(bestPlayer.id);
+        scoreboard.removePlayer(player.id);
         scoreboard.removePlayer(USER_IDS[0]);
         assert.deepStrictEqual(Object.values(scoreboard.getTeams()), [
             secondTeam,
@@ -127,7 +127,7 @@ describe("score/exp updating", () => {
 
     describe("multi player, single team scoreboard", () => {
         beforeEach(() => {
-            scoreboard.addPlayer(
+            scoreboard.addTeamPlayer(
                 FIRST_TEAM_NAME,
                 new Player("second_user#1010", USER_IDS[1], AVATAR_URL, 0)
             );
@@ -178,7 +178,7 @@ describe("score/exp updating", () => {
     describe("multi player, multi team scoreboard", () => {
         let secondTeam: Team;
         beforeEach(() => {
-            scoreboard.addPlayer(
+            scoreboard.addTeamPlayer(
                 FIRST_TEAM_NAME,
                 new Player("second_user#1010", USER_IDS[1], AVATAR_URL, 0)
             );
@@ -188,7 +188,7 @@ describe("score/exp updating", () => {
                 new Player("jennie#2325", USER_IDS[2], AVATAR_URL, 0)
             );
 
-            scoreboard.addPlayer(
+            scoreboard.addTeamPlayer(
                 SECOND_TEAM_NAME,
                 new Player("g-dragon#9999", USER_IDS[3], AVATAR_URL, 0)
             );
@@ -261,7 +261,7 @@ describe("score/exp updating", () => {
     describe("multiguess", () => {
         let secondTeam: Team;
         beforeEach(async () => {
-            scoreboard.addPlayer(
+            scoreboard.addTeamPlayer(
                 FIRST_TEAM_NAME,
                 new Player("sakura#5478", USER_IDS[1], AVATAR_URL, 0)
             );
@@ -271,7 +271,7 @@ describe("score/exp updating", () => {
                 new Player("jennie#2325", USER_IDS[2], AVATAR_URL, 0)
             );
 
-            scoreboard.addPlayer(
+            scoreboard.addTeamPlayer(
                 SECOND_TEAM_NAME,
                 new Player("g-dragon#9999", USER_IDS[3], AVATAR_URL, 0)
             );
@@ -306,7 +306,7 @@ describe("score/exp updating", () => {
 describe("winner detection", () => {
     let secondTeam: Team;
     beforeEach(() => {
-        scoreboard.addPlayer(
+        scoreboard.addTeamPlayer(
             FIRST_TEAM_NAME,
             new Player("sakura#5478", USER_IDS[1], AVATAR_URL, 0)
         );
@@ -316,7 +316,7 @@ describe("winner detection", () => {
             new Player("jennie#2325", USER_IDS[2], AVATAR_URL, 0)
         );
 
-        scoreboard.addPlayer(
+        scoreboard.addTeamPlayer(
             SECOND_TEAM_NAME,
             new Player("g-dragon#9999", USER_IDS[3], AVATAR_URL, 0)
         );

--- a/src/test/test_setup.ts
+++ b/src/test/test_setup.ts
@@ -5,11 +5,13 @@ import * as discordUtils from "../helpers/discord_utils";
 import kmqKnexConfig from "../config/knexfile_kmq";
 import dbContext from "../database_context";
 import Player from "../structures/player";
+import EliminationPlayer from "../structures/elimination_player";
 import { EnvType } from "../types";
 import { IPCLogger } from "../logger";
 import { md5Hash } from "../helpers/utils";
 import { state } from "../kmq_worker";
 import LocalizationManager from "../helpers/localization_manager";
+import { DEFAULT_LIVES } from "../structures/elimination_scoreboard";
 
 const logger = new IPCLogger("test_setup");
 const sandbox = sinon.createSandbox();
@@ -126,6 +128,13 @@ before(async function () {
     sandbox
         .stub(Player, "fromUserID")
         .callsFake((id) => new Player("", id, "", 0));
+
+    sandbox
+        .stub(EliminationPlayer, "fromUserID")
+        .callsFake(
+            (id, score) =>
+                new EliminationPlayer("", id, "", score ?? DEFAULT_LIVES)
+        );
     console.log("Performing migrations...");
     await dbContext.agnostic.raw("DROP DATABASE IF EXISTS kmq_test;");
     await dbContext.agnostic.raw("CREATE DATABASE kmq_test;");


### PR DESCRIPTION
* Create Player upon VC entry instead of on-demand or elimination game start
* Remove redundant `participants` in GameSession and use scoreboard to manage instead
* Start elimination game with current VC members instead, and don't require to ,join
* Remove `Scoreboard::isEmpty()` and replace previous checks using it with checking to see if `Scoreboard::firstPlace` is empty (they were relying on the side effect that there are no scoreboard entries when there is no one in first place)
* Show players with 0 points on scoreboard, but only if they are in VC
* Provide more accurate counts of active players for stats by checking players are currently in VC
* Add `EliminationPlayer::fromUserID()`
* Remove redundant `Player::getID()`/`getName()` (already `public readonly`)