### PR TITLE
Add skip and bookmark buttons in music session

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -873,8 +873,7 @@
                 "description": "Vote to skip the current song. A song is skipped when majority of participants vote to skip it."
             },
             "success": {
-                "description": "{{skipCounter}} skips achieved, skipping...",
-                "title": "Skip"
+                "description": "{{skipCounter}} skips achieved, skipping..."
             },
             "vote": {
                 "description": "{{skipCounter}} skip requests received.",
@@ -1013,6 +1012,7 @@
         "andManyOthers": "and many others...",
         "artist": "artist",
         "artistAliases": "Artist Aliases",
+        "bookmark": "Bookmark",
         "classic": {
             "yourScore": "Your score is {{score}}."
         },
@@ -1252,6 +1252,7 @@
             "description": "Sending {{songs}} to {{players}}.\n\nBookmark songs during the game by right-clicking the song message and selecting `Apps > Bookmark Song`",
             "title": "Sending Bookmarked Songs..."
         },
+        "skip": "Skip",
         "song": "song",
         "songAliases": "Song Aliases",
         "team": {

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -873,8 +873,7 @@
                 "description": "현재 노래를 건너뛰려면 투표하세요. (대다수의 참가자가 건너뛰기로 투표하면 노래를 건너뜁니다.)"
             },
             "success": {
-                "description": "{{skipCounter}} 건너뛰기 요청이 수락되었습니다!",
-                "title": "건너뛰기"
+                "description": "{{skipCounter}} 건너뛰기 요청이 수락되었습니다!"
             },
             "vote": {
                 "description": "{{skipCounter}} 건너뛰기가 요청되었습니다!",
@@ -1013,6 +1012,7 @@
         "andManyOthers": "그리고 많은 다른 사람들...",
         "artist": "아티스트",
         "artistAliases": "아티스트 별칭",
+        "bookmark": "북마크",
         "classic": {
             "yourScore": "당신의 점수는 {{score}}점 입니다."
         },
@@ -1252,6 +1252,7 @@
             "description": "{{players}}에게 {{songs}}을(를) 보냅니다.\n\n노래 메시지를 마우스 오른쪽 버튼으로 클릭하고 `앱 > Bookmark Song`를 선택하여 게임 중에 노래를 북마크하세요.",
             "title": "북마크된 노래를 보내는 중..."
         },
+        "skip": "건너뛰기",
         "song": "노래",
         "songAliases": "노래 별칭",
         "team": {

--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -77,10 +77,7 @@ export default class ForceSkipCommand implements BaseCommand {
             MessageContext.fromMessage(message),
             {
                 color: EMBED_SUCCESS_COLOR,
-                title: state.localizer.translate(
-                    message.guildID,
-                    "misc.skip"
-                ),
+                title: state.localizer.translate(message.guildID, "misc.skip"),
                 description: state.localizer.translate(
                     message.guildID,
                     "command.forceskip.description"

--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -79,7 +79,7 @@ export default class ForceSkipCommand implements BaseCommand {
                 color: EMBED_SUCCESS_COLOR,
                 title: state.localizer.translate(
                     message.guildID,
-                    "command.skip.success.title"
+                    "misc.skip"
                 ),
                 description: state.localizer.translate(
                     message.guildID,

--- a/src/events/client/interactionCreate.ts
+++ b/src/events/client/interactionCreate.ts
@@ -71,8 +71,8 @@ export default async function interactionCreateHandler(
             Eris.Constants.ApplicationCommandTypes.MESSAGE
         ) {
             if (interaction.data.name === BOOKMARK_COMMAND_NAME) {
-                const gameSession = state.gameSessions[interaction.guildID];
-                if (!gameSession) {
+                const session = Session.getSession(interaction.guildID);
+                if (!session) {
                     tryCreateInteractionErrorAcknowledgement(
                         interaction,
                         state.localizer.translate(
@@ -83,7 +83,7 @@ export default async function interactionCreateHandler(
                     return;
                 }
 
-                gameSession.handleBookmarkInteraction(interaction);
+                session.handleBookmarkInteraction(interaction);
             } else if (interaction.data.name === PROFILE_COMMAND_NAME) {
                 const messageId = interaction.data.target_id;
                 const authorId =

--- a/src/events/client/interactionCreate.ts
+++ b/src/events/client/interactionCreate.ts
@@ -8,6 +8,9 @@ import {
 } from "../../helpers/discord_utils";
 import { state } from "../../kmq_worker";
 import { handleProfileInteraction } from "../../commands/game_commands/profile";
+import Session from "../../structures/session";
+import GameSession from "../../structures/game_session";
+import MusicSession from "../../structures/music_session";
 
 export const BOOKMARK_COMMAND_NAME = "Bookmark Song";
 export const PROFILE_COMMAND_NAME = "Profile";
@@ -24,8 +27,11 @@ export default async function interactionCreateHandler(
         | Eris.UnknownInteraction
 ): Promise<void> {
     if (interaction instanceof Eris.ComponentInteraction) {
-        const gameSession = state.gameSessions[interaction.guildID];
-        if (!gameSession || !gameSession.round) {
+        const session = Session.getSession(interaction.guildID);
+        if (
+            !session ||
+            (!session.round && interaction.data.custom_id !== "bookmark")
+        ) {
             tryInteractionAcknowledge(interaction);
             return;
         }
@@ -41,10 +47,14 @@ export default async function interactionCreateHandler(
             interaction.guildID
         );
 
-        gameSession.handleMultipleChoiceInteraction(
-            interaction,
-            messageContext
-        );
+        if (session instanceof GameSession) {
+            session.handleMultipleChoiceInteraction(
+                interaction,
+                messageContext
+            );
+        } else if (session instanceof MusicSession) {
+            await session.handleButtonInteraction(interaction, messageContext);
+        }
     } else if (interaction instanceof Eris.CommandInteraction) {
         if (
             interaction.data.type ===

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -2,6 +2,7 @@
 import Eris from "eris";
 import EmbedPaginator from "eris-pagination";
 import axios from "axios";
+import * as uuid from "uuid";
 import GuildPreference, { GameOptions } from "../structures/guild_preference";
 import GameSession from "../structures/game_session";
 import { IPCLogger } from "../logger";
@@ -52,6 +53,7 @@ import { LocaleType, DEFAULT_LOCALE } from "./localization_manager";
 import Round from "../structures/round";
 import Session from "../structures/session";
 import MusicSession from "../structures/music_session";
+import MusicRound from "../structures/music_round";
 
 const logger = new IPCLogger("discord_utils");
 export const EMBED_ERROR_COLOR = 0xed4245; // Red
@@ -822,6 +824,33 @@ export async function sendRoundMessage(
             await round.interactionMessage.edit({ embeds: [embed as Object] });
             return round.interactionMessage;
         }
+    }
+
+    if (round instanceof MusicRound) {
+        const buttons: Array<Eris.InteractionButton> = [];
+        round.interactionSkipUUID = uuid.v4();
+        buttons.push({
+            type: 2,
+            style: 1,
+            label: state.localizer.translate(
+                messageContext.guildID,
+                "misc.skip"
+            ),
+            custom_id: round.interactionSkipUUID,
+        });
+
+        buttons.push({
+            type: 2,
+            style: 1,
+            label: state.localizer.translate(
+                messageContext.guildID,
+                "misc.bookmark"
+            ),
+            custom_id: "bookmark",
+        });
+
+        round.interactionComponents = [{ type: 1, components: buttons }];
+        embed.components = round.interactionComponents;
     }
 
     embed.thumbnailUrl = thumbnailUrl;

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -15,7 +15,7 @@ import { PATREON_SUPPORTER_BADGE, Patron } from "./patreon_manager";
 import { containsHangul, md5Hash } from "./utils";
 import Session from "../structures/session";
 
-const GAME_SESSION_INACTIVE_THRESHOLD = 30;
+const GAME_SESSION_INACTIVE_THRESHOLD = 10;
 
 const logger = new IPCLogger("game_utils");
 

--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -132,12 +132,6 @@ export default class GameRound extends Round {
     /** List of players who incorrectly guessed in the multiple choice */
     public incorrectMCGuessers: Set<string>;
 
-    /** Interactable components attached to this round's message */
-    public interactionComponents: Array<Eris.ActionRow>;
-
-    /** The message containing this round's interactable components */
-    public interactionMessage: Eris.Message<Eris.TextableChannel>;
-
     /** Info about the players that won this GameRound */
     public playerRoundResults: Array<PlayerRoundResult>;
 
@@ -171,7 +165,6 @@ export default class GameRound extends Round {
         this.interactionCorrectAnswerUUID = null;
         this.interactionIncorrectAnswerUUIDs = {};
         this.incorrectMCGuessers = new Set();
-        this.interactionComponents = [];
         this.interactionMessage = null;
         this.playerRoundResults = [];
         this.bonusModifier =
@@ -327,9 +320,9 @@ export default class GameRound extends Round {
 
     /**
      * @param interactionUUID - the UUID of an interaction
-     * @returns true if the given UUID is one of the guesses of the current game round
+     * @returns true if the given UUID is one of the interactions (i.e. guesses) of the current game round
      */
-    isValidInteractionGuess(interactionUUID: string): boolean {
+    isValidInteraction(interactionUUID: string): boolean {
         return (
             interactionUUID === this.interactionCorrectAnswerUUID ||
             Object.keys(this.interactionIncorrectAnswerUUIDs).includes(

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -340,10 +340,10 @@ export default class GameSession extends Session {
                 this.songSelector.getUniqueSongCounter(guildPreference)
             );
 
-            // if message fails to send, no ID is returned
             round.roundMessageID = endRoundMessage?.id;
         }
 
+        this.updateBookmarkSongList();
         await super.endRound(guildPreference, messageContext);
 
         if (this.scoreboard.gameFinished(guildPreference)) {
@@ -616,16 +616,12 @@ export default class GameSession extends Session {
         interaction: Eris.ComponentInteraction,
         messageContext: MessageContext
     ): Promise<void> {
-        if (!this.round) {
-            return;
-        }
-
         if (
-            !getCurrentVoiceMembers(this.voiceChannelID)
-                .map((x) => x.id)
-                .includes(interaction.member.id)
+            !this.handleInSessionInteractionFailures(
+                interaction,
+                messageContext
+            )
         ) {
-            tryInteractionAcknowledge(interaction);
             return;
         }
 
@@ -635,17 +631,6 @@ export default class GameSession extends Session {
                 state.localizer.translate(
                     this.guildID,
                     "misc.failure.interaction.alreadyEliminated"
-                )
-            );
-            return;
-        }
-
-        if (!this.round.isValidInteractionGuess(interaction.data.custom_id)) {
-            tryCreateInteractionErrorAcknowledgement(
-                interaction,
-                state.localizer.translate(
-                    this.guildID,
-                    "misc.failure.interaction.optionFromPreviousRound"
                 )
             );
             return;

--- a/src/structures/music_round.ts
+++ b/src/structures/music_round.ts
@@ -1,10 +1,19 @@
+import Eris from "eris";
 import { EMBED_SUCCESS_BONUS_COLOR } from "../helpers/discord_utils";
-import { PlayerRoundResult } from "../types";
+import { PlayerRoundResult, QueriedSong } from "../types";
 import MessageContext from "./message_context";
 import Round from "./round";
 import { UniqueSongCounter } from "./song_selector";
 
-export default class ListenRound extends Round {
+export default class MusicRound extends Round {
+    /** UUID associated with skip interaction custom_id */
+    public interactionSkipUUID: string;
+
+    constructor(song: QueriedSong) {
+        super(song);
+        this.interactionSkipUUID = null;
+    }
+
     getEndRoundDescription(
         messageContext: MessageContext,
         uniqueSongCounter: UniqueSongCounter,
@@ -22,5 +31,54 @@ export default class ListenRound extends Round {
         }
 
         return null;
+    }
+
+    /**
+     * @param interactionID - the custom_id of an interaction
+     * @returns true if the given UUID is one of the interactions (i.e. skip/bookmark) of the current game round
+     */
+    isValidInteraction(interactionID: string): boolean {
+        return (
+            interactionID === this.interactionSkipUUID ||
+            interactionID === "bookmark"
+        );
+    }
+
+    async interactionSuccessfulSkip(): Promise<void> {
+        if (!this.interactionMessage) return;
+        this.interactionComponents = this.interactionComponents.map((x) => ({
+            type: 1,
+            components: x.components.map((y: Eris.InteractionButton) => ({
+                label: y.label,
+                custom_id: y.custom_id,
+                style: y.custom_id === this.interactionSkipUUID ? 3 : y.style,
+                type: y.type,
+                disabled: y.custom_id === this.interactionSkipUUID,
+            })),
+        }));
+
+        await this.interactionMessage.edit({
+            embeds: this.interactionMessage.embeds,
+            components: this.interactionComponents,
+        });
+    }
+
+    async interactionMarkButtons(): Promise<void> {
+        if (!this.interactionMessage) return;
+        this.interactionComponents = this.interactionComponents.map((x) => ({
+            type: 1,
+            components: x.components.map((y: Eris.InteractionButton) => ({
+                label: y.label,
+                custom_id: y.custom_id,
+                style: y.style,
+                type: y.type,
+                disabled: y.custom_id === this.interactionSkipUUID,
+            })),
+        }));
+
+        await this.interactionMessage.edit({
+            embeds: this.interactionMessage.embeds,
+            components: this.interactionComponents,
+        });
     }
 }

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -168,7 +168,12 @@ export default class MusicSession extends Session {
                     ),
                     state.localizer.translate(
                         guildID,
-                        "command.skip.vote.description"
+                        "command.skip.vote.description",
+                        {
+                            skipCounter: `${this.round.getSkipCount()}/${getMajorityCount(
+                                guildID
+                            )}`,
+                        }
                     )
                 );
 

--- a/src/structures/music_session.ts
+++ b/src/structures/music_session.ts
@@ -1,8 +1,12 @@
+import Eris from "eris";
 import { chooseRandom, delay } from "../helpers/utils";
 import { QueriedSong } from "../types";
 import {
     getCurrentVoiceMembers,
     sendRoundMessage,
+    tryCreateInteractionSuccessAcknowledgement,
+    getMajorityCount,
+    getDebugLogHeader,
 } from "../helpers/discord_utils";
 import KmqMember from "./kmq_member";
 import Round from "./round";
@@ -13,10 +17,26 @@ import MessageContext from "./message_context";
 import { GuessResult } from "./game_session";
 import { IPCLogger } from "../logger";
 import { isUserPremium } from "../helpers/game_utils";
+import { isSkipMajority, skipSong } from "../commands/game_commands/skip";
+import { state } from "../kmq_worker";
+import { getGuildPreference } from "../helpers/game_utils";
 
 const logger = new IPCLogger("music_session");
 
 export default class MusicSession extends Session {
+    /** The current MusicRound */
+    public round: MusicRound;
+
+    constructor(
+        textChannelID: string,
+        voiceChannelID: string,
+        guildID: string,
+        gameSessionCreator: KmqMember
+    ) {
+        super(textChannelID, voiceChannelID, guildID, gameSessionCreator);
+        this.round = null;
+    }
+
     updateOwner(): void {
         if (this.finished) {
             return;
@@ -56,7 +76,7 @@ export default class MusicSession extends Session {
             const remainingDuration =
                 this.getRemainingDuration(guildPreference);
 
-            const endRoundMessage = await sendRoundMessage(
+            const startRoundMessage = await sendRoundMessage(
                 messageContext,
                 null,
                 this,
@@ -66,8 +86,9 @@ export default class MusicSession extends Session {
                 this.songSelector.getUniqueSongCounter(guildPreference)
             );
 
-            // if message fails to send, no ID is returned
-            this.round.roundMessageID = endRoundMessage?.id;
+            this.round.interactionMessage = startRoundMessage;
+            this.round.roundMessageID = startRoundMessage?.id;
+            this.updateBookmarkSongList();
         }
     }
 
@@ -76,6 +97,7 @@ export default class MusicSession extends Session {
         messageContext?: MessageContext,
         guessResult?: GuessResult
     ): Promise<void> {
+        await this.round?.interactionMarkButtons();
         super.endRound(guildPreference, messageContext, guessResult);
     }
 
@@ -93,6 +115,68 @@ export default class MusicSession extends Session {
 
     getListeners(): number {
         return getCurrentVoiceMembers(this.voiceChannelID).length;
+    }
+
+    async handleButtonInteraction(
+        interaction: Eris.ComponentInteraction,
+        messageContext: MessageContext
+    ): Promise<void> {
+        if (
+            interaction.data.custom_id !== "bookmark" &&
+            !this.handleInSessionInteractionFailures(
+                interaction,
+                messageContext
+            )
+        ) {
+            return;
+        }
+
+        const guildID = interaction.guildID;
+        if (interaction.data.custom_id === "bookmark") {
+            this.handleBookmarkInteraction(interaction);
+        } else if (
+            interaction.data.custom_id === this.round.interactionSkipUUID
+        ) {
+            this.round.userSkipped(interaction.member.id);
+            if (isSkipMajority(guildID, this)) {
+                await this.round.interactionSuccessfulSkip();
+                await tryCreateInteractionSuccessAcknowledgement(
+                    interaction,
+                    state.localizer.translate(guildID, "misc.skip"),
+                    state.localizer.translate(
+                        guildID,
+                        "command.skip.success.description",
+                        {
+                            skipCounter: `${this.round.getSkipCount()}/${getMajorityCount(
+                                guildID
+                            )}`,
+                        }
+                    )
+                );
+
+                skipSong(
+                    messageContext,
+                    this,
+                    await getGuildPreference(guildID)
+                );
+            } else {
+                tryCreateInteractionSuccessAcknowledgement(
+                    interaction,
+                    state.localizer.translate(
+                        guildID,
+                        "command.skip.vote.title"
+                    ),
+                    state.localizer.translate(
+                        guildID,
+                        "command.skip.vote.description"
+                    )
+                );
+
+                logger.info(
+                    `${getDebugLogHeader(messageContext)} | Skip vote received.`
+                );
+            }
+        }
     }
 
     /**

--- a/src/structures/round.ts
+++ b/src/structures/round.ts
@@ -1,3 +1,4 @@
+import Eris from "eris";
 import { PlayerRoundResult, QueriedSong } from "../types";
 import { state } from "../kmq_worker";
 import { UniqueSongCounter } from "./song_selector";
@@ -35,6 +36,12 @@ export default abstract class Round {
     /** Whether the Round has been skipped */
     public skipAchieved: boolean;
 
+    /** Interactable components attached to this round's message */
+    public interactionComponents: Array<Eris.ActionRow>;
+
+    /** The message containing this round's interactable components */
+    public interactionMessage: Eris.Message<Eris.TextableChannel>;
+
     constructor(song: QueriedSong) {
         this.song = song;
         this.songAliases = state.aliases.song[song.youtubeLink] || [];
@@ -46,6 +53,7 @@ export default abstract class Round {
         this.roundMessageID = null;
         this.skippers = new Set();
         this.skipAchieved = false;
+        this.interactionComponents = [];
     }
 
     abstract getEndRoundDescription(
@@ -53,10 +61,13 @@ export default abstract class Round {
         uniqueSongCounter: UniqueSongCounter,
         playerRoundResults: Array<PlayerRoundResult>
     ): string;
+
     abstract getEndRoundColor(
         correctGuess: boolean,
         userBonusActive: boolean
     ): number;
+
+    abstract isValidInteraction(interactionUUID: string): boolean;
 
     /**
      * Adds a skip vote for the specified user


### PR DESCRIPTION
Two interactable buttons that appear only in the music session. Shows ephemeral messages as a response to both. When the majority skip count is achieved, the skip button is disabled and turned green and the round is skipped. The bookmark button never gets disabled