### PR TITLE
Cyclic dependency cleanup: Refactor Session to use cached GuildPreference reference

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,7 @@
             "warn"
         ],
         "import/no-cycle": [
-            "off"
+            "warn"
         ],
         "@typescript-eslint/consistent-type-imports": ["warn"],
         "jsdoc/require-jsdoc": [

--- a/src/commands/game_commands/begin.ts
+++ b/src/commands/game_commands/begin.ts
@@ -83,7 +83,7 @@ export default class BeginCommand implements BaseCommand {
                 guildPreference
             );
 
-            gameSession.startRound(guildPreference, messageContext);
+            gameSession.startRound(messageContext);
 
             logger.info(
                 `${getDebugLogHeader(message)} | Teams game session starting)`

--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -14,7 +14,6 @@ import type CommandArgs from "../../interfaces/command_args";
 import type HelpDocumentation from "../../interfaces/help";
 import LocalizationManager from "../../helpers/localization_manager";
 import { getMention } from "../../helpers/utils";
-import GuildPreference from "../../structures/guild_preference";
 
 const logger = new IPCLogger("forceskip");
 
@@ -46,10 +45,6 @@ export default class ForceSkipCommand implements BaseCommand {
             );
             return;
         }
-
-        const guildPreference = await GuildPreference.getGuildPreference(
-            message.guildID
-        );
 
         const session = Session.getSession(message.guildID);
         if (
@@ -93,16 +88,11 @@ export default class ForceSkipCommand implements BaseCommand {
             true
         );
 
-        await session.endRound(
-            guildPreference,
-            MessageContext.fromMessage(message),
-            { correct: false }
-        );
+        await session.endRound(MessageContext.fromMessage(message), {
+            correct: false,
+        });
 
-        await session.startRound(
-            guildPreference,
-            MessageContext.fromMessage(message)
-        );
+        await session.startRound(MessageContext.fromMessage(message));
         session.lastActiveNow();
         logger.info(`${getDebugLogHeader(message)} | Owner force-skipped.`);
     };

--- a/src/commands/game_commands/music.ts
+++ b/src/commands/game_commands/music.ts
@@ -184,6 +184,7 @@ export default class MusicCommand implements BaseCommand {
         }
 
         const musicSession = new MusicSession(
+            guildPreference,
             textChannel.id,
             voiceChannel.id,
             guildID,
@@ -198,6 +199,6 @@ export default class MusicCommand implements BaseCommand {
             guildPreference
         );
 
-        musicSession.startRound(guildPreference, messageContext);
+        musicSession.startRound(messageContext);
     };
 }

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -381,6 +381,7 @@ export default class PlayCommand implements BaseCommand {
             );
 
             gameSession = new GameSession(
+                guildPreference,
                 textChannel.id,
                 voiceChannel.id,
                 textChannel.guild.id,
@@ -480,6 +481,7 @@ export default class PlayCommand implements BaseCommand {
             }
 
             gameSession = new GameSession(
+                guildPreference,
                 textChannel.id,
                 voiceChannel.id,
                 textChannel.guild.id,
@@ -505,7 +507,7 @@ export default class PlayCommand implements BaseCommand {
                 guildPreference
             );
 
-            await gameSession.startRound(guildPreference, messageContext);
+            await gameSession.startRound(messageContext);
         }
     };
 }

--- a/src/commands/game_commands/skip.ts
+++ b/src/commands/game_commands/skip.ts
@@ -13,7 +13,6 @@ import CommandPrechecks from "../../command_prechecks";
 import type EliminationScoreboard from "../../structures/elimination_scoreboard";
 import type Round from "../../structures/round";
 import Session from "../../structures/session";
-import GuildPreference from "../../structures/guild_preference";
 import type CommandArgs from "../../interfaces/command_args";
 import type HelpDocumentation from "../../interfaces/help";
 import { GameType } from "../../enums/game_type";
@@ -97,20 +96,18 @@ export function isSkipMajority(guildID: string, session: Session): boolean {
  * Skip the current song (end the current round and start a new one)
  * @param messageContext - The context that triggered skipping
  * @param session - The current session
- * @param guildPreference - The guild's preference
  */
 export async function skipSong(
     messageContext: MessageContext,
-    session: Session,
-    guildPreference: GuildPreference
+    session: Session
 ): Promise<void> {
     logger.info(
         `${getDebugLogHeader(messageContext)} | Skip majority achieved.`
     );
     session.round.skipAchieved = true;
-    await session.endRound(guildPreference, messageContext, { correct: false });
+    await session.endRound(messageContext, { correct: false });
 
-    session.startRound(guildPreference, messageContext);
+    session.startRound(messageContext);
 }
 
 export default class SkipCommand implements BaseCommand {
@@ -172,11 +169,7 @@ export default class SkipCommand implements BaseCommand {
 
         if (isSkipMajority(message.guildID, session)) {
             sendSkipMessage(message, session.round);
-            skipSong(
-                MessageContext.fromMessage(message),
-                session,
-                await GuildPreference.getGuildPreference(message.guildID)
-            );
+            skipSong(MessageContext.fromMessage(message), session);
         } else {
             logger.info(`${getDebugLogHeader(message)} | Skip vote received.`);
             await sendSkipNotification(message, session.round);

--- a/src/commands/game_options/timer.ts
+++ b/src/commands/game_options/timer.ts
@@ -97,10 +97,7 @@ export default class GuessTimeoutCommand implements BaseCommand {
         if (session && session.round && session.connection.playing) {
             // Timer can start mid-song, starting when the user enters the command
             session.stopGuessTimeout();
-            session.startGuessTimeout(
-                MessageContext.fromMessage(message),
-                guildPreference
-            );
+            session.startGuessTimeout(MessageContext.fromMessage(message));
         }
 
         await sendOptionsMessage(

--- a/src/test/ci/begin.test.ts
+++ b/src/test/ci/begin.test.ts
@@ -8,9 +8,16 @@ import Player from "../../structures/player";
 import type TeamScoreboard from "../../structures/team_scoreboard";
 import MessageContext from "../../structures/message_context";
 import * as discordUtils from "../../helpers/discord_utils";
+import GuildPreference from "../../structures/guild_preference";
 
 const sandbox = sinon.createSandbox();
 const gameStarter = new KmqMember("jisoo", "jisoo#4747", "url", "123");
+
+function getMockGuildPreference(): GuildPreference {
+    const guildPreference = new GuildPreference("test");
+    sinon.stub(guildPreference, "updateGuildPreferences");
+    return guildPreference;
+}
 
 describe("begin command", () => {
     describe("can start", () => {
@@ -24,7 +31,9 @@ describe("begin command", () => {
             sandbox
                 .stub(discordUtils, "getCurrentVoiceMembers")
                 .callsFake((_voiceChannelID) => []);
+
             const gameSession = new GameSession(
+                getMockGuildPreference(),
                 null,
                 null,
                 null,
@@ -52,6 +61,7 @@ describe("begin command", () => {
                 .stub(discordUtils, "getCurrentVoiceMembers")
                 .callsFake((_voiceChannelID) => []);
             const gameSession = new GameSession(
+                getMockGuildPreference(),
                 null,
                 null,
                 null,

--- a/src/test/ci/game_session.test.ts
+++ b/src/test/ci/game_session.test.ts
@@ -12,6 +12,14 @@ import Eris, { Collection } from "eris";
 import KmqClient from "../../kmq_client";
 import Session from "../../structures/session";
 
+function getMockGuildPreference(): GuildPreference {
+    const guildPreference = new GuildPreference("test");
+    sinon.stub(guildPreference, "updateGuildPreferences");
+    return guildPreference;
+}
+
+let guildPreference: GuildPreference;
+
 describe("startRound", function () {
     let gameSession: GameSession;
     let prepareRoundSpy: sinon.SinonSpy;
@@ -22,7 +30,7 @@ describe("startRound", function () {
     const sandbox = sinon.createSandbox();
     beforeEach(() => {
         sandbox.stub(utils, "delay");
-
+        guildPreference = getMockGuildPreference();
         voiceChannelStub = sinon.createStubInstance(Eris.VoiceChannel);
         voiceChannelStub.voiceMembers = new Collection(Eris.Member);
         const x = sinon.createStubInstance(KmqClient);
@@ -32,6 +40,7 @@ describe("startRound", function () {
         sandbox.stub(discord_utils, "getDebugLogHeader").callsFake(() => "");
 
         gameSession = new GameSession(
+            guildPreference,
             "123",
             "123",
             "123",
@@ -56,9 +65,8 @@ describe("startRound", function () {
 
     describe("happy path", () => {
         it("should start the round successfully", async () => {
-            const guildPreference = new GuildPreference("test");
             voiceChannelStub.voiceMembers.add({ id: "1" } as any);
-            await gameSession.startRound(guildPreference, null);
+            await gameSession.startRound(null);
             assert.ok(prepareRoundSpy.called);
             assert.ok(ensureVoiceConnectionSpy.called);
             assert.ok(playSongSpy.called);

--- a/src/test/ci/game_utils.test.ts
+++ b/src/test/ci/game_utils.test.ts
@@ -289,12 +289,21 @@ describe("song query", () => {
         });
     });
 
-    describe("cleanupInactiveGameSessions", () => {
+    describe("cleanupInactiveGameSessions", async () => {
         const guildId = "123";
         sandbox
             .stub(discordUtils, "getCurrentVoiceMembers")
             .callsFake((_voiceChannelID) => []);
-        const gameSession = new GameSession(null, null, guildId, null, null);
+        guildPreference = await getMockGuildPreference();
+        const gameSession = new GameSession(
+            guildPreference,
+            null,
+            null,
+            guildId,
+            null,
+            null
+        );
+
         sandbox.restore();
         const endSandbox = sinon.createSandbox();
         const endSessionStub = sandbox.stub(gameSession, "endSession");

--- a/src/test/ci/leaderboard.test.ts
+++ b/src/test/ci/leaderboard.test.ts
@@ -15,6 +15,7 @@ import { LeaderboardScope } from "../../enums/option_types/leaderboard_scope";
 import { LeaderboardDuration } from "../../enums/option_types/leaderboard_duration";
 import { GameType } from "../../enums/game_type";
 import { LEADERBOARD_ENTRIES_PER_PAGE } from "../../constants";
+import GuildPreference from "../../structures/guild_preference";
 
 const sandbox = sinon.createSandbox();
 
@@ -42,6 +43,14 @@ const lastWeek = new Date(new Date(date).setDate(INITIAL_DAY - 7));
 const lastMonth = new Date(new Date(date).setMonth(INITIAL_MONTH - 1));
 
 const INITIAL_TOTAL_ENTRIES = LEADERBOARD_ENTRIES_PER_PAGE * 5;
+
+function getMockGuildPreference(): GuildPreference {
+    const guildPreference = new GuildPreference("test");
+    sinon.stub(guildPreference, "updateGuildPreferences");
+    return guildPreference;
+}
+
+let guildPreference: GuildPreference;
 
 function generatePlayerStats(numberPlayers: number, offset = 0): any {
     return [...Array(numberPlayers).keys()].map((i) => ({
@@ -227,6 +236,7 @@ describe("getLeaderboardEmbeds", () => {
         describe("game leaderboard", () => {
             beforeEach(async () => {
                 await dbContext.kmq("player_stats").del();
+                guildPreference = getMockGuildPreference();
             });
 
             it("should match the number of pages and embeds", async () => {
@@ -234,6 +244,7 @@ describe("getLeaderboardEmbeds", () => {
                     .stub(discordUtils, "getCurrentVoiceMembers")
                     .callsFake((_voiceChannelID) => []);
                 const gameSession = new GameSession(
+                    guildPreference,
                     "",
                     "",
                     SERVER_ID,
@@ -586,6 +597,7 @@ describe("getLeaderboardEmbeds", () => {
                     .stub(discordUtils, "getCurrentVoiceMembers")
                     .callsFake((_voiceChannelID) => []);
                 const gameSession = new GameSession(
+                    guildPreference,
                     "",
                     "",
                     SERVER_ID,


### PR DESCRIPTION
- GuildPreferences are now cached
- refactor Session classes to store GuildPreference rather than fetch every time
- enable cyclic dependency ESLint rule

Closes #1280 
Reduces warnings from 2 to 0
