### PR TITLE
Load i18next backend synchronously to fix fact translations

### DIFF
--- a/src/helpers/localization_manager.ts
+++ b/src/helpers/localization_manager.ts
@@ -16,6 +16,7 @@ export default class LocalizationManager {
         this.internalLocalizer.init({
             preload: Object.values(LocaleType),
             supportedLngs: Object.values(LocaleType),
+            initImmediate: false,
             saveMissing: true,
             fallbackLng: DEFAULT_LOCALE,
             interpolation: {


### PR DESCRIPTION
`fact.fun.birthday` and `fact.fun.fanclubName` were attempting to be localized on bot startup, but the i18next backend wasn't ready, so they weren't translated