### PR TITLE
Add ,music command

### DIFF
--- a/.github/workflows/gci-e2e.yml
+++ b/.github/workflows/gci-e2e.yml
@@ -28,7 +28,7 @@ jobs:
       DB_USER_CI: root
       DB_PORT: 3306
       AUDIO_SONGS_PER_ARTIST: 10
-      PREMIUM_AUDIO_SONGS_PER_ARTIST: 25
+      PREMIUM_AUDIO_SONGS_PER_ARTIST: 50
     steps:
       - name: Checkout KMQ_Discord
         uses: actions/checkout@v2

--- a/.github/workflows/gci-tests.yml
+++ b/.github/workflows/gci-tests.yml
@@ -24,7 +24,7 @@ jobs:
             DB_USER_CI: root
             DB_PORT: 3306
             AUDIO_SONGS_PER_ARTIST: 10
-            PREMIUM_AUDIO_SONGS_PER_ARTIST: 25
+            PREMIUM_AUDIO_SONGS_PER_ARTIST: 50
         steps:
             - name: Checkout KMQ_Discord
               uses: actions/checkout@v2

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -873,8 +873,7 @@
                 "description": "Vote to skip the current song. A song is skipped when majority of participants vote to skip it."
             },
             "success": {
-                "description": "{{skipCounter}} skips achieved, skipping...",
-                "title": "Skip"
+                "description": "{{skipCounter}} skips achieved, skipping..."
             },
             "vote": {
                 "description": "{{skipCounter}} skip requests received.",
@@ -1013,6 +1012,7 @@
         "andManyOthers": "and many others...",
         "artist": "artist",
         "artistAliases": "Artist Aliases",
+        "bookmark": "Bookmark",
         "classic": {
             "yourScore": "Your score is {{score}}."
         },
@@ -1252,6 +1252,7 @@
             "description": "Sending {{songs}} to {{players}}.\n\nBookmark songs during the game by right-clicking the song message and selecting `Apps > Bookmark Song`",
             "title": "Sending Bookmarked Songs..."
         },
+        "skip": "Skip",
         "song": "song",
         "songAliases": "Song Aliases",
         "team": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -580,10 +580,6 @@
                     "description": "You do not have permission to use this command.",
                     "title": "Hidden Game Mode"
                 },
-                "notInVC": {
-                    "description": "Send {{play}} again when you are in a voice channel.",
-                    "title": "Join a Voice Channel"
-                },
                 "overrideTeamsOrElimination": {
                     "description": "If you meant to start a {{oldGameType}} game, {{end}} this game, call {{playOldGameType}}, {{gameSpecificInstructions}}, and then call {{begin}}.",
                     "elimination": {
@@ -1060,6 +1056,10 @@
                 "title": "Missing Permissions"
             },
             "missingPermissionsText": "Ensure that the bot has the following permissions: {{missingPermissions}}\n\nSee the following link for details: {{permissionsLink}}. If you are still having issues, join the official KMQ server found in {{helpCommand}}",
+            "notInVC": {
+                "description": "Send {{command}} again when you are in a voice channel.",
+                "title": "Join a Voice Channel"
+            },
             "retrievingSongData": {
                 "description": "Try again in a bit, or report this error to the official KMQ server found in {{helpCommand}}.",
                 "title": "Error Retrieving Song Data"
@@ -1155,7 +1155,7 @@
                 "vote": "Give us a vote (and get 2x exp, see `,vote`) and leave a review on [top.gg!](https://top.gg/bot/508759831755096074)"
             },
             "wrongSongName": {
-                "aliases.": "Have a suggestion for an alternate song name? Tell us on the official KMQ server!",
+                "aliases": "Have a suggestion for an alternate song name? Tell us on the official KMQ server!",
                 "title": "Wrong Song Name?"
             }
         },
@@ -1236,6 +1236,7 @@
             "debugChannel": "You can't do that in this channel.",
             "debugServer": "You can't do that in this server.",
             "differentVC": "You must be in the same voice channel as the bot to use this command.",
+            "notMusicSession": "You can't do that while in a music session.",
             "title": "Wait..."
         },
         "releaseDate": "Release Date",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -549,6 +549,7 @@
             "help": {
                 "description": "Displays the current game options."
             },
+            "musicSessionNotAvailable": "Some options are not available during a music session",
             "notSet": "Not set",
             "overview": "Now playing the top {{limit}} out of {{totalSongs}} available songs from the following options:\n\n{{priorityOptions}}",
             "perCommandHelp": "Looking for information on how to use a command? Check out \"{{helpCommand}} [command]\" to learn more.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1251,6 +1251,7 @@
             "differentVC": "You must be in the same voice channel as the bot to use this command.",
             "notMusicSession": "You can't do that while in a music session.",
             "notPremium": "You need KMQ Premium to use this command (see {{premium}}).",
+            "premiumOrDebugChannel": "This command only works in the official KMQ server or for KMQ Premium members (see {{premium}}).",
             "title": "Wait..."
         },
         "releaseDate": "Release Date",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -529,6 +529,13 @@
                 }
             }
         },
+        "music": {
+            "help": {
+                "description": "Stream songs from the current options. Only available to KMQ Premium users.",
+                "example": "Music will start playing in the current voice channel."
+            },
+            "musicStarting": "Music Starting in #{{textChannelName}} in 🔊 {{voiceChannelName}}"
+        },
         "news": {
             "help": {
                 "description": "Displays the latest updates to KMQ."

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -550,7 +550,7 @@
                 "description": "Displays the current game options."
             },
             "notSet": "Not set",
-            "overview": "Now playing the top {{limit}} out of {{totalSongs}} available songs from the following game options:\n\n{{priorityOptions}}",
+            "overview": "Now playing the top {{limit}} out of {{totalSongs}} available songs from the following options:\n\n{{priorityOptions}}",
             "perCommandHelp": "Looking for information on how to use a command? Check out \"{{helpCommand}} [command]\" to learn more.",
             "premiumOptionsNonPremiumGame": "Note: active game is not premium",
             "preset": "Preset",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1244,6 +1244,7 @@
             "debugServer": "You can't do that in this server.",
             "differentVC": "You must be in the same voice channel as the bot to use this command.",
             "notMusicSession": "You can't do that while in a music session.",
+            "notPremium": "You need KMQ Premium to use this command (see {{premium}}).",
             "title": "Wait..."
         },
         "releaseDate": "Release Date",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -637,7 +637,7 @@
                         "title": "Premium Supporter Badge!"
                     },
                     "moreSongs": {
-                        "description": "Gain access to the top 25 b-sides for every artist (up from 10)",
+                        "description": "Gain access to the top 50 b-sides for every artist (up from 10)",
                         "title": "More songs!"
                     },
                     "special": {

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -580,10 +580,6 @@
                     "description": "이 명령어를 사용할 권한이 없습니다.",
                     "title": "숨겨진 게임 모드"
                 },
-                "notInVC": {
-                    "description": "음성 채널에 있을 때 {{play}}를 다시 보내세요.",
-                    "title": "음성 채널을 가입하세요!"
-                },
                 "overrideTeamsOrElimination": {
                     "description": "{{oldGameType}} 게임, 이 게임을 {{end}} 시작하려면 {{playOldGameType}}, {{gameSpecificInstructions}}를 호출한 다음 {{begin}}를 호출하세요.",
                     "elimination": {
@@ -1060,6 +1056,10 @@
                 "title": "누락된 권한"
             },
             "missingPermissionsText": "봇에 {{missingPermissions}} 권한이 있는지 확인하세요.\n\n자세한 내용은 {{permissionsLink}} 링크를 참조하세요. (여전히 문제가 발생하면 {{helpCommand}}에 있는 공식 KMQ 서버에 가입하세요.)",
+            "notInVC": {
+                "description": "음성 채널에 있을 때 {{command}}를 다시 보내세요.",
+                "title": "음성 채널을 가입하세요!"
+            },
             "retrievingSongData": {
                 "description": "잠시 후 다시 시도하거나 {{helpCommand}}에 있는 공식 KMQ 서버에 이 오류를 보고하세요.",
                 "title": "노래 데이터를 검색하는 동안 오류가 발생했습니다."
@@ -1155,7 +1155,7 @@
                 "vote": "투표를 하고 (경험치 2배 획득, `,vote` 참조) [top.gg!](https://top.gg/bot/508759831755096074)에 리뷰를 남겨주세요."
             },
             "wrongSongName": {
-                "aliases.": "노래 이름에 대한 제안이 있으십니까? (공식 KMQ 서버에서 알려주세요!)",
+                "aliases": "노래 이름에 대한 제안이 있으십니까? (공식 KMQ 서버에서 알려주세요!)",
                 "title": "노래 이름이 이상한가요?"
             }
         },
@@ -1236,6 +1236,7 @@
             "debugChannel": "이 채널에서는 할 수 없습니다.",
             "debugServer": "이 서버에서는 할 수 없습니다.",
             "differentVC": "이 명령어를 사용하려면 봇과 동일한 음성 채널에 있어야 합니다.",
+            "notMusicSession": "이 명령어는 음악 세션에서 사용할 수 없습니다.",
             "title": "잠시만 기다려주십시오..."
         },
         "releaseDate": "출시 날짜",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -873,8 +873,7 @@
                 "description": "현재 노래를 건너뛰려면 투표하세요. (대다수의 참가자가 건너뛰기로 투표하면 노래를 건너뜁니다.)"
             },
             "success": {
-                "description": "{{skipCounter}} 건너뛰기 요청이 수락되었습니다!",
-                "title": "건너뛰기"
+                "description": "{{skipCounter}} 건너뛰기 요청이 수락되었습니다!"
             },
             "vote": {
                 "description": "{{skipCounter}} 건너뛰기가 요청되었습니다!",
@@ -1013,6 +1012,7 @@
         "andManyOthers": "그리고 많은 다른 사람들...",
         "artist": "아티스트",
         "artistAliases": "아티스트 별칭",
+        "bookmark": "북마크",
         "classic": {
             "yourScore": "당신의 점수는 {{score}}점 입니다."
         },
@@ -1252,6 +1252,7 @@
             "description": "{{players}}에게 {{songs}}을(를) 보냅니다.\n\n노래 메시지를 마우스 오른쪽 버튼으로 클릭하고 `앱 > Bookmark Song`를 선택하여 게임 중에 노래를 북마크하세요.",
             "title": "북마크된 노래를 보내는 중..."
         },
+        "skip": "건너뛰기",
         "song": "노래",
         "songAliases": "노래 별칭",
         "team": {

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -1244,6 +1244,7 @@
             "debugServer": "이 서버에서는 할 수 없습니다.",
             "differentVC": "이 명령어를 사용하려면 봇과 동일한 음성 채널에 있어야 합니다.",
             "notMusicSession": "이 명령어는 음악 세션에서 사용할 수 없습니다.",
+            "notPremium": "이 명령을 사용하려면 KMQ Premium이 필요합니다 ({{premium}} 참조).",
             "title": "잠시만 기다려주십시오..."
         },
         "releaseDate": "출시 날짜",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -550,7 +550,7 @@
                 "description": "현재 게임 옵션을 표시합니다."
             },
             "notSet": "설정되지 않음",
-            "overview": "이제 다음 게임 옵션에서 사용 가능한 노래 {{totalSongs}}개 중 상위 {{limit}}개를 재생합니다.\n\n{{priorityOptions}}",
+            "overview": "이제 다음 옵션에서 사용 가능한 노래 {{totalSongs}}개 중 상위 {{limit}}개를 재생합니다.\n\n{{priorityOptions}}",
             "perCommandHelp": "명령 사용 방법에 대한 정보를 찾고 계십니까? (자세한 내용은 \"{{helpCommand}} [명령]\"을 확인하세요.)",
             "premiumOptionsNonPremiumGame": "주의: 액티브 게임은 프리미엄이 아닙니다",
             "preset": "사전 설정",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -529,6 +529,13 @@
                 }
             }
         },
+        "music": {
+            "help": {
+                "description": "Stream songs from the current options. Only available to KMQ Premium users.",
+                "example": "Music will start playing in the current voice channel."
+            },
+            "musicStarting": "Music Starting in #{{textChannelName}} in 🔊 {{voiceChannelName}}"
+        },
         "news": {
             "help": {
                 "description": "KMQ에 대한 최신 업데이트를 표시합니다."

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -637,7 +637,7 @@
                         "title": "프리미엄 서포터 배지!"
                     },
                     "moreSongs": {
-                        "description": "모든 아티스트의 상위 25개 b-side에 액세스 (최대 10개)하세요.",
+                        "description": "모든 아티스트의 상위 50개 b-side에 액세스 (최대 10개)하세요.",
                         "title": "노래 더!"
                     },
                     "special": {

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -531,10 +531,10 @@
         },
         "music": {
             "help": {
-                "description": "Stream songs from the current options. Only available to KMQ Premium users.",
-                "example": "Music will start playing in the current voice channel."
+                "description": "현재 옵션에서 노래를 스트리밍합니다. KMQ 프리미엄 사용자만 사용할 수 있습니다.",
+                "example": "현재 음성 채널에서 음악이 재생되기 시작합니다."
             },
-            "musicStarting": "Music Starting in #{{textChannelName}} in 🔊 {{voiceChannelName}}"
+            "musicStarting": "🔊 {{voiceChannelName}}의 {{textChannelName}}에서 시작하는 음악"
         },
         "news": {
             "help": {

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -1251,6 +1251,7 @@
             "differentVC": "이 명령어를 사용하려면 봇과 동일한 음성 채널에 있어야 합니다.",
             "notMusicSession": "이 명령어는 음악 세션에서 사용할 수 없습니다.",
             "notPremium": "이 명령을 사용하려면 KMQ Premium이 필요합니다 ({{premium}} 참조).",
+            "premiumOrDebugChannel": "이 명령은 공식 KMQ 서버 또는 KMQ Premium 멤버에 대해서만 작동합니다({{premium}} 참조).",
             "title": "잠시만 기다려주십시오..."
         },
         "releaseDate": "출시 날짜",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -549,6 +549,7 @@
             "help": {
                 "description": "현재 게임 옵션을 표시합니다."
             },
+            "musicSessionNotAvailable": "음악 세션 중에는 일부 옵션을 사용할 수 없습니다",
             "notSet": "설정되지 않음",
             "overview": "이제 다음 옵션에서 사용 가능한 노래 {{totalSongs}}개 중 상위 {{limit}}개를 재생합니다.\n\n{{priorityOptions}}",
             "perCommandHelp": "명령 사용 방법에 대한 정보를 찾고 계십니까? (자세한 내용은 \"{{helpCommand}} [명령]\"을 확인하세요.)",

--- a/src/ci_checks/check_help.sh
+++ b/src/ci_checks/check_help.sh
@@ -2,7 +2,7 @@
 
 filenames[0]='./src/commands/game_commands/*.ts'
 filenames[1]='./src/commands/game_options/*.ts'
-exceptions=("debug", "join", "begin", "premium")
+exceptions=("debug", "join", "begin", "premium", "music")
 
 for command_path in ${filenames[@]}
 do

--- a/src/command_prechecks.ts
+++ b/src/command_prechecks.ts
@@ -3,27 +3,34 @@ import {
     getDebugLogHeader,
     sendErrorMessage,
 } from "./helpers/discord_utils";
+import Session from "./structures/session";
 import GameSession from "./structures/game_session";
 import MessageContext from "./structures/message_context";
 import { GameType, GuildTextableMessage } from "./types";
 import { IPCLogger } from "./logger";
 import dbContext from "./database_context";
 import { state } from "./kmq_worker";
+import MusicSession from "./structures/music_session";
 
 const logger = new IPCLogger("command_prechecks");
 export interface PrecheckArgs {
     message: GuildTextableMessage;
-    gameSession: GameSession;
+    session: Session;
     errorMessage?: string;
 }
 
 export default class CommandPrechecks {
-    static inGameCommandPrecheck(precheckArgs: PrecheckArgs): boolean {
-        const { message, gameSession, errorMessage } = precheckArgs;
-        if (!gameSession) {
+    static inSessionCommandPrecheck(precheckArgs: PrecheckArgs): boolean {
+        const { message, session, errorMessage } = precheckArgs;
+        if (!session) {
             return false;
         }
 
+        if (session instanceof MusicSession) {
+            return areUserAndBotInSameVoiceChannel(message);
+        }
+
+        const gameSession = session as GameSession;
         if (!areUserAndBotInSameVoiceChannel(message)) {
             if (
                 gameSession.gameType === GameType.ELIMINATION ||
@@ -52,6 +59,26 @@ export default class CommandPrechecks {
                     errorMessage ?? "misc.preCheck.differentVC"
                 ),
             });
+            return false;
+        }
+
+        return true;
+    }
+
+    static notMusicPrecheck(precheckArgs: PrecheckArgs): boolean {
+        const { session, message } = precheckArgs;
+        if (session && !(session instanceof GameSession)) {
+            sendErrorMessage(MessageContext.fromMessage(message), {
+                title: state.localizer.translate(
+                    message.guildID,
+                    "misc.preCheck.title"
+                ),
+                description: state.localizer.translate(
+                    message.guildID,
+                    "misc.preCheck.notMusicSession"
+                ),
+            });
+
             return false;
         }
 
@@ -113,8 +140,13 @@ export default class CommandPrechecks {
     static async competitionPrecheck(
         precheckArgs: PrecheckArgs
     ): Promise<boolean> {
-        const { message, gameSession, errorMessage } = precheckArgs;
-        if (!gameSession || gameSession.gameType !== GameType.COMPETITION) {
+        const { message, session, errorMessage } = precheckArgs;
+        const gameSession = session as GameSession;
+        if (
+            !session ||
+            session instanceof MusicSession ||
+            gameSession.gameType !== GameType.COMPETITION
+        ) {
             return true;
         }
 

--- a/src/command_prechecks.ts
+++ b/src/command_prechecks.ts
@@ -226,4 +226,35 @@ export default class CommandPrechecks {
 
         return false;
     }
+
+    static async premiumOrDebugServerPrecheck(
+        precheckArgs: PrecheckArgs
+    ): Promise<boolean> {
+        const { message } = precheckArgs;
+        const premium = await isUserPremium(message.author.id);
+        const isDebugServer = process.env.DEBUG_SERVER_ID === message.guildID;
+        if (premium || isDebugServer) {
+            return true;
+        }
+
+        logger.warn(
+            `${getDebugLogHeader(
+                message
+            )} | User attempted to use a command only usable in the debug server/for premium users`
+        );
+
+        sendErrorMessage(MessageContext.fromMessage(message), {
+            title: state.localizer.translate(
+                message.guildID,
+                "misc.preCheck.title"
+            ),
+            description: state.localizer.translate(
+                message.guildID,
+                "misc.preCheck.premiumOrDebugServer",
+                { premium: `\`${process.env.BOT_PREFIX}premium\`` }
+            ),
+        });
+
+        return false;
+    }
 }

--- a/src/commands/game_commands/begin.ts
+++ b/src/commands/game_commands/begin.ts
@@ -1,6 +1,6 @@
 import BaseCommand, { CommandArgs } from "../interfaces/base_command";
 import { getGuildPreference } from "../../helpers/game_utils";
-import { sendBeginGameMessage } from "./play";
+import { sendBeginGameSessionMessage } from "./play";
 import { GameType } from "../../types";
 import TeamScoreboard from "../../structures/team_scoreboard";
 import {
@@ -71,7 +71,7 @@ export default class BeginCommand implements BaseCommand {
                 discriminator: player.name.split("#")[1],
             }));
 
-            sendBeginGameMessage(
+            sendBeginGameSessionMessage(
                 channel.name,
                 getUserVoiceChannel(messageContext).name,
                 messageContext,

--- a/src/commands/game_commands/begin.ts
+++ b/src/commands/game_commands/begin.ts
@@ -13,11 +13,15 @@ import MessageContext from "../../structures/message_context";
 import GameSession from "../../structures/game_session";
 import { state } from "../../kmq_worker";
 import CommandPrechecks from "../../command_prechecks";
+import Session from "../../structures/session";
 
 const logger = new IPCLogger("begin");
 
 export default class BeginCommand implements BaseCommand {
-    preRunChecks = [{ checkFn: CommandPrechecks.competitionPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
+    ];
 
     static canStart(
         gameSession: GameSession,
@@ -46,21 +50,12 @@ export default class BeginCommand implements BaseCommand {
         return true;
     }
 
-    call = async ({
-        message,
-        gameSessions,
-        channel,
-    }: CommandArgs): Promise<void> => {
+    call = async ({ message, channel }: CommandArgs): Promise<void> => {
         const { guildID } = message;
-        const gameSession = gameSessions[guildID];
+        const gameSession = Session.getSession(guildID) as GameSession;
+        const messageContext = MessageContext.fromMessage(message);
 
-        if (
-            !BeginCommand.canStart(
-                gameSession,
-                MessageContext.fromMessage(message)
-            )
-        )
-            return;
+        if (!BeginCommand.canStart(gameSession, messageContext)) return;
         const guildPreference = await getGuildPreference(guildID);
         if (!gameSession.sessionInitialized) {
             let participants: Array<{
@@ -78,15 +73,12 @@ export default class BeginCommand implements BaseCommand {
 
             sendBeginGameMessage(
                 channel.name,
-                getUserVoiceChannel(MessageContext.fromMessage(message)).name,
-                message,
+                getUserVoiceChannel(messageContext).name,
+                messageContext,
                 participants
             );
 
-            gameSession.startRound(
-                guildPreference,
-                MessageContext.fromMessage(message)
-            );
+            gameSession.startRound(guildPreference, messageContext);
 
             logger.info(
                 `${getDebugLogHeader(message)} | Teams game session starting)`

--- a/src/commands/game_commands/end.ts
+++ b/src/commands/game_commands/end.ts
@@ -3,6 +3,7 @@ import { getDebugLogHeader } from "../../helpers/discord_utils";
 import { IPCLogger } from "../../logger";
 import CommandPrechecks from "../../command_prechecks";
 import { state } from "../../kmq_worker";
+import Session from "../../structures/session";
 
 const logger = new IPCLogger("end");
 
@@ -10,7 +11,7 @@ export default class EndCommand implements BaseCommand {
     aliases = ["stop", "e"];
 
     preRunChecks = [
-        { checkFn: CommandPrechecks.inGameCommandPrecheck },
+        { checkFn: CommandPrechecks.inSessionCommandPrecheck },
         { checkFn: CommandPrechecks.competitionPrecheck },
     ];
 
@@ -25,16 +26,14 @@ export default class EndCommand implements BaseCommand {
         priority: 1020,
     });
 
-    call = async ({ gameSessions, message }: CommandArgs): Promise<void> => {
-        const gameSession = gameSessions[message.guildID];
-        if (!gameSession) {
-            logger.warn(
-                `${getDebugLogHeader(message)} | No active game session`
-            );
+    call = async ({ message }: CommandArgs): Promise<void> => {
+        const session = Session.getSession(message.guildID);
+        if (!session) {
+            logger.warn(`${getDebugLogHeader(message)} | No active session`);
             return;
         }
 
-        await gameSession.endSession();
-        logger.info(`${getDebugLogHeader(message)} | Game session ended`);
+        await session.endSession();
+        logger.info(`${getDebugLogHeader(message)} | Session ended`);
     };
 }

--- a/src/commands/game_commands/forcehint.ts
+++ b/src/commands/game_commands/forcehint.ts
@@ -23,6 +23,7 @@ export default class ForceHintCommand implements BaseCommand {
     preRunChecks = [
         { checkFn: CommandPrechecks.inSessionCommandPrecheck },
         { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
     ];
 
     help = (guildID: string): Help => ({

--- a/src/commands/game_commands/forcehint.ts
+++ b/src/commands/game_commands/forcehint.ts
@@ -12,6 +12,8 @@ import { KmqImages } from "../../constants";
 import { generateHint, validHintCheck } from "./hint";
 import CommandPrechecks from "../../command_prechecks";
 import { state } from "../../kmq_worker";
+import Session from "../../structures/session";
+import GameSession from "src/structures/game_session";
 
 const logger = new IPCLogger("forcehint");
 
@@ -19,7 +21,7 @@ export default class ForceHintCommand implements BaseCommand {
     aliases = ["fhint", "fh"];
 
     preRunChecks = [
-        { checkFn: CommandPrechecks.inGameCommandPrecheck },
+        { checkFn: CommandPrechecks.inSessionCommandPrecheck },
         { checkFn: CommandPrechecks.competitionPrecheck },
     ];
 
@@ -34,8 +36,8 @@ export default class ForceHintCommand implements BaseCommand {
         priority: 1009,
     });
 
-    call = async ({ gameSessions, message }: CommandArgs): Promise<void> => {
-        const gameSession = gameSessions[message.guildID];
+    call = async ({ message }: CommandArgs): Promise<void> => {
+        const gameSession = Session.getSession(message.guildID) as GameSession;
         const gameRound = gameSession?.round;
         const guildPreference = await getGuildPreference(message.guildID);
 

--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -77,10 +77,7 @@ export default class ForceSkipCommand implements BaseCommand {
             MessageContext.fromMessage(message),
             {
                 color: EMBED_SUCCESS_COLOR,
-                title: state.localizer.translate(
-                    message.guildID,
-                    "command.skip.success.title"
-                ),
+                title: state.localizer.translate(message.guildID, "misc.skip"),
                 description: state.localizer.translate(
                     message.guildID,
                     "command.forceskip.description"

--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -13,6 +13,7 @@ import MessageContext from "../../structures/message_context";
 import { KmqImages } from "../../constants";
 import CommandPrechecks from "../../command_prechecks";
 import { state } from "../../kmq_worker";
+import Session from "../../structures/session";
 
 const logger = new IPCLogger("forceskip");
 
@@ -20,7 +21,7 @@ export default class ForceSkipCommand implements BaseCommand {
     aliases = ["fskip", "fs"];
 
     preRunChecks = [
-        { checkFn: CommandPrechecks.inGameCommandPrecheck },
+        { checkFn: CommandPrechecks.inSessionCommandPrecheck },
         { checkFn: CommandPrechecks.competitionPrecheck },
     ];
 
@@ -35,32 +36,29 @@ export default class ForceSkipCommand implements BaseCommand {
         priority: 1009,
     });
 
-    call = async ({ gameSessions, message }: CommandArgs): Promise<void> => {
-        const guildPreference = await getGuildPreference(message.guildID);
-        const gameSession = gameSessions[message.guildID];
-        if (
-            !gameSession ||
-            !gameSession.round ||
-            !areUserAndBotInSameVoiceChannel(message)
-        ) {
+    call = async ({ message }: CommandArgs): Promise<void> => {
+        if (!areUserAndBotInSameVoiceChannel(message)) {
             logger.warn(
                 `${getDebugLogHeader(
                     message
-                )} | Invalid force-skip. !gameSession: ${!gameSession}. !gameSession.round: ${
-                    gameSession && !gameSession.round
-                }. !areUserAndBotInSameVoiceChannel: ${!areUserAndBotInSameVoiceChannel(
-                    message
-                )}`
+                )} | Invalid forceskip. User and bot are not in the same voice channel.`
             );
             return;
         }
 
-        if (gameSession.round.skipAchieved) {
-            // song already being skipped
+        const guildPreference = await getGuildPreference(message.guildID);
+        const session = Session.getSession(message.guildID);
+        if (
+            !session ||
+            !session.round ||
+            session.round.skipAchieved ||
+            session.round.finished ||
+            !areUserAndBotInSameVoiceChannel(message)
+        ) {
             return;
         }
 
-        if (message.author.id !== gameSession.owner.id) {
+        if (message.author.id !== session.owner.id) {
             await sendErrorMessage(MessageContext.fromMessage(message), {
                 title: state.localizer.translate(
                     message.guildID,
@@ -69,13 +67,13 @@ export default class ForceSkipCommand implements BaseCommand {
                 description: state.localizer.translate(
                     message.guildID,
                     "command.forceskip.failure.notOwner.description",
-                    { mentionedUser: getMention(gameSession.owner.id) }
+                    { mentionedUser: getMention(session.owner.id) }
                 ),
             });
             return;
         }
 
-        gameSession.round.skipAchieved = true;
+        session.round.skipAchieved = true;
         sendInfoMessage(
             MessageContext.fromMessage(message),
             {
@@ -93,17 +91,17 @@ export default class ForceSkipCommand implements BaseCommand {
             true
         );
 
-        await gameSession.endRound(
+        await session.endRound(
             guildPreference,
             MessageContext.fromMessage(message),
             { correct: false }
         );
 
-        await gameSession.startRound(
+        await session.startRound(
             guildPreference,
             MessageContext.fromMessage(message)
         );
-        gameSession.lastActiveNow();
+        session.lastActiveNow();
         logger.info(`${getDebugLogHeader(message)} | Owner force-skipped.`);
     };
 }

--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -49,7 +49,6 @@ export default class ForceSkipCommand implements BaseCommand {
         const guildPreference = await getGuildPreference(message.guildID);
         const session = Session.getSession(message.guildID);
         if (
-            !session ||
             !session.round ||
             session.round.skipAchieved ||
             session.round.finished ||

--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -51,8 +51,7 @@ export default class ForceSkipCommand implements BaseCommand {
         if (
             !session.round ||
             session.round.skipAchieved ||
-            session.round.finished ||
-            !areUserAndBotInSameVoiceChannel(message)
+            session.round.finished
         ) {
             return;
         }

--- a/src/commands/game_commands/hint.ts
+++ b/src/commands/game_commands/hint.ts
@@ -18,6 +18,7 @@ import GuildPreference from "../../structures/guild_preference";
 import CommandPrechecks from "../../command_prechecks";
 import { state } from "../../kmq_worker";
 import GameRound from "../../structures/game_round";
+import Session from "../../structures/session";
 
 const logger = new IPCLogger("hint");
 
@@ -198,8 +199,9 @@ export default class HintCommand implements BaseCommand {
     aliases = ["h"];
 
     preRunChecks = [
-        { checkFn: CommandPrechecks.inGameCommandPrecheck },
+        { checkFn: CommandPrechecks.inSessionCommandPrecheck },
         { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
     ];
 
     help = (guildID: string): Help => ({
@@ -213,8 +215,8 @@ export default class HintCommand implements BaseCommand {
         priority: 1020,
     });
 
-    call = async ({ gameSessions, message }: CommandArgs): Promise<void> => {
-        const gameSession = gameSessions[message.guildID];
+    call = async ({ message }: CommandArgs): Promise<void> => {
+        const gameSession = Session.getSession(message.guildID) as GameSession;
         const gameRound = gameSession?.round;
         const guildPreference = await getGuildPreference(message.guildID);
         if (!validHintCheck(gameSession, guildPreference, gameRound, message))

--- a/src/commands/game_commands/join.ts
+++ b/src/commands/game_commands/join.ts
@@ -17,20 +17,20 @@ import { state } from "../../kmq_worker";
 import MessageContext from "../../structures/message_context";
 import CommandPrechecks from "../../command_prechecks";
 import { IPCLogger } from "../../logger";
+import Session from "../../structures/session";
 
 const logger = new IPCLogger("join");
 
 export default class JoinCommand implements BaseCommand {
-    preRunChecks = [{ checkFn: CommandPrechecks.competitionPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
+    ];
 
     aliases = ["j"];
 
-    call = async ({
-        message,
-        gameSessions,
-        parsedMessage,
-    }: CommandArgs): Promise<void> => {
-        const gameSession = gameSessions[message.guildID];
+    call = async ({ message, parsedMessage }: CommandArgs): Promise<void> => {
+        const gameSession = Session.getSession(message.guildID) as GameSession;
         if (!gameSession || gameSession.gameType !== GameType.TEAMS) {
             return;
         }

--- a/src/commands/game_commands/list.ts
+++ b/src/commands/game_commands/list.ts
@@ -120,7 +120,7 @@ export default class ListCommand implements BaseCommand {
                     {
                         content: state.localizer.translate(
                             message.guildID,
-                            "command.list.failure.groupsInFile"
+                            "command.list.failure.groupsInFile.description"
                         ),
                     },
                     {

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -31,14 +31,14 @@ const logger = new IPCLogger("music");
  * @param message - The original message that triggered the command
  * @param participants - The list of participants
  */
-export async function sendBeginGameMessage(
+export async function sendBeginMusicSessionMessage(
     textChannelName: string,
     voiceChannelName: string,
     message: GuildTextableMessage
 ): Promise<void> {
     const startTitle = state.localizer.translate(
         message.guildID,
-        "command.play.gameStarting",
+        "command.music.musicStarting",
         {
             textChannelName,
             voiceChannelName,
@@ -133,7 +133,7 @@ export default class MusicCommand implements BaseCommand {
             logger.warn(
                 `${getDebugLogHeader(
                     message
-                )} | Attempted to start game before restart.`
+                )} | Attempted to start music session before restart.`
             );
             return;
         }
@@ -168,7 +168,7 @@ export default class MusicCommand implements BaseCommand {
             gameOwner
         );
 
-        await sendBeginGameMessage(
+        await sendBeginMusicSessionMessage(
             textChannel.name,
             voiceChannel.name,
             message

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -94,7 +94,10 @@ export async function sendBeginMusicSessionMessage(
 }
 
 export default class MusicCommand implements BaseCommand {
-    preRunChecks = [{ checkFn: CommandPrechecks.notRestartingPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.notRestartingPrecheck },
+        { checkFn: CommandPrechecks.premiumPrecheck },
+    ];
 
     validations = {
         minArgCount: 0,

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -1,0 +1,182 @@
+import {
+    EMBED_SUCCESS_BONUS_COLOR,
+    getDebugLogHeader,
+    getUserVoiceChannel,
+    sendErrorMessage,
+    sendInfoMessage,
+    voicePermissionsCheck,
+} from "../../helpers/discord_utils";
+import { getGuildPreference } from "../../helpers/game_utils";
+import MusicSession from "../../structures/music_session";
+import MessageContext from "../../structures/message_context";
+import { state } from "../../kmq_worker";
+import BaseCommand, { CommandArgs, Help } from "../interfaces/base_command";
+import { IPCLogger } from "../../logger";
+import KmqMember from "../../structures/kmq_member";
+import { GameInfoMessage, GuildTextableMessage } from "../../types";
+import { chooseWeightedRandom } from "../../helpers/utils";
+import dbContext from "../../database_context";
+import Eris from "eris";
+import { KmqImages } from "../../constants";
+import { getTimeUntilRestart } from "../../helpers/management_utils";
+import Session from "../../structures/session";
+import GameSession from "../../structures/game_session";
+
+const logger = new IPCLogger("music");
+
+/**
+ * Sends the beginning of game session message
+ * @param textChannelName - The name of the text channel to send the message to
+ * @param voiceChannelName - The name of the voice channel to join
+ * @param message - The original message that triggered the command
+ * @param participants - The list of participants
+ */
+export async function sendBeginGameMessage(
+    textChannelName: string,
+    voiceChannelName: string,
+    message: GuildTextableMessage
+): Promise<void> {
+    const startTitle = state.localizer.translate(
+        message.guildID,
+        "command.play.gameStarting",
+        {
+            textChannelName,
+            voiceChannelName,
+        }
+    );
+
+    const gameInfoMessage: GameInfoMessage = chooseWeightedRandom(
+        await dbContext.kmq("game_messages")
+    );
+
+    const fields: Eris.EmbedField[] = [];
+    if (gameInfoMessage) {
+        fields.push({
+            name: state.localizer.translate(
+                message.guildID,
+                gameInfoMessage.title
+            ),
+            value: state.localizer.translate(
+                message.guildID,
+                gameInfoMessage.message
+            ),
+            inline: false,
+        });
+    }
+
+    await sendInfoMessage(MessageContext.fromMessage(message), {
+        title: startTitle,
+        color: EMBED_SUCCESS_BONUS_COLOR,
+        thumbnailUrl: KmqImages.HAPPY,
+        fields,
+    });
+}
+
+export default class MusicCommand implements BaseCommand {
+    validations = {
+        minArgCount: 0,
+        maxArgCount: 0,
+        arguments: [],
+    };
+
+    aliases = ["radio", "listen"];
+
+    help = (guildID: string): Help => ({
+        name: "music",
+        description: state.localizer.translate(
+            guildID,
+            "command.music.help.description"
+        ),
+        usage: "music",
+        // priority: 1050,
+        examples: [
+            {
+                example: "`,music`",
+                explanation: state.localizer.translate(
+                    guildID,
+                    "command.music.help.example"
+                ),
+            },
+        ],
+    });
+
+    call = async ({ message, channel }: CommandArgs): Promise<void> => {
+        const messageContext = MessageContext.fromMessage(message);
+        const guildID = message.guildID;
+        const session = Session.getSession(guildID);
+        if (session instanceof GameSession) {
+            sendErrorMessage(messageContext, {
+                title: "command.music.failure.existingGameSession.title",
+                description: "command.music.failure.existingGameSession.title",
+            });
+            return;
+        }
+
+        const guildPreference = await getGuildPreference(message.guildID);
+        const textChannel = channel;
+        const gameOwner = KmqMember.fromUser(message.author);
+        const voiceChannel = getUserVoiceChannel(messageContext);
+        const timeUntilRestart = await getTimeUntilRestart();
+        if (timeUntilRestart) {
+            await sendErrorMessage(messageContext, {
+                title: state.localizer.translate(
+                    message.guildID,
+                    "command.play.failure.botRestarting.title"
+                ),
+                description: state.localizer.translate(
+                    message.guildID,
+                    "command.play.failure.botRestarting.description",
+                    { timeUntilRestart: `\`${timeUntilRestart}\`` }
+                ),
+            });
+
+            logger.warn(
+                `${getDebugLogHeader(
+                    message
+                )} | Attempted to start game before restart.`
+            );
+            return;
+        }
+
+        if (!voiceChannel) {
+            await sendErrorMessage(messageContext, {
+                title: state.localizer.translate(
+                    message.guildID,
+                    "misc.failure.notInVC.title"
+                ),
+                description: state.localizer.translate(
+                    message.guildID,
+                    "misc.failure.notInVC.description",
+                    { command: `\`${process.env.BOT_PREFIX}music\`` }
+                ),
+            });
+
+            logger.warn(
+                `${getDebugLogHeader(message)} | User not in voice channel`
+            );
+            return;
+        }
+
+        if (!voicePermissionsCheck(message)) {
+            return;
+        }
+
+        const musicSession = new MusicSession(
+            textChannel.id,
+            voiceChannel.id,
+            guildID,
+            gameOwner
+        );
+
+        await sendBeginGameMessage(
+            textChannel.name,
+            voiceChannel.name,
+            message
+        );
+
+        musicSession.startRound(guildPreference, messageContext);
+        logger.info(`${getDebugLogHeader(message)} | Music session starting`);
+
+        state.musicSessions[guildID] = musicSession;
+    };
+}

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -126,6 +126,21 @@ export default class MusicCommand implements BaseCommand {
         ],
     });
 
+    resetPremium = async (guildPreference: GuildPreference): Promise<void> => {
+        const guildID = guildPreference.guildID;
+        const session = Session.getSession(guildID);
+        if (!session || session instanceof GameSession) {
+            return;
+        }
+
+        if (!session.isPremium()) {
+            logger.info(
+                `gid: ${guildID} | Music session ending, no longer premium.`
+            );
+            await session.endSession();
+        }
+    };
+
     call = async ({ message, channel }: CommandArgs): Promise<void> => {
         const messageContext = MessageContext.fromMessage(message);
         const guildID = message.guildID;

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -114,7 +114,7 @@ export default class MusicCommand implements BaseCommand {
             "command.music.help.description"
         ),
         usage: ",music",
-        priority: 1050,
+        priority: 1040,
         examples: [
             {
                 example: "`,music`",

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -71,7 +71,11 @@ export async function sendBeginMusicSessionMessage(
     const optionsEmbedPayload = await generateOptionsMessage(
         messageContext,
         guildPreference,
-        null
+        null,
+        false,
+        false,
+        null,
+        true
     );
 
     await sendInfoMessage(

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -106,8 +106,8 @@ export default class MusicCommand implements BaseCommand {
             guildID,
             "command.music.help.description"
         ),
-        usage: "music",
-        // priority: 1050,
+        usage: ",music",
+        priority: 1050,
         examples: [
             {
                 example: "`,music`",

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -147,6 +147,7 @@ export default class PlayCommand implements BaseCommand {
     preRunChecks = [
         { checkFn: CommandPrechecks.competitionPrecheck },
         { checkFn: CommandPrechecks.notMusicPrecheck },
+        { checkFn: CommandPrechecks.notRestartingPrecheck },
     ];
 
     validations = {

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -30,7 +30,6 @@ import KmqMember from "../../structures/kmq_member";
 import CommandPrechecks from "../../command_prechecks";
 import { state } from "../../kmq_worker";
 import { DEFAULT_LIVES } from "../../structures/elimination_scoreboard";
-import Session from "../../structures/session";
 
 const logger = new IPCLogger("play");
 
@@ -41,7 +40,7 @@ const logger = new IPCLogger("play");
  * @param messageContext - The original message that triggered the command
  * @param participants - The list of participants
  */
-export async function sendBeginGameMessage(
+export async function sendBeginGameSessionMessage(
     textChannelName: string,
     voiceChannelName: string,
     messageContext: MessageContext,
@@ -214,9 +213,9 @@ export default class PlayCommand implements BaseCommand {
     }: CommandArgs): Promise<void> => {
         const messageContext = MessageContext.fromMessage(message);
         const guildID = message.guildID;
-        const existingGameSession = Session.getSession(guildID) as GameSession;
         const guildPreference = await getGuildPreference(guildID);
         const voiceChannel = getUserVoiceChannel(messageContext);
+        const gameSessions = state.gameSessions;
 
         const timeUntilRestart = await getTimeUntilRestart();
         if (timeUntilRestart) {
@@ -235,7 +234,7 @@ export default class PlayCommand implements BaseCommand {
             logger.warn(
                 `${getDebugLogHeader(
                     message
-                )} | Attempted to start game before restart.`
+                )} | Attempted to start game session before restart.`
             );
             return;
         }
@@ -268,8 +267,8 @@ export default class PlayCommand implements BaseCommand {
             GameType.CLASSIC;
 
         if (
-            existingGameSession &&
-            !existingGameSession.sessionInitialized &&
+            gameSessions[message.guildID] &&
+            !gameSessions[message.guildID].sessionInitialized &&
             gameType === GameType.TEAMS
         ) {
             // User sent ,play teams twice, reset the GameSession
@@ -283,7 +282,10 @@ export default class PlayCommand implements BaseCommand {
 
         const prefix = process.env.BOT_PREFIX;
 
-        if (!existingGameSession || !existingGameSession.sessionInitialized) {
+        if (
+            !gameSessions[message.guildID] ||
+            !gameSessions[message.guildID].sessionInitialized
+        ) {
             // (1) No game session exists yet (create ELIMINATION, TEAMS, CLASSIC, or COMPETITION game), or
             // (2) User attempting to ,play after a ,play teams that didn't start, start CLASSIC game
             const textChannel = channel;
@@ -325,9 +327,9 @@ export default class PlayCommand implements BaseCommand {
                 });
             } else {
                 // (1 and 2) CLASSIC, ELIMINATION, and COMPETITION game creation
-                if (existingGameSession) {
+                if (gameSessions[message.guildID]) {
                     // (2) Let the user know they're starting a non-teams game
-                    const oldGameType = existingGameSession.gameType;
+                    const oldGameType = gameSessions[message.guildID].gameType;
                     const ignoringOldGameTypeTitle = state.localizer.translate(
                         guildID,
                         "command.play.failure.overrideTeamsOrElimination.title",
@@ -422,7 +424,7 @@ export default class PlayCommand implements BaseCommand {
                     lives
                 );
 
-                await sendBeginGameMessage(
+                await sendBeginGameSessionMessage(
                     textChannel.name,
                     voiceChannel.name,
                     messageContext,
@@ -435,8 +437,8 @@ export default class PlayCommand implements BaseCommand {
             }
 
             // prevent any duplicate game sessions
-            if (existingGameSession) {
-                existingGameSession.endSession();
+            if (gameSessions[message.guildID]) {
+                gameSessions[message.guildID].endSession();
             }
 
             state.gameSessions[guildID] = gameSession;

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -1,5 +1,6 @@
 import Eris from "eris";
 import GameSession from "../../structures/game_session";
+import Session from "../../structures/session";
 import {
     sendErrorMessage,
     getDebugLogHeader,
@@ -12,10 +13,7 @@ import {
     generateOptionsMessage,
     generateEmbed,
 } from "../../helpers/discord_utils";
-import {
-    deleteSession,
-    getTimeUntilRestart,
-} from "../../helpers/management_utils";
+import { getTimeUntilRestart } from "../../helpers/management_utils";
 import {
     activeBonusUsers,
     getGuildPreference,
@@ -313,7 +311,7 @@ export default class PlayCommand implements BaseCommand {
             gameType === GameType.TEAMS
         ) {
             // User sent ,play teams twice, reset the GameSession
-            deleteSession(guildID);
+            Session.deleteSession(guildID);
             logger.info(
                 `${getDebugLogHeader(
                     message

--- a/src/commands/game_commands/premium.ts
+++ b/src/commands/game_commands/premium.ts
@@ -1,8 +1,8 @@
-import { KmqImages } from "../../constants";
-import { sendInfoMessage } from "../../helpers/discord_utils";
-import { isUserPremium } from "../../helpers/game_utils";
+// import { KmqImages } from "../../constants";
+// import { sendInfoMessage } from "../../helpers/discord_utils";
+// import { isUserPremium } from "../../helpers/game_utils";
 import { state } from "../../kmq_worker";
-import MessageContext from "../../structures/message_context";
+// import MessageContext from "../../structures/message_context";
 import BaseCommand, { CommandArgs, Help } from "../interfaces/base_command";
 
 export default class PremiumCommand implements BaseCommand {
@@ -31,57 +31,60 @@ export default class PremiumCommand implements BaseCommand {
         usage: ",premium",
     });
 
-    call = async ({ message }: CommandArgs): Promise<void> => {
-        const premiumMember = await isUserPremium(message.author.id);
-        sendInfoMessage(MessageContext.fromMessage(message), {
-            description: `${state.localizer.translate(
-                message.guildID,
-                premiumMember
-                    ? "command.premium.status.description.premium"
-                    : "command.premium.status.description.nonPremium"
-            )}\n\n${state.localizer.translate(
-                message.guildID,
-                "command.premium.status.description.connectionReminder"
-            )}`,
-            fields: [
-                {
-                    name: state.localizer.translate(
-                        message.guildID,
-                        "command.premium.status.perks.moreSongs.title"
-                    ),
-                    value: state.localizer.translate(
-                        message.guildID,
-                        "command.premium.status.perks.moreSongs.description"
-                    ),
-                },
-                {
-                    name: state.localizer.translate(
-                        message.guildID,
-                        "command.premium.status.perks.special.title"
-                    ),
-                    value: state.localizer.translate(
-                        message.guildID,
-                        "command.premium.status.perks.special.description"
-                    ),
-                },
-                {
-                    name: state.localizer.translate(
-                        message.guildID,
-                        "command.premium.status.perks.badge.title"
-                    ),
-                    value: state.localizer.translate(
-                        message.guildID,
-                        "command.premium.status.perks.badge.description"
-                    ),
-                },
-            ],
-            thumbnailUrl: KmqImages.HAPPY,
-            title: state.localizer.translate(
-                message.guildID,
-                premiumMember
-                    ? "command.premium.status.title.premium"
-                    : "command.premium.status.title.nonPremium"
-            ),
-        });
+    call = async ({}: CommandArgs): Promise<void> => {
+        // Temporarily disable premium command
+        return;
+        // call = async ({ message }: CommandArgs): Promise<void> => {
+        // const premiumMember = await isUserPremium(message.author.id);
+        // sendInfoMessage(MessageContext.fromMessage(message), {
+        //     description: `${state.localizer.translate(
+        //         message.guildID,
+        //         premiumMember
+        //             ? "command.premium.status.description.premium"
+        //             : "command.premium.status.description.nonPremium"
+        //     )}\n\n${state.localizer.translate(
+        //         message.guildID,
+        //         "command.premium.status.description.connectionReminder"
+        //     )}`,
+        //     fields: [
+        //         {
+        //             name: state.localizer.translate(
+        //                 message.guildID,
+        //                 "command.premium.status.perks.moreSongs.title"
+        //             ),
+        //             value: state.localizer.translate(
+        //                 message.guildID,
+        //                 "command.premium.status.perks.moreSongs.description"
+        //             ),
+        //         },
+        //         {
+        //             name: state.localizer.translate(
+        //                 message.guildID,
+        //                 "command.premium.status.perks.special.title"
+        //             ),
+        //             value: state.localizer.translate(
+        //                 message.guildID,
+        //                 "command.premium.status.perks.special.description"
+        //             ),
+        //         },
+        //         {
+        //             name: state.localizer.translate(
+        //                 message.guildID,
+        //                 "command.premium.status.perks.badge.title"
+        //             ),
+        //             value: state.localizer.translate(
+        //                 message.guildID,
+        //                 "command.premium.status.perks.badge.description"
+        //             ),
+        //         },
+        //     ],
+        //     thumbnailUrl: KmqImages.HAPPY,
+        //     title: state.localizer.translate(
+        //         message.guildID,
+        //         premiumMember
+        //             ? "command.premium.status.title.premium"
+        //             : "command.premium.status.title.nonPremium"
+        //     ),
+        // });
     };
 }

--- a/src/commands/game_commands/skip.ts
+++ b/src/commands/game_commands/skip.ts
@@ -74,13 +74,12 @@ async function sendSkipMessage(
  */
 export function isSkipMajority(guildID: string, session: Session): boolean {
     if (session instanceof GameSession) {
-        const gameSession = session as GameSession;
-        if (gameSession.gameType === GameType.ELIMINATION) {
+        if (session.gameType === GameType.ELIMINATION) {
             return (
-                gameSession.round.getSkipCount() >=
+                session.round.getSkipCount() >=
                 Math.floor(
                     (
-                        gameSession.scoreboard as EliminationScoreboard
+                        session.scoreboard as EliminationScoreboard
                     ).getAlivePlayersCount() * 0.5
                 ) +
                     1
@@ -149,11 +148,10 @@ export default class SkipCommand implements BaseCommand {
         }
 
         if (session instanceof GameSession) {
-            const gameSession = session as GameSession;
-            if (gameSession.gameType === GameType.ELIMINATION) {
+            if (session.gameType === GameType.ELIMINATION) {
                 if (
                     !(
-                        gameSession.scoreboard as EliminationScoreboard
+                        session.scoreboard as EliminationScoreboard
                     ).isPlayerEliminated(message.author.id)
                 ) {
                     logger.info(
@@ -161,7 +159,7 @@ export default class SkipCommand implements BaseCommand {
                             message
                         )} | User skipped, elimination mode`
                     );
-                    gameSession.round.userSkipped(message.author.id);
+                    session.round.userSkipped(message.author.id);
                 }
             }
         }

--- a/src/commands/game_options/answer.ts
+++ b/src/commands/game_options/answer.ts
@@ -23,7 +23,10 @@ export enum AnswerType {
 export const DEFAULT_ANSWER_TYPE = AnswerType.TYPING;
 
 export default class AnswerCommand implements BaseCommand {
-    preRunChecks = [{ checkFn: CommandPrechecks.competitionPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
+    ];
 
     validations = {
         minArgCount: 0,

--- a/src/commands/game_options/guessmode.ts
+++ b/src/commands/game_options/guessmode.ts
@@ -21,7 +21,10 @@ export enum GuessModeType {
 export const DEFAULT_GUESS_MODE = GuessModeType.SONG_NAME;
 
 export default class GuessModeCommand implements BaseCommand {
-    preRunChecks = [{ checkFn: CommandPrechecks.competitionPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
+    ];
 
     aliases = ["mode"];
 

--- a/src/commands/game_options/multiguess.ts
+++ b/src/commands/game_options/multiguess.ts
@@ -20,7 +20,10 @@ export enum MultiGuessType {
 export const DEFAULT_MULTIGUESS_TYPE = MultiGuessType.ON;
 
 export default class MultiGuessCommand implements BaseCommand {
-    preRunChecks = [{ checkFn: CommandPrechecks.competitionPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
+    ];
 
     validations = {
         minArgCount: 0,

--- a/src/commands/game_options/seek.ts
+++ b/src/commands/game_options/seek.ts
@@ -21,7 +21,10 @@ export enum SeekType {
 export const DEFAULT_SEEK = SeekType.RANDOM;
 
 export default class SeekCommand implements BaseCommand {
-    preRunChecks = [{ checkFn: CommandPrechecks.competitionPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
+    ];
 
     validations = {
         minArgCount: 0,

--- a/src/commands/game_options/special.ts
+++ b/src/commands/game_options/special.ts
@@ -87,6 +87,7 @@ export default class SpecialCommand implements BaseCommand {
                 "This is an unreleased game option, and can only be used on the official KMQ server",
         },
         { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
     ];
 
     validations = {

--- a/src/commands/game_options/special.ts
+++ b/src/commands/game_options/special.ts
@@ -60,7 +60,7 @@ export default class SpecialCommand implements BaseCommand {
     preRunChecks = [
         { checkFn: CommandPrechecks.competitionPrecheck },
         { checkFn: CommandPrechecks.notMusicPrecheck },
-        { checkFn: CommandPrechecks.premiumPrecheck },
+        { checkFn: CommandPrechecks.premiumOrDebugServerPrecheck },
     ];
 
     validations = {

--- a/src/commands/game_options/special.ts
+++ b/src/commands/game_options/special.ts
@@ -58,13 +58,9 @@ export const specialFfmpegArgs = {
 };
 export default class SpecialCommand implements BaseCommand {
     preRunChecks = [
-        {
-            checkFn: CommandPrechecks.debugServerPrecheck,
-            errorMessage:
-                "This is an unreleased game option, and can only be used on the official KMQ server",
-        },
         { checkFn: CommandPrechecks.competitionPrecheck },
         { checkFn: CommandPrechecks.notMusicPrecheck },
+        { checkFn: CommandPrechecks.premiumPrecheck },
     ];
 
     validations = {

--- a/src/commands/game_options/timer.ts
+++ b/src/commands/game_options/timer.ts
@@ -16,7 +16,10 @@ const logger = new IPCLogger("guessTimeout");
 export default class GuessTimeoutCommand implements BaseCommand {
     aliases = ["time", "timeout", "t"];
 
-    preRunChecks = [{ checkFn: CommandPrechecks.competitionPrecheck }];
+    preRunChecks = [
+        { checkFn: CommandPrechecks.competitionPrecheck },
+        { checkFn: CommandPrechecks.notMusicPrecheck },
+    ];
 
     validations = {
         minArgCount: 0,

--- a/src/commands/interfaces/base_command.ts
+++ b/src/commands/interfaces/base_command.ts
@@ -1,10 +1,8 @@
 import Eris from "eris";
 import { PrecheckArgs } from "../../command_prechecks";
-import GameSession from "../../structures/game_session";
 import { GuildTextableMessage, ParsedMessage } from "../../types";
 
 export interface CommandArgs {
-    gameSessions: { [guildID: string]: GameSession };
     message: GuildTextableMessage;
     channel: Eris.TextChannel;
     parsedMessage: ParsedMessage;

--- a/src/events/client/interactionCreate.ts
+++ b/src/events/client/interactionCreate.ts
@@ -8,6 +8,9 @@ import {
 } from "../../helpers/discord_utils";
 import { state } from "../../kmq_worker";
 import { handleProfileInteraction } from "../../commands/game_commands/profile";
+import Session from "../../structures/session";
+import GameSession from "../../structures/game_session";
+import MusicSession from "../../structures/music_session";
 
 export const BOOKMARK_COMMAND_NAME = "Bookmark Song";
 export const PROFILE_COMMAND_NAME = "Profile";
@@ -24,8 +27,11 @@ export default async function interactionCreateHandler(
         | Eris.UnknownInteraction
 ): Promise<void> {
     if (interaction instanceof Eris.ComponentInteraction) {
-        const gameSession = state.gameSessions[interaction.guildID];
-        if (!gameSession || !gameSession.round) {
+        const session = Session.getSession(interaction.guildID);
+        if (
+            !session ||
+            (!session.round && interaction.data.custom_id !== "bookmark")
+        ) {
             tryInteractionAcknowledge(interaction);
             return;
         }
@@ -41,10 +47,14 @@ export default async function interactionCreateHandler(
             interaction.guildID
         );
 
-        gameSession.handleMultipleChoiceInteraction(
-            interaction,
-            messageContext
-        );
+        if (session instanceof GameSession) {
+            session.handleMultipleChoiceInteraction(
+                interaction,
+                messageContext
+            );
+        } else if (session instanceof MusicSession) {
+            await session.handleButtonInteraction(interaction, messageContext);
+        }
     } else if (interaction instanceof Eris.CommandInteraction) {
         if (
             interaction.data.type ===
@@ -61,8 +71,8 @@ export default async function interactionCreateHandler(
             Eris.Constants.ApplicationCommandTypes.MESSAGE
         ) {
             if (interaction.data.name === BOOKMARK_COMMAND_NAME) {
-                const gameSession = state.gameSessions[interaction.guildID];
-                if (!gameSession) {
+                const session = Session.getSession(interaction.guildID);
+                if (!session) {
                     tryCreateInteractionErrorAcknowledgement(
                         interaction,
                         state.localizer.translate(
@@ -73,7 +83,7 @@ export default async function interactionCreateHandler(
                     return;
                 }
 
-                gameSession.handleBookmarkInteraction(interaction);
+                session.handleBookmarkInteraction(interaction);
             } else if (interaction.data.name === PROFILE_COMMAND_NAME) {
                 const messageId = interaction.data.target_id;
                 const authorId =

--- a/src/events/client/messageCreate.ts
+++ b/src/events/client/messageCreate.ts
@@ -11,6 +11,7 @@ import { state } from "../../kmq_worker";
 import validate from "../../helpers/validate";
 import { EnvType, GuildTextableMessage, ParsedMessage } from "../../types";
 import MessageContext from "../../structures/message_context";
+import Session from "../../structures/session";
 
 const logger = new IPCLogger("messageCreate");
 
@@ -90,14 +91,13 @@ export default async function messageCreateHandler(
                     : null
             )
         ) {
-            const { gameSessions } = state;
-            const gameSession = gameSessions[message.guildID];
+            const session = Session.getSession(message.guildID);
             if (invokedCommand.preRunChecks) {
                 for (const precheck of invokedCommand.preRunChecks) {
                     if (
                         !(await precheck.checkFn({
                             message,
-                            gameSession,
+                            session,
                             errorMessage: precheck.errorMessage,
                         }))
                     ) {
@@ -114,7 +114,6 @@ export default async function messageCreateHandler(
 
             try {
                 await invokedCommand.call({
-                    gameSessions,
                     channel: textChannel,
                     message,
                     parsedMessage,

--- a/src/events/client/messageCreate.ts
+++ b/src/events/client/messageCreate.ts
@@ -12,6 +12,7 @@ import validate from "../../helpers/validate";
 import { EnvType, GuildTextableMessage, ParsedMessage } from "../../types";
 import MessageContext from "../../structures/message_context";
 import Session from "../../structures/session";
+import GameSession from "../../structures/game_session";
 
 const logger = new IPCLogger("messageCreate");
 
@@ -51,17 +52,14 @@ export default async function messageCreateHandler(
 
     const parsedMessage = parseMessage(message.content) || null;
     const textChannel = message.channel as Eris.TextChannel;
+    const messageContext = MessageContext.fromMessage(message);
     if (
         message.mentions.includes(state.client.user) &&
         message.content.split(" ").length === 1
     ) {
         // Any message that mentions the bot sends the current options
         const guildPreference = await getGuildPreference(message.guildID);
-        sendOptionsMessage(
-            MessageContext.fromMessage(message),
-            guildPreference,
-            null
-        );
+        sendOptionsMessage(messageContext, guildPreference, null);
         return;
     }
 
@@ -69,6 +67,7 @@ export default async function messageCreateHandler(
         ? state.client.commands[parsedMessage.action]
         : null;
 
+    const session = Session.getSession(message.guildID);
     if (invokedCommand) {
         if (!state.rateLimiter.check(message.author.id)) {
             logger.error(
@@ -91,7 +90,6 @@ export default async function messageCreateHandler(
                     : null
             )
         ) {
-            const session = Session.getSession(message.guildID);
             if (invokedCommand.preRunChecks) {
                 for (const precheck of invokedCommand.preRunChecks) {
                     if (
@@ -130,7 +128,7 @@ export default async function messageCreateHandler(
                     logger.error(e.stack);
                 }
 
-                sendErrorMessage(MessageContext.fromMessage(message), {
+                sendErrorMessage(messageContext, {
                     title: state.localizer.translate(
                         message.guildID,
                         "misc.failure.command.title"
@@ -143,11 +141,7 @@ export default async function messageCreateHandler(
                 });
             }
         }
-    } else if (state.gameSessions[message.guildID]?.round) {
-        const gameSession = state.gameSessions[message.guildID];
-        gameSession.guessSong(
-            MessageContext.fromMessage(message),
-            message.content
-        );
+    } else if (session instanceof GameSession && session.round) {
+        session.guessSong(messageContext, message.content);
     }
 }

--- a/src/events/client/voiceChannelJoin.ts
+++ b/src/events/client/voiceChannelJoin.ts
@@ -1,5 +1,6 @@
 import Eris from "eris";
-import { state } from "../../kmq_worker";
+import GameSession from "../../structures/game_session";
+import Session from "../../structures/session";
 
 /**
  * @param member - The member that joined the voice channel
@@ -9,21 +10,23 @@ export default async function voiceChannelJoinHandler(
     member: Eris.Member,
     newChannel: Eris.VoiceChannel
 ): Promise<void> {
-    const gameSession = state.gameSessions[newChannel.guild.id];
-    if (!gameSession || gameSession.finished) {
+    const session = Session.getSession(newChannel.guild.id);
+    if (!session || session.finished) {
         return;
     }
 
     if (
-        newChannel.id !== gameSession.voiceChannelID ||
+        newChannel.id !== session.voiceChannelID ||
         member.id === process.env.BOT_CLIENT_ID
     ) {
         return;
     }
 
-    const oldPremiumState = gameSession.isPremiumGame();
-    await gameSession.setPlayerInVC(member.id, true);
-    if (oldPremiumState !== gameSession.isPremiumGame()) {
-        gameSession.updatePremiumStatus();
+    if (session instanceof GameSession) {
+        const oldPremiumState = session.isPremiumGame();
+        await session.setPlayerInVC(member.id, true);
+        if (oldPremiumState !== session.isPremiumGame()) {
+            session.updatePremiumStatus();
+        }
     }
 }

--- a/src/events/client/voiceChannelJoin.ts
+++ b/src/events/client/voiceChannelJoin.ts
@@ -1,6 +1,7 @@
 import Eris from "eris";
 import GameSession from "../../structures/game_session";
 import Session from "../../structures/session";
+import MusicSession from "../../structures/music_session";
 
 /**
  * @param member - The member that joined the voice channel
@@ -22,11 +23,15 @@ export default async function voiceChannelJoinHandler(
         return;
     }
 
+    const oldPremiumState = session.isPremium();
     if (session instanceof GameSession) {
-        const oldPremiumState = session.isPremiumGame();
         await session.setPlayerInVC(member.id, true);
-        if (oldPremiumState !== session.isPremiumGame()) {
-            session.updatePremiumStatus();
-        }
+    }
+
+    if (
+        oldPremiumState !== session.isPremium() ||
+        session instanceof MusicSession
+    ) {
+        session.updatePremiumStatus();
     }
 }

--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -2,6 +2,7 @@ import Eris from "eris";
 import { checkBotIsAlone } from "../../helpers/discord_utils";
 import Session from "../../structures/session";
 import GameSession from "../../structures/game_session";
+import MusicSession from "../../structures/music_session";
 
 /**
  * Handles the 'voiceChannelLeave' event
@@ -27,12 +28,15 @@ export default async function voiceChannelLeaveHandler(
         return;
     }
 
-    session.updateOwner();
     if (session instanceof GameSession) {
         const oldPremiumState = session.isPremiumGame();
         await session.setPlayerInVC(member.id, false);
         if (oldPremiumState !== session.isPremiumGame()) {
             await session.updatePremiumStatus();
         }
+    } else if (session instanceof MusicSession) {
+        session.verifyPremium();
     }
+
+    session.updateOwner();
 }

--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -27,14 +27,12 @@ export default async function voiceChannelLeaveHandler(
         return;
     }
 
-    if (!session.finished) {
-        session.updateOwner();
-        if (session instanceof GameSession) {
-            const oldPremiumState = session.isPremiumGame();
-            await session.setPlayerInVC(member.id, false);
-            if (oldPremiumState !== session.isPremiumGame()) {
-                await session.updatePremiumStatus();
-            }
+    session.updateOwner();
+    if (session instanceof GameSession) {
+        const oldPremiumState = session.isPremiumGame();
+        await session.setPlayerInVC(member.id, false);
+        if (oldPremiumState !== session.isPremiumGame()) {
+            await session.updatePremiumStatus();
         }
     }
 }

--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -28,15 +28,17 @@ export default async function voiceChannelLeaveHandler(
         return;
     }
 
+    const oldPremiumState = session.isPremium();
     if (session instanceof GameSession) {
-        const oldPremiumState = session.isPremiumGame();
         await session.setPlayerInVC(member.id, false);
-        if (oldPremiumState !== session.isPremiumGame()) {
-            await session.updatePremiumStatus();
-        }
-    } else if (session instanceof MusicSession) {
-        session.verifyPremium();
     }
 
     session.updateOwner();
+
+    if (
+        oldPremiumState !== session.isPremium() ||
+        session instanceof MusicSession
+    ) {
+        await session.updatePremiumStatus();
+    }
 }

--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -1,6 +1,7 @@
 import Eris from "eris";
-import { state } from "../../kmq_worker";
 import { checkBotIsAlone } from "../../helpers/discord_utils";
+import Session from "../../structures/session";
+import GameSession from "../../structures/game_session";
 
 /**
  * Handles the 'voiceChannelLeave' event
@@ -12,24 +13,28 @@ export default async function voiceChannelLeaveHandler(
     oldChannel: Eris.VoiceChannel
 ): Promise<void> {
     const guildID = oldChannel.guild.id;
-    const gameSession = state.gameSessions[guildID];
-    if (!gameSession || gameSession.finished) {
+    const session = Session.getSession(guildID);
+    if (!session || session.finished) {
         return;
     }
 
-    if (oldChannel.id !== gameSession.voiceChannelID) {
+    if (oldChannel.id !== session.voiceChannelID) {
         return;
     }
 
     if (checkBotIsAlone(guildID)) {
-        gameSession.endSession();
+        session.endSession();
         return;
     }
 
-    gameSession.updateOwner();
-    const oldPremiumState = gameSession.isPremiumGame();
-    await gameSession.setPlayerInVC(member.id, false);
-    if (oldPremiumState !== gameSession.isPremiumGame()) {
-        await gameSession.updatePremiumStatus();
+    if (!session.finished) {
+        session.updateOwner();
+        if (session instanceof GameSession) {
+            const oldPremiumState = session.isPremiumGame();
+            await session.setPlayerInVC(member.id, false);
+            if (oldPremiumState !== session.isPremiumGame()) {
+                await session.updatePremiumStatus();
+            }
+        }
     }
 }

--- a/src/events/client/voiceChannelSwitch.ts
+++ b/src/events/client/voiceChannelSwitch.ts
@@ -32,25 +32,23 @@ export default async function voiceChannelSwitchHandler(
         return;
     }
 
-    if (!session.finished) {
-        if (session instanceof GameSession) {
-            const oldPremiumState = session.isPremiumGame();
-            if (member.id !== process.env.BOT_CLIENT_ID) {
-                await session.setPlayerInVC(
-                    member.id,
-                    newChannel.id === session.voiceChannelID
-                );
-            } else {
-                // Bot was moved to another VC
-                session.voiceChannelID = newChannel.id;
-                session.syncAllVoiceMembers();
-            }
-
-            if (oldPremiumState !== session.isPremiumGame()) {
-                session.updatePremiumStatus();
-            }
+    if (session instanceof GameSession) {
+        const oldPremiumState = session.isPremiumGame();
+        if (member.id !== process.env.BOT_CLIENT_ID) {
+            await session.setPlayerInVC(
+                member.id,
+                newChannel.id === session.voiceChannelID
+            );
+        } else {
+            // Bot was moved to another VC
+            session.voiceChannelID = newChannel.id;
+            session.syncAllVoiceMembers();
         }
 
-        session.updateOwner();
+        if (oldPremiumState !== session.isPremiumGame()) {
+            session.updatePremiumStatus();
+        }
     }
+
+    session.updateOwner();
 }

--- a/src/events/client/voiceChannelSwitch.ts
+++ b/src/events/client/voiceChannelSwitch.ts
@@ -1,6 +1,7 @@
 import Eris from "eris";
-import { state } from "../../kmq_worker";
 import { checkBotIsAlone } from "../../helpers/discord_utils";
+import Session from "../../structures/session";
+import GameSession from "../../structures/game_session";
 
 /**
  * Handles the 'voiceChannelSwitch' event
@@ -14,38 +15,42 @@ export default async function voiceChannelSwitchHandler(
     oldChannel: Eris.VoiceChannel
 ): Promise<void> {
     const guildID = oldChannel.guild.id;
-    const gameSession = state.gameSessions[guildID];
-    if (!gameSession || gameSession.finished) {
+    const session = Session.getSession(guildID);
+    if (!session || session.finished) {
         return;
     }
 
     if (
-        newChannel.id !== gameSession.voiceChannelID &&
-        oldChannel.id !== gameSession.voiceChannelID
+        newChannel.id !== session.voiceChannelID &&
+        oldChannel.id !== session.voiceChannelID
     ) {
         return;
     }
 
     if (checkBotIsAlone(guildID)) {
-        gameSession.endSession();
+        session.endSession();
         return;
     }
 
-    if (member.id !== process.env.BOT_CLIENT_ID) {
-        await gameSession.setPlayerInVC(
-            member.id,
-            newChannel.id === gameSession.voiceChannelID
-        );
-    } else {
-        // Bot was moved to another VC
-        gameSession.voiceChannelID = newChannel.id;
-        gameSession.syncAllVoiceMembers();
-    }
+    if (!session.finished) {
+        if (session instanceof GameSession) {
+            const oldPremiumState = session.isPremiumGame();
+            if (member.id !== process.env.BOT_CLIENT_ID) {
+                await session.setPlayerInVC(
+                    member.id,
+                    newChannel.id === session.voiceChannelID
+                );
+            } else {
+                // Bot was moved to another VC
+                session.voiceChannelID = newChannel.id;
+                session.syncAllVoiceMembers();
+            }
 
-    const oldPremiumState = gameSession.isPremiumGame();
-    if (oldPremiumState !== gameSession.isPremiumGame()) {
-        gameSession.updatePremiumStatus();
-    }
+            if (oldPremiumState !== session.isPremiumGame()) {
+                session.updatePremiumStatus();
+            }
+        }
 
-    gameSession.updateOwner();
+        session.updateOwner();
+    }
 }

--- a/src/events/client/voiceChannelSwitch.ts
+++ b/src/events/client/voiceChannelSwitch.ts
@@ -33,8 +33,8 @@ export default async function voiceChannelSwitchHandler(
         return;
     }
 
+    const oldPremiumState = session.isPremium();
     if (session instanceof GameSession) {
-        const oldPremiumState = session.isPremiumGame();
         if (member.id !== process.env.BOT_CLIENT_ID) {
             await session.setPlayerInVC(
                 member.id,
@@ -45,14 +45,14 @@ export default async function voiceChannelSwitchHandler(
             session.voiceChannelID = newChannel.id;
             await session.syncAllVoiceMembers();
         }
+    }
 
-        if (oldPremiumState !== session.isPremiumGame()) {
-            session.updatePremiumStatus();
-        }
+    session.updateOwner();
 
-        session.updateOwner();
-    } else if (session instanceof MusicSession) {
-        session.updateOwner();
-        session.verifyPremium();
+    if (
+        oldPremiumState !== session.isPremium() ||
+        session instanceof MusicSession
+    ) {
+        session.updatePremiumStatus();
     }
 }

--- a/src/events/client/voiceChannelSwitch.ts
+++ b/src/events/client/voiceChannelSwitch.ts
@@ -2,6 +2,7 @@ import Eris from "eris";
 import { checkBotIsAlone } from "../../helpers/discord_utils";
 import Session from "../../structures/session";
 import GameSession from "../../structures/game_session";
+import MusicSession from "../../structures/music_session";
 
 /**
  * Handles the 'voiceChannelSwitch' event
@@ -42,13 +43,16 @@ export default async function voiceChannelSwitchHandler(
         } else {
             // Bot was moved to another VC
             session.voiceChannelID = newChannel.id;
-            session.syncAllVoiceMembers();
+            await session.syncAllVoiceMembers();
         }
 
         if (oldPremiumState !== session.isPremiumGame()) {
             session.updatePremiumStatus();
         }
-    }
 
-    session.updateOwner();
+        session.updateOwner();
+    } else if (session instanceof MusicSession) {
+        session.updateOwner();
+        session.verifyPremium();
+    }
 }

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1116,7 +1116,7 @@ export async function generateOptionsMessage(
     if (
         premiumRequest &&
         session instanceof GameSession &&
-        !session.isPremiumGame()
+        !session.isPremium()
     ) {
         nonPremiumGameWarning = italicize(
             state.localizer.translate(

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -104,18 +104,31 @@ export function getDebugLogHeader(
         | Eris.ComponentInteraction
         | Eris.CommandInteraction
 ): string {
-    if (context instanceof Eris.Message) {
-        return `gid: ${context.guildID}, uid: ${context.author.id}, tid: ${context.channel.id}`;
+    const session = Session.getSession(context.guildID);
+    let sessionType: string;
+    if (session) {
+        if (session instanceof GameSession) {
+            sessionType = "GameSession";
+        } else if (session instanceof MusicSession) {
+            sessionType = "MusicSession";
+        }
+    } else {
+        sessionType = "No active session";
     }
 
-    if (
+    let header: string;
+    if (context instanceof Eris.Message) {
+        header = `gid: ${context.guildID}, uid: ${context.author.id}, tid: ${context.channel.id}`;
+    } else if (
         context instanceof Eris.ComponentInteraction ||
         context instanceof Eris.CommandInteraction
     ) {
-        return `gid: ${context.guildID}, uid: ${context.member?.id}, tid: ${context.channel.id}`;
+        header = `gid: ${context.guildID}, uid: ${context.member?.id}, tid: ${context.channel.id}`;
+    } else {
+        header = `gid: ${context.guildID}, tid: ${context.textChannelID}`;
     }
 
-    return `gid: ${context.guildID}, tid: ${context.textChannelID}`;
+    return `${header} | sessionType = ${sessionType}`;
 }
 
 /**

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1050,6 +1050,7 @@ export async function generateOptionsMessage(
             GameOption.ANSWER_TYPE,
             GameOption.GOAL,
             GameOption.SPECIAL_TYPE,
+            GameOption.TIMER,
         ];
 
         for (const option of disabledOptions) {

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1049,6 +1049,7 @@ export async function generateOptionsMessage(
             GameOption.MULTIGUESS,
             GameOption.ANSWER_TYPE,
             GameOption.GOAL,
+            GameOption.SPECIAL_TYPE,
         ];
 
         for (const option of disabledOptions) {

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -2,6 +2,7 @@
 import Eris from "eris";
 import EmbedPaginator from "eris-pagination";
 import axios from "axios";
+import * as uuid from "uuid";
 import GuildPreference, { GameOptions } from "../structures/guild_preference";
 import GameSession from "../structures/game_session";
 import { IPCLogger } from "../logger";
@@ -52,6 +53,7 @@ import { LocaleType, DEFAULT_LOCALE } from "./localization_manager";
 import Round from "../structures/round";
 import Session from "../structures/session";
 import MusicSession from "../structures/music_session";
+import MusicRound from "../structures/music_round";
 
 const logger = new IPCLogger("discord_utils");
 export const EMBED_ERROR_COLOR = 0xed4245; // Red
@@ -822,6 +824,33 @@ export async function sendRoundMessage(
             await round.interactionMessage.edit({ embeds: [embed as Object] });
             return round.interactionMessage;
         }
+    }
+
+    if (round instanceof MusicRound) {
+        const buttons: Array<Eris.InteractionButton> = [];
+        round.interactionSkipUUID = uuid.v4();
+        buttons.push({
+            type: 2,
+            style: 1,
+            label: state.localizer.translate(
+                messageContext.guildID,
+                "misc.skip"
+            ),
+            custom_id: round.interactionSkipUUID,
+        });
+
+        buttons.push({
+            type: 2,
+            style: 1,
+            label: state.localizer.translate(
+                messageContext.guildID,
+                "misc.bookmark"
+            ),
+            custom_id: "bookmark",
+        });
+
+        round.interactionComponents = [{ type: 1, components: buttons }];
+        embed.components = round.interactionComponents;
     }
 
     embed.thumbnailUrl = thumbnailUrl;

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1068,12 +1068,16 @@ export async function generateOptionsMessage(
     );
 
     // Options excluded from embed fields since they are of higher importance (shown above them as part of the embed description)
-    const priorityOptions = PriorityGameOption.map(
-        (option) =>
-            `${bold(process.env.BOT_PREFIX + GameOptionCommand[option])}: ${
-                optionStrings[option]
-            }`
-    ).join("\n");
+    const priorityOptions = PriorityGameOption.filter(
+        (option) => optionStrings[option]
+    )
+        .map(
+            (option) =>
+                `${bold(process.env.BOT_PREFIX + GameOptionCommand[option])}: ${
+                    optionStrings[option]
+                }`
+        )
+        .join("\n");
 
     let nonPremiumGameWarning = "";
     if (

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -875,6 +875,7 @@ export function getFormattedLimit(
  * @param preset - Specifies whether the GameOptions were modified by a preset
  * @param allReset - Specifies whether all GameOptions were reset
  * @param footerText - The footer text
+ * @param isMusicSession - Whether the session is a MusicSession
  *  @returns an embed of current game options
  */
 export async function generateOptionsMessage(
@@ -883,7 +884,8 @@ export async function generateOptionsMessage(
     updatedOptions?: { option: GameOption; reset: boolean }[],
     preset = false,
     allReset = false,
-    footerText?: string
+    footerText?: string,
+    isMusicSession = false
 ): Promise<EmbedPayload> {
     if (guildPreference.gameOptions.forcePlaySongID) {
         await sendInfoMessage(
@@ -1042,7 +1044,7 @@ export async function generateOptionsMessage(
     }
 
     // Special case: disable these options in a music session
-    if (session instanceof MusicSession) {
+    if (session instanceof MusicSession || isMusicSession) {
         const disabledOptions = [
             GameOption.GUESS_MODE_TYPE,
             GameOption.SEEK_TYPE,

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -478,14 +478,14 @@ export function removePremium(userIDs: string[]): void {
 /**
  * @param guildID - The guild ID
  * @param playerID - The player ID
- * @returns whether the current game is a premium game, or the player is premium
+ * @returns whether the current game is a premium game/music session, or the player is premium
  */
 export async function isPremiumRequest(
     guildID: string,
     playerID: string
 ): Promise<boolean> {
     return (
-        state.gameSessions[guildID]?.isPremiumGame() ||
+        Session.getSession(guildID)?.isPremium() ||
         (await isUserPremium(playerID))
     );
 }

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -14,8 +14,6 @@ import { LocaleType } from "./localization_manager";
 import { PATREON_SUPPORTER_BADGE, Patron } from "./patreon_manager";
 import { containsHangul, md5Hash } from "./utils";
 import Session from "../structures/session";
-import MusicSession from "../structures/music_session";
-import { SeekType } from "../commands/game_options/seek";
 
 const GAME_SESSION_INACTIVE_THRESHOLD = 30;
 
@@ -100,18 +98,11 @@ export async function getGuildPreference(
         .select("*")
         .where("guild_id", "=", guildID);
 
-    const session = Session.getSession(guildID);
-
     if (guildPreferences.length === 0) {
         const guildPreference = GuildPreference.fromGuild(guildID);
         await dbContext
             .kmq("guilds")
             .insert({ guild_id: guildID, join_date: new Date() });
-
-        if (session instanceof MusicSession) {
-            guildPreference.gameOptions.seekType = SeekType.BEGINNING;
-        }
-
         return guildPreference;
     }
 
@@ -124,16 +115,10 @@ export async function getGuildPreference(
         .map((x) => ({ [x["option_name"]]: JSON.parse(x["option_value"]) }))
         .reduce((total, curr) => Object.assign(total, curr), {});
 
-    const guildPreference = GuildPreference.fromGuild(
+    return GuildPreference.fromGuild(
         guildPreferences[0].guild_id,
         gameOptionPairs
     );
-
-    if (session instanceof MusicSession) {
-        guildPreference.gameOptions.seekType = SeekType.BEGINNING;
-    }
-
-    return guildPreference;
 }
 
 /**

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -15,7 +15,7 @@ import { PATREON_SUPPORTER_BADGE, Patron } from "./patreon_manager";
 import { containsHangul, md5Hash } from "./utils";
 import Session from "../structures/session";
 
-const GAME_SESSION_INACTIVE_THRESHOLD = 30;
+const GAME_SESSION_INACTIVE_THRESHOLD = 10;
 
 const logger = new IPCLogger("game_utils");
 

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -14,6 +14,8 @@ import { LocaleType } from "./localization_manager";
 import { PATREON_SUPPORTER_BADGE, Patron } from "./patreon_manager";
 import { containsHangul, md5Hash } from "./utils";
 import Session from "../structures/session";
+import MusicSession from "../structures/music_session";
+import { SeekType } from "../commands/game_options/seek";
 
 const GAME_SESSION_INACTIVE_THRESHOLD = 30;
 
@@ -98,11 +100,18 @@ export async function getGuildPreference(
         .select("*")
         .where("guild_id", "=", guildID);
 
+    const session = Session.getSession(guildID);
+
     if (guildPreferences.length === 0) {
         const guildPreference = GuildPreference.fromGuild(guildID);
         await dbContext
             .kmq("guilds")
             .insert({ guild_id: guildID, join_date: new Date() });
+
+        if (session instanceof MusicSession) {
+            guildPreference.gameOptions.seekType = SeekType.BEGINNING;
+        }
+
         return guildPreference;
     }
 
@@ -115,10 +124,16 @@ export async function getGuildPreference(
         .map((x) => ({ [x["option_name"]]: JSON.parse(x["option_value"]) }))
         .reduce((total, curr) => Object.assign(total, curr), {});
 
-    return GuildPreference.fromGuild(
+    const guildPreference = GuildPreference.fromGuild(
         guildPreferences[0].guild_id,
         gameOptionPairs
     );
+
+    if (session instanceof MusicSession) {
+        guildPreference.gameOptions.seekType = SeekType.BEGINNING;
+    }
+
+    return guildPreference;
 }
 
 /**

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -133,12 +133,19 @@ function clearInactiveVoiceConnections(): void {
         state.client.voiceConnections.keys()
     ) as Array<string>;
 
-    const activeVoiceChannelGuildIDs = Object.values(state.gameSessions).map(
-        (x) => x.guildID
+    const activeGameVoiceChannelGuildIDs = new Set(
+        Object.values(state.gameSessions).map((x) => x.guildID)
+    );
+
+    const activeMusicVoiceChannelGuildIDs = new Set(
+        Object.values(state.musicSessions).map((x) => x.guildID)
     );
 
     for (const existingVoiceChannelGuildID of existingVoiceChannelGuildIDs) {
-        if (!activeVoiceChannelGuildIDs.includes(existingVoiceChannelGuildID)) {
+        if (
+            !activeGameVoiceChannelGuildIDs.has(existingVoiceChannelGuildID) &&
+            !activeMusicVoiceChannelGuildIDs.has(existingVoiceChannelGuildID)
+        ) {
             const voiceChannelID = state.client.voiceConnections.get(
                 existingVoiceChannelGuildID
             ).channelID;

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -361,11 +361,17 @@ export async function reloadCaches(): Promise<void> {
  * Deletes the GameSession corresponding to a given guild ID
  * @param guildID - The guild ID
  */
-export function deleteGameSession(guildID: string): void {
-    if (!(guildID in state.gameSessions)) {
-        logger.debug(`gid: ${guildID} | GameSession already ended`);
+export function deleteSession(guildID: string): void {
+    const isGameSession = guildID in state.gameSessions;
+    const isMusicSession = guildID in state.musicSessions;
+    if (!isGameSession && !isMusicSession) {
+        logger.debug(`gid: ${guildID} | Session already ended`);
         return;
     }
 
-    delete state.gameSessions[guildID];
+    if (isGameSession) {
+        delete state.gameSessions[guildID];
+    } else if (isMusicSession) {
+        delete state.musicSessions[guildID];
+    }
 }

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -363,22 +363,3 @@ export function reloadCaches(): void {
     reloadBonusGroups();
     reloadLocales();
 }
-
-/**
- * Deletes the GameSession corresponding to a given guild ID
- * @param guildID - The guild ID
- */
-export function deleteSession(guildID: string): void {
-    const isGameSession = guildID in state.gameSessions;
-    const isMusicSession = guildID in state.musicSessions;
-    if (!isGameSession && !isMusicSession) {
-        logger.debug(`gid: ${guildID} | Session already ended`);
-        return;
-    }
-
-    if (isGameSession) {
-        delete state.gameSessions[guildID];
-    } else if (isMusicSession) {
-        delete state.musicSessions[guildID];
-    }
-}

--- a/src/kmq_worker.ts
+++ b/src/kmq_worker.ts
@@ -20,6 +20,7 @@ import KmqClient from "./kmq_client";
 import ReloadCommand from "./commands/admin/reload";
 import EvalCommand from "./commands/admin/eval";
 import LocalizationManager from "./helpers/localization_manager";
+import Session from "./structures/session";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const logger = new IPCLogger("kmq");
@@ -27,6 +28,7 @@ config({ path: path.resolve(__dirname, "../.env") });
 
 const state: State = {
     gameSessions: {},
+    musicSessions: {},
     client: null,
     aliases: {
         artist: {},
@@ -87,9 +89,9 @@ export class BotWorker extends BaseClusterWorker {
 
         const endSessionPromises = Object.keys(state.gameSessions).map(
             async (guildID) => {
-                const gameSession = state.gameSessions[guildID];
-                logger.debug(`gid: ${guildID} | Forcing game session end`);
-                await gameSession.endSession();
+                const session = Session.getSession(guildID);
+                logger.debug(`gid: ${guildID} | Forcing session end`);
+                await session.endSession();
             }
         );
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,7 +5,6 @@ import { isMaster } from "cluster";
 import winston from "winston";
 import path from "path";
 import DailyRotateFile from "winston-daily-rotate-file";
-import { EnvType } from "./types";
 
 config({ path: resolve(__dirname, "../.env") });
 
@@ -35,7 +34,6 @@ export function getInternalLogger(): winston.Logger {
         transports: [
             new winston.transports.Console({
                 format: format.combine(format.timestamp(), consoleFormat),
-                silent: process.env.NODE_ENV === EnvType.TEST,
             }),
             new DailyRotateFile({
                 filename: path.join(__dirname, "../logs/error.log"),

--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -132,12 +132,6 @@ export default class GameRound extends Round {
     /** List of players who incorrectly guessed in the multiple choice */
     public incorrectMCGuessers: Set<string>;
 
-    /** Interactable components attached to this round's message */
-    public interactionComponents: Array<Eris.ActionRow>;
-
-    /** The message containing this round's interactable components */
-    public interactionMessage: Eris.Message<Eris.TextableChannel>;
-
     /** Info about the players that won this GameRound */
     public playerRoundResults: Array<PlayerRoundResult>;
 
@@ -171,7 +165,6 @@ export default class GameRound extends Round {
         this.interactionCorrectAnswerUUID = null;
         this.interactionIncorrectAnswerUUIDs = {};
         this.incorrectMCGuessers = new Set();
-        this.interactionComponents = [];
         this.interactionMessage = null;
         this.playerRoundResults = [];
         this.bonusModifier =
@@ -327,9 +320,9 @@ export default class GameRound extends Round {
 
     /**
      * @param interactionUUID - the UUID of an interaction
-     * @returns true if the given UUID is one of the guesses of the current game round
+     * @returns true if the given UUID is one of the interactions (i.e. guesses) of the current game round
      */
-    isValidInteractionGuess(interactionUUID: string): boolean {
+    isValidInteraction(interactionUUID: string): boolean {
         return (
             interactionUUID === this.interactionCorrectAnswerUUID ||
             Object.keys(this.interactionIncorrectAnswerUUIDs).includes(

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -585,6 +585,10 @@ export default class GameSession extends Session {
 
     /** Updates owner to the first player to join the game that didn't leave VC */
     updateOwner(): void {
+        if (this.finished) {
+            return;
+        }
+
         const voiceMembers = getCurrentVoiceMembers(this.voiceChannelID).filter(
             (x) => x.id !== process.env.BOT_CLIENT_ID
         );
@@ -687,9 +691,8 @@ export default class GameSession extends Session {
      * The game has changed its premium state, so update filtered songs/remove ,special
      */
     async updatePremiumStatus(): Promise<void> {
-        await this.reloadSongs(await getGuildPreference(this.guildID));
-
         const guildPreference = await getGuildPreference(this.guildID);
+        await this.reloadSongs(guildPreference);
         if (
             !this.isPremiumGame() &&
             this.guildID !== process.env.DEBUG_SERVER_ID &&

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -340,10 +340,10 @@ export default class GameSession extends Session {
                 this.songSelector.getUniqueSongCounter(guildPreference)
             );
 
-            // if message fails to send, no ID is returned
             round.roundMessageID = endRoundMessage?.id;
         }
 
+        this.updateBookmarkSongList();
         await super.endRound(guildPreference, messageContext);
 
         if (this.scoreboard.gameFinished(guildPreference)) {
@@ -616,16 +616,12 @@ export default class GameSession extends Session {
         interaction: Eris.ComponentInteraction,
         messageContext: MessageContext
     ): Promise<void> {
-        if (!this.round) {
-            return;
-        }
-
         if (
-            !getCurrentVoiceMembers(this.voiceChannelID)
-                .map((x) => x.id)
-                .includes(interaction.member.id)
+            !this.handleInSessionInteractionFailures(
+                interaction,
+                messageContext
+            )
         ) {
-            tryInteractionAcknowledge(interaction);
             return;
         }
 
@@ -635,17 +631,6 @@ export default class GameSession extends Session {
                 state.localizer.translate(
                     this.guildID,
                     "misc.failure.interaction.alreadyEliminated"
-                )
-            );
-            return;
-        }
-
-        if (!this.round.isValidInteractionGuess(interaction.data.custom_id)) {
-            tryCreateInteractionErrorAcknowledgement(
-                interaction,
-                state.localizer.translate(
-                    this.guildID,
-                    "misc.failure.interaction.optionFromPreviousRound"
                 )
             );
             return;

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -671,31 +671,10 @@ export default class GameSession extends Session {
     }
 
     /**
-     * The game has changed its premium state, so update filtered songs/remove ,special
+     * Whether the current game session has premium features
+     * @returns whether the session is premium
      */
-    async updatePremiumStatus(): Promise<void> {
-        const guildPreference = await getGuildPreference(this.guildID);
-        await this.reloadSongs(guildPreference);
-
-        if (!this.isPremiumGame()) {
-            for (const [commandName, command] of Object.entries(
-                state.client.commands
-            )) {
-                if (command.resetPremium) {
-                    logger.info(
-                        `gid: ${this.guildID} | Resetting premium for game option: ${commandName}`
-                    );
-                    await command.resetPremium(guildPreference);
-                }
-            }
-        }
-    }
-
-    /**
-     * Whether the current game has premium features
-     * @returns whether the game is premium
-     */
-    isPremiumGame(): boolean {
+    isPremium(): boolean {
         return this.scoreboard
             .getPlayers()
             .filter((x) => x.inVC)

--- a/src/structures/guild_preference.ts
+++ b/src/structures/guild_preference.ts
@@ -39,12 +39,12 @@ import {
     DEFAULT_MULTIGUESS_TYPE,
     MultiGuessType,
 } from "../commands/game_options/multiguess";
-import { state } from "../kmq_worker";
 import { SpecialType } from "../commands/game_options/special";
 import {
     AnswerType,
     DEFAULT_ANSWER_TYPE,
 } from "../commands/game_options/answer";
+import Session from "./session";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const logger = new IPCLogger("guild_preference");
@@ -899,9 +899,9 @@ export default class GuildPreference {
                 .merge()
                 .transacting(trx);
         });
-        const gameSession = state.gameSessions[this.guildID];
-        if (gameSession) {
-            await gameSession.reloadSongs(this);
+        const session = Session.getSession(this.guildID);
+        if (session) {
+            await session.reloadSongs(this);
         }
     }
 

--- a/src/structures/music_round.ts
+++ b/src/structures/music_round.ts
@@ -1,10 +1,19 @@
+import Eris from "eris";
 import { EMBED_SUCCESS_BONUS_COLOR } from "../helpers/discord_utils";
-import { PlayerRoundResult } from "../types";
+import { PlayerRoundResult, QueriedSong } from "../types";
 import MessageContext from "./message_context";
 import Round from "./round";
 import { UniqueSongCounter } from "./song_selector";
 
-export default class ListenRound extends Round {
+export default class MusicRound extends Round {
+    /** UUID associated with skip interaction custom_id */
+    public interactionSkipUUID: string;
+
+    constructor(song: QueriedSong) {
+        super(song);
+        this.interactionSkipUUID = null;
+    }
+
     getEndRoundDescription(
         messageContext: MessageContext,
         uniqueSongCounter: UniqueSongCounter,
@@ -22,5 +31,54 @@ export default class ListenRound extends Round {
         }
 
         return null;
+    }
+
+    /**
+     * @param interactionID - the custom_id of an interaction
+     * @returns true if the given UUID is one of the interactions (i.e. skip/bookmark) of the current game round
+     */
+    isValidInteraction(interactionID: string): boolean {
+        return (
+            interactionID === this.interactionSkipUUID ||
+            interactionID === "bookmark"
+        );
+    }
+
+    async interactionSuccessfulSkip(): Promise<void> {
+        if (!this.interactionMessage) return;
+        this.interactionComponents = this.interactionComponents.map((x) => ({
+            type: 1,
+            components: x.components.map((y: Eris.InteractionButton) => ({
+                label: y.label,
+                custom_id: y.custom_id,
+                style: y.custom_id === this.interactionSkipUUID ? 3 : y.style,
+                type: y.type,
+                disabled: y.custom_id === this.interactionSkipUUID,
+            })),
+        }));
+
+        await this.interactionMessage.edit({
+            embeds: this.interactionMessage.embeds,
+            components: this.interactionComponents,
+        });
+    }
+
+    async interactionMarkButtons(): Promise<void> {
+        if (!this.interactionMessage) return;
+        this.interactionComponents = this.interactionComponents.map((x) => ({
+            type: 1,
+            components: x.components.map((y: Eris.InteractionButton) => ({
+                label: y.label,
+                custom_id: y.custom_id,
+                style: y.style,
+                type: y.type,
+                disabled: y.custom_id === this.interactionSkipUUID,
+            })),
+        }));
+
+        await this.interactionMessage.edit({
+            embeds: this.interactionMessage.embeds,
+            components: this.interactionComponents,
+        });
     }
 }

--- a/src/structures/music_round.ts
+++ b/src/structures/music_round.ts
@@ -1,0 +1,26 @@
+import { EMBED_SUCCESS_BONUS_COLOR } from "../helpers/discord_utils";
+import { PlayerRoundResult } from "../types";
+import MessageContext from "./message_context";
+import Round from "./round";
+import { UniqueSongCounter } from "./song_selector";
+
+export default class ListenRound extends Round {
+    getEndRoundDescription(
+        messageContext: MessageContext,
+        uniqueSongCounter: UniqueSongCounter,
+        _playerRoundResults: Array<PlayerRoundResult>
+    ): string {
+        return this.getUniqueSongCounterMessage(
+            messageContext,
+            uniqueSongCounter
+        );
+    }
+
+    getEndRoundColor(_correctGuess: boolean, userBonusActive: boolean): number {
+        if (userBonusActive) {
+            return EMBED_SUCCESS_BONUS_COLOR;
+        }
+
+        return null;
+    }
+}

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -21,6 +21,11 @@ export default class MusicSession extends Session {
             (x) => x.id !== process.env.BOT_CLIENT_ID
         );
 
+        const voiceMemberIDs = new Set(voiceMembers.map((x) => x.id));
+        if (voiceMemberIDs.has(this.owner.id) || voiceMemberIDs.size === 0) {
+            return;
+        }
+
         this.owner = KmqMember.fromUser(chooseRandom(voiceMembers));
 
         super.updateOwner();

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -1,8 +1,12 @@
+import Eris from "eris";
 import { chooseRandom, delay } from "../helpers/utils";
 import { QueriedSong } from "../types";
 import {
     getCurrentVoiceMembers,
     sendRoundMessage,
+    tryCreateInteractionSuccessAcknowledgement,
+    getMajorityCount,
+    getDebugLogHeader,
 } from "../helpers/discord_utils";
 import KmqMember from "./kmq_member";
 import Round from "./round";
@@ -13,10 +17,26 @@ import MessageContext from "./message_context";
 import { GuessResult } from "./game_session";
 import { IPCLogger } from "../logger";
 import { isUserPremium } from "../helpers/game_utils";
+import { isSkipMajority, skipSong } from "../commands/game_commands/skip";
+import { state } from "../kmq_worker";
+import { getGuildPreference } from "../helpers/game_utils";
 
 const logger = new IPCLogger("music_session");
 
 export default class MusicSession extends Session {
+    /** The current MusicRound */
+    public round: MusicRound;
+
+    constructor(
+        textChannelID: string,
+        voiceChannelID: string,
+        guildID: string,
+        gameSessionCreator: KmqMember
+    ) {
+        super(textChannelID, voiceChannelID, guildID, gameSessionCreator);
+        this.round = null;
+    }
+
     updateOwner(): void {
         if (this.finished) {
             return;
@@ -56,7 +76,7 @@ export default class MusicSession extends Session {
             const remainingDuration =
                 this.getRemainingDuration(guildPreference);
 
-            const endRoundMessage = await sendRoundMessage(
+            const startRoundMessage = await sendRoundMessage(
                 messageContext,
                 null,
                 this,
@@ -66,8 +86,9 @@ export default class MusicSession extends Session {
                 this.songSelector.getUniqueSongCounter(guildPreference)
             );
 
-            // if message fails to send, no ID is returned
-            this.round.roundMessageID = endRoundMessage?.id;
+            this.round.interactionMessage = startRoundMessage;
+            this.round.roundMessageID = startRoundMessage?.id;
+            this.updateBookmarkSongList();
         }
     }
 
@@ -76,6 +97,7 @@ export default class MusicSession extends Session {
         messageContext?: MessageContext,
         guessResult?: GuessResult
     ): Promise<void> {
+        await this.round?.interactionMarkButtons();
         super.endRound(guildPreference, messageContext, guessResult);
     }
 
@@ -93,6 +115,73 @@ export default class MusicSession extends Session {
 
     getListeners(): number {
         return getCurrentVoiceMembers(this.voiceChannelID).length;
+    }
+
+    async handleButtonInteraction(
+        interaction: Eris.ComponentInteraction,
+        messageContext: MessageContext
+    ): Promise<void> {
+        if (
+            interaction.data.custom_id !== "bookmark" &&
+            !this.handleInSessionInteractionFailures(
+                interaction,
+                messageContext
+            )
+        ) {
+            return;
+        }
+
+        const guildID = interaction.guildID;
+        if (interaction.data.custom_id === "bookmark") {
+            this.handleBookmarkInteraction(interaction);
+        } else if (
+            interaction.data.custom_id === this.round.interactionSkipUUID
+        ) {
+            this.round.userSkipped(interaction.member.id);
+            if (isSkipMajority(guildID, this)) {
+                await this.round.interactionSuccessfulSkip();
+                await tryCreateInteractionSuccessAcknowledgement(
+                    interaction,
+                    state.localizer.translate(guildID, "misc.skip"),
+                    state.localizer.translate(
+                        guildID,
+                        "command.skip.success.description",
+                        {
+                            skipCounter: `${this.round.getSkipCount()}/${getMajorityCount(
+                                guildID
+                            )}`,
+                        }
+                    )
+                );
+
+                skipSong(
+                    messageContext,
+                    this,
+                    await getGuildPreference(guildID)
+                );
+            } else {
+                tryCreateInteractionSuccessAcknowledgement(
+                    interaction,
+                    state.localizer.translate(
+                        guildID,
+                        "command.skip.vote.title"
+                    ),
+                    state.localizer.translate(
+                        guildID,
+                        "command.skip.vote.description",
+                        {
+                            skipCounter: `${this.round.getSkipCount()}/${getMajorityCount(
+                                guildID
+                            )}`,
+                        }
+                    )
+                );
+
+                logger.info(
+                    `${getDebugLogHeader(messageContext)} | Skip vote received.`
+                );
+            }
+        }
     }
 
     /**

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -185,16 +185,13 @@ export default class MusicSession extends Session {
     }
 
     /**
-     * At least one premium member required to use a music session
+     * Whether the current music session has premium features
+     * @returns whether the session is premium
      */
-    verifyPremium(): void {
-        if (
-            !getCurrentVoiceMembers(this.voiceChannelID).some((x) =>
-                isUserPremium(x.id)
-            )
-        ) {
-            this.endSession();
-        }
+    isPremium(): boolean {
+        return getCurrentVoiceMembers(this.voiceChannelID).some((x) =>
+            isUserPremium(x.id)
+        );
     }
 
     /**

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -1,0 +1,96 @@
+import { chooseRandom, delay } from "../helpers/utils";
+import { QueriedSong } from "../types";
+import {
+    getCurrentVoiceMembers,
+    sendRoundMessage,
+} from "../helpers/discord_utils";
+import KmqMember from "./kmq_member";
+import Round from "./round";
+import Session, { SONG_START_DELAY } from "./session";
+import MusicRound from "./music_round";
+import GuildPreference from "./guild_preference";
+import MessageContext from "./message_context";
+import { GuessResult } from "./game_session";
+import { IPCLogger } from "../logger";
+
+const logger = new IPCLogger("music_session");
+
+export default class MusicSession extends Session {
+    updateOwner(): void {
+        const voiceMembers = getCurrentVoiceMembers(this.voiceChannelID).filter(
+            (x) => x.id !== process.env.BOT_CLIENT_ID
+        );
+
+        this.owner = KmqMember.fromUser(chooseRandom(voiceMembers));
+
+        super.updateOwner();
+    }
+
+    /**
+     * Starting a new MusicRound
+     * @param guildPreference - The guild's GuildPreference
+     * @param messageContext - An object containing relevant parts of Eris.Message
+     */
+    async startRound(
+        guildPreference: GuildPreference,
+        messageContext: MessageContext
+    ): Promise<void> {
+        await delay(SONG_START_DELAY);
+        if (this.finished || this.round) {
+            return;
+        }
+
+        await super.startRound(guildPreference, messageContext);
+
+        if (messageContext) {
+            const remainingDuration =
+                this.getRemainingDuration(guildPreference);
+
+            const endRoundMessage = await sendRoundMessage(
+                messageContext,
+                null,
+                this,
+                guildPreference.gameOptions.guessModeType,
+                guildPreference.isMultipleChoiceMode(),
+                remainingDuration,
+                this.songSelector.getUniqueSongCounter(guildPreference)
+            );
+
+            // if message fails to send, no ID is returned
+            this.round.roundMessageID = endRoundMessage?.id;
+        }
+    }
+
+    async endRound(
+        guildPreference: GuildPreference,
+        messageContext?: MessageContext,
+        guessResult?: GuessResult
+    ): Promise<void> {
+        super.endRound(guildPreference, messageContext, guessResult);
+    }
+
+    async endSession(): Promise<void> {
+        if (this.finished) {
+            return;
+        }
+
+        this.finished = true;
+        logger.info(
+            `gid: ${this.guildID} | Music session ended. rounds_played = ${this.roundsPlayed}`
+        );
+        super.endSession();
+    }
+
+    getListeners(): number {
+        return getCurrentVoiceMembers(this.voiceChannelID).length;
+    }
+
+    /**
+     * Prepares a new GameRound
+     * @param randomSong - The queried song
+     * @returns the new GameRound
+     */
+    protected prepareRound(randomSong: QueriedSong): Round {
+        return new MusicRound(randomSong);
+    }
+}

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -113,10 +113,6 @@ export default class MusicSession extends Session {
         super.endSession();
     }
 
-    getListeners(): number {
-        return getCurrentVoiceMembers(this.voiceChannelID).length;
-    }
-
     async handleButtonInteraction(
         interaction: Eris.ComponentInteraction,
         messageContext: MessageContext

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -12,11 +12,16 @@ import GuildPreference from "./guild_preference";
 import MessageContext from "./message_context";
 import { GuessResult } from "./game_session";
 import { IPCLogger } from "../logger";
+import { isUserPremium } from "../helpers/game_utils";
 
 const logger = new IPCLogger("music_session");
 
 export default class MusicSession extends Session {
     updateOwner(): void {
+        if (this.finished) {
+            return;
+        }
+
         const voiceMembers = getCurrentVoiceMembers(this.voiceChannelID).filter(
             (x) => x.id !== process.env.BOT_CLIENT_ID
         );
@@ -88,6 +93,19 @@ export default class MusicSession extends Session {
 
     getListeners(): number {
         return getCurrentVoiceMembers(this.voiceChannelID).length;
+    }
+
+    /**
+     * At least one premium member required to use a music session
+     */
+    verifyPremium(): void {
+        if (
+            !getCurrentVoiceMembers(this.voiceChannelID).some((x) =>
+                isUserPremium(x.id)
+            )
+        ) {
+            this.endSession();
+        }
     }
 
     /**

--- a/src/structures/round.ts
+++ b/src/structures/round.ts
@@ -1,3 +1,4 @@
+import Eris from "eris";
 import { PlayerRoundResult, QueriedSong } from "../types";
 import { state } from "../kmq_worker";
 import { UniqueSongCounter } from "./song_selector";
@@ -35,6 +36,12 @@ export default abstract class Round {
     /** Whether the Round has been skipped */
     public skipAchieved: boolean;
 
+    /** Interactable components attached to this round's message */
+    public interactionComponents: Array<Eris.ActionRow>;
+
+    /** The message containing this round's interactable components */
+    public interactionMessage: Eris.Message<Eris.TextableChannel>;
+
     constructor(song: QueriedSong) {
         this.song = song;
         this.songAliases = state.aliases.song[song.youtubeLink] || [];
@@ -46,6 +53,7 @@ export default abstract class Round {
         this.roundMessageID = null;
         this.skippers = new Set();
         this.skipAchieved = false;
+        this.interactionComponents = [];
     }
 
     abstract getEndRoundDescription(
@@ -53,10 +61,13 @@ export default abstract class Round {
         uniqueSongCounter: UniqueSongCounter,
         playerRoundResults: Array<PlayerRoundResult>
     ): string;
+
     abstract getEndRoundColor(
         correctGuess: boolean,
         userBonusActive: boolean
     ): number;
+
+    abstract isValidInteraction(interactionUUID: string): boolean;
 
     /**
      * Adds a skip vote for the specified user

--- a/src/structures/round.ts
+++ b/src/structures/round.ts
@@ -27,7 +27,7 @@ export default abstract class Round {
     public finished: boolean;
 
     /**  The Discord ID of the end round message */
-    public endRoundMessageID: string;
+    public roundMessageID: string;
 
     /** List of players who have opted to skip the current Round */
     public skippers: Set<string>;
@@ -43,7 +43,7 @@ export default abstract class Round {
             (x) => state.aliases.artist[x] || []
         );
         this.startedAt = Date.now();
-        this.endRoundMessageID = null;
+        this.roundMessageID = null;
         this.skippers = new Set();
         this.skipAchieved = false;
     }

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -364,7 +364,11 @@ export default abstract class Session {
         messageContext: MessageContext,
         guildPreference: GuildPreference
     ): Promise<void> {
-        if (!guildPreference.isGuessTimeoutSet()) return;
+        if (
+            this instanceof MusicSession ||
+            !guildPreference.isGuessTimeoutSet()
+        )
+            return;
 
         const time = guildPreference.gameOptions.guessTimeout;
         this.guessTimeoutFunc = setTimeout(async () => {
@@ -574,7 +578,11 @@ export default abstract class Session {
         try {
             let inputArgs = ["-ss", seekLocation.toString()];
             let encoderArgs = [];
-            const specialType = guildPreference.gameOptions.specialType;
+            const specialType =
+                this instanceof MusicSession
+                    ? null
+                    : guildPreference.gameOptions.specialType;
+
             if (specialType) {
                 const ffmpegArgs = specialFfmpegArgs[specialType](seekLocation);
                 inputArgs = ffmpegArgs.inputArgs;

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -432,7 +432,9 @@ export default abstract class Session {
     async reloadSongs(guildPreference: GuildPreference): Promise<void> {
         const session = Session.getSession(guildPreference.guildID);
         if (!session) {
-            return;
+            throw new Error(
+                `Session doesn't exist for guild ID: ${guildPreference.guildID}`
+            );
         }
 
         await this.songSelector.reloadSongs(

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -13,7 +13,7 @@ import {
 } from "../helpers/discord_utils";
 import dbContext from "../database_context";
 import { QueriedSong } from "../types";
-import { GuessResult } from "./game_session";
+import GameSession, { GuessResult } from "./game_session";
 import GuildPreference from "./guild_preference";
 import KmqMember from "./kmq_member";
 import MessageContext from "./message_context";
@@ -411,9 +411,15 @@ export default abstract class Session {
     }
 
     async reloadSongs(guildPreference: GuildPreference): Promise<void> {
+        const session = Session.getSession(guildPreference.guildID);
+        if (!session) {
+            return;
+        }
+
         await this.songSelector.reloadSongs(
             guildPreference,
-            state.gameSessions[this.guildID]?.isPremiumGame() ?? false
+            session instanceof MusicSession ||
+                (session instanceof GameSession && session.isPremiumGame())
         );
     }
 

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -30,6 +30,7 @@ import { KmqImages } from "../constants";
 import { bold, friendlyFormattedNumber } from "../helpers/utils";
 import { SeekType } from "../commands/game_options/seek";
 import { specialFfmpegArgs } from "../commands/game_options/special";
+import MusicSession from "./music_session";
 
 export const SONG_START_DELAY = 3000;
 const BOOKMARK_MESSAGE_SIZE = 10;
@@ -536,7 +537,11 @@ export default abstract class Session {
         const songLocation = `${process.env.SONG_DOWNLOAD_DIR}/${round.song.youtubeLink}.ogg`;
 
         let seekLocation: number;
-        const seekType = guildPreference.gameOptions.seekType;
+        const seekType =
+            this instanceof MusicSession
+                ? SeekType.BEGINNING
+                : guildPreference.gameOptions.seekType;
+
         if (seekType === SeekType.BEGINNING) {
             seekLocation = 0;
         } else {

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -139,7 +139,7 @@ export default class SongSelector {
         filteredSongs: Set<QueriedSong>,
         ignoredSongs?: Set<string>,
         alternatingGender?: Gender,
-        shuffleType?: ShuffleType
+        shuffleType = ShuffleType.RANDOM
     ): QueriedSong {
         let queriedSongList = [...filteredSongs];
         if (ignoredSongs) {

--- a/src/test/ci/game_session.test.ts
+++ b/src/test/ci/game_session.test.ts
@@ -10,6 +10,7 @@ import * as game_utils from "../../helpers/game_utils";
 import * as utils from "../../helpers/utils";
 import Eris, { Collection } from "eris";
 import KmqClient from "../../kmq_client";
+import Session from "../../structures/session";
 
 describe("startRound", function () {
     let gameSession: GameSession;
@@ -38,6 +39,7 @@ describe("startRound", function () {
             GameType.CLASSIC
         );
 
+        sandbox.stub(Session, "getSession").callsFake(() => gameSession);
         prepareRoundSpy = sinon.spy(gameSession, <any>"prepareRound");
         playSongSpy = sinon.stub(gameSession, <any>"playSong");
         ensureVoiceConnectionSpy = sinon.spy(

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import RateLimiter from "./rate_limiter";
 import LocalizationManager, {
     LocaleType,
 } from "./helpers/localization_manager";
+import MusicSession from "./structures/music_session";
 
 export type GuildTextableMessage = Eris.Message<GuildTextableChannel>;
 
@@ -67,6 +68,7 @@ export interface GameInfoMessage {
 
 export interface State {
     gameSessions: { [guildID: string]: GameSession };
+    musicSessions: { [guildID: string]: MusicSession };
     client: KmqClient;
     aliases: {
         artist: { [artistName: string]: Array<string> };


### PR DESCRIPTION
I separated some logic out of GameSession into a new class, Session. The new MusicSession class inherits from Session. Commands no longer receive gameSessions passed as an argument. Accessing a session should be done with `Session.getSession()` instead of accessing state directly.

The music command is pretty barebones right now. The only obvious frontend change is that it sends the round message at the start of the round instead of at the end. I'd like to add a ~~text-based duration slider that auto-updates the song message every 5 seconds~~ command to the song's progress. I'd also like to add a skip button and a bookmark button. The options message should also be updated to ~~only show relevant options when a music session is active~~ cross out irrelevant options, and seek should be automatically forced to beginning.