### PR TITLE
Add check for changes in Daisuki database schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ data/skip_seed
 data/group_list.txt
 .eslintcache
 .vscode/launch.json
+data/frozen_table_schema.json

--- a/src/seed/bootstrap.ts
+++ b/src/seed/bootstrap.ts
@@ -166,6 +166,12 @@ async function bootstrapDatabases(): Promise<void> {
             process.exit(1);
         }
 
+        const dataDir = path.join(__dirname, "../../data");
+        if (!fs.existsSync(dataDir)) {
+            logger.info("Data directory doesn't exist, creating...");
+            fs.mkdirSync(dataDir);
+        }
+
         await bootstrapDatabases();
     }
 })();

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -9,7 +9,7 @@ import { downloadAndConvertSongs } from "../scripts/download-new-songs";
 import { DatabaseContext, getNewConnection } from "../database_context";
 import { generateKmqDataTables, loadStoredProcedures } from "./bootstrap";
 import { EnvType } from "../types";
-import _, { remove } from "lodash";
+import _ from "lodash";
 import { parseJsonFile } from "../helpers/utils";
 
 config({ path: path.resolve(__dirname, "../../.env") });

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -9,7 +9,7 @@ import { downloadAndConvertSongs } from "../scripts/download-new-songs";
 import { DatabaseContext, getNewConnection } from "../database_context";
 import { generateKmqDataTables, loadStoredProcedures } from "./bootstrap";
 import { EnvType } from "../types";
-import _ from "lodash";
+import _, { remove } from "lodash";
 import { parseJsonFile } from "../helpers/utils";
 
 config({ path: path.resolve(__dirname, "../../.env") });
@@ -127,11 +127,13 @@ async function validateDaisukiTableSchema(
             );
 
             const addedColumns = _.difference(frozenSchema[table], columnNames);
-            outputMessages.push(
-                `__${table}__\nAdded columns: ${JSON.stringify(
-                    addedColumns
-                )}.\nRemoved Columns: ${JSON.stringify(removedColumns)}\n`
-            );
+            if (removedColumns.length > 0) {
+                outputMessages.push(
+                    `__${table}__\nAdded columns: ${JSON.stringify(
+                        addedColumns
+                    )}.\nRemoved Columns: ${JSON.stringify(removedColumns)}\n`
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Adds a frozen schema file in `data/`. Every time we seed the database, we check the new database's schema against the frozen one. If there is a change, the seed will fail. After manually checking the schema update is valid, we can delete the frozen schema file so that a new one can be generated.