### PR TITLE
Add song name search functionality to lookup

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -518,7 +518,7 @@
             "inCurrentGameOptions": "In Current Game Options?",
             "inKMQ": "This song is included in KMQ! Here's the link to [Daisuki]({{link}}).",
             "notFound": {
-                "description": "The requested song was not found in KMQ's copy of the Daisuki database. It is not included in KMQ.",
+                "description": "The requested song was not found in KMQ's copy of the Daisuki database, therefore it is not included in KMQ.",
                 "title": "Song Not Found"
             },
             "notInKMQ": "This song has an entry on [Daisuki]({{link}}), but it isn't included in KMQ.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -523,7 +523,8 @@
             },
             "notInKMQ": "This song has an entry on [Daisuki]({{link}}), but it isn't included in KMQ.",
             "songNameSearchResult": {
-                "description": "The following songs are available in KMQ:",
+                "notFoundDescription": "Could not find any songs by that name",
+                "successDescription": "The following songs are available in KMQ:",
                 "title": "Lookup Results"
             },
             "validation": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -522,6 +522,10 @@
                 "title": "Song Not Found"
             },
             "notInKMQ": "This song has an entry on [Daisuki]({{link}}), but it isn't included in KMQ.",
+            "songNameSearchResult": {
+                "description": "The following songs are available in KMQ:",
+                "title": "Lookup Results"
+            },
             "validation": {
                 "invalidYouTubeID": "Expected a valid YouTube ID or link."
             }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -518,12 +518,13 @@
             "inCurrentGameOptions": "현재 게임 옵션",
             "inKMQ": "KMQ에 수록된 곡이며 [여기]({{link}})에 링크가 있습니다.",
             "notFound": {
-                "description": "요청한 노래는 KMQ의 Daisuki 데이터베이스 사본에서 찾을 수 없으므로 KMQ에 포함되지 않습니다.",
+                "description": "KMQ의 Daisuki 데이터베이스 사본에서 요청한 노래를 찾을 수 없으며 KMQ에는 포함되어 있지 않습니다.",
                 "title": "노래를 찾을 수 없음"
             },
             "notInKMQ": "이 노래는 [Daisuki]({{link}})에 항목이 있지만 KMQ에는 포함되어 있지 않습니다.",
             "songNameSearchResult": {
-                "description": "다음 노래는 KMQ에서 사용할 수 있습니다:",
+                "notFoundDescription": "해당 이름의 노래를 찾을 수 없습니다.",
+                "successDescription": "다음 노래는 KMQ에서 사용할 수 있습니다:",
                 "title": "검색 결과"
             },
             "validation": {

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -522,6 +522,10 @@
                 "title": "노래를 찾을 수 없음"
             },
             "notInKMQ": "이 노래는 [Daisuki]({{link}})에 항목이 있지만 KMQ에는 포함되어 있지 않습니다.",
+            "songNameSearchResult": {
+                "description": "다음 노래는 KMQ에서 사용할 수 있습니다:",
+                "title": "검색 결과"
+            },
             "validation": {
                 "invalidYouTubeID": "올바른 유튜브 아이디 또는 링크가 필요합니다."
             }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -518,7 +518,7 @@
             "inCurrentGameOptions": "현재 게임 옵션",
             "inKMQ": "KMQ에 수록된 곡이며 [여기]({{link}})에 링크가 있습니다.",
             "notFound": {
-                "description": "KMQ의 Daisuki 데이터베이스 사본에서 요청한 노래를 찾을 수 없으며 KMQ에는 포함되어 있지 않습니다.",
+                "description": "요청한 노래는 KMQ의 Daisuki 데이터베이스 사본에서 찾을 수 없으므로 KMQ에 포함되지 않습니다.",
                 "title": "노래를 찾을 수 없음"
             },
             "notInKMQ": "이 노래는 [Daisuki]({{link}})에 항목이 있지만 KMQ에는 포함되어 있지 않습니다.",

--- a/src/commands/game_commands/lookup.ts
+++ b/src/commands/game_commands/lookup.ts
@@ -1,13 +1,16 @@
 import { IPCLogger } from "../../logger";
 import { KmqImages } from "../../constants";
 import {
+    chunkArray,
     friendlyFormattedDate,
     friendlyFormattedNumber,
+    isValidURL,
 } from "../../helpers/utils";
 import {
     getDebugLogHeader,
     sendErrorMessage,
     sendInfoMessage,
+    sendPaginationedEmbed,
 } from "../../helpers/discord_utils";
 import {
     getLocalizedArtistName,
@@ -24,6 +27,8 @@ import Session from "../../structures/session";
 import SongSelector from "../../structures/song_selector";
 import State from "../../state";
 import dbContext from "../../database_context";
+import type { EmbedOptions } from "eris";
+import type { GuildTextableMessage } from "../../types";
 import type BaseCommand from "../interfaces/base_command";
 import type CommandArgs from "../../interfaces/command_args";
 import type HelpDocumentation from "../../interfaces/help";
@@ -39,11 +44,290 @@ const getDaisukiLink = (id: string, isMV: boolean): string => {
     return `https://kpop.daisuki.com.br/audio_videos.html?playid=${id}`;
 };
 
+async function lookupByYoutubeID(
+    message: GuildTextableMessage,
+    videoID: string,
+    guildID: string,
+    locale: LocaleType
+): Promise<void> {
+    const messageContext = MessageContext.fromMessage(message);
+    const kmqSongEntry: QueriedSong = await dbContext
+        .kmq("available_songs")
+        .select(SongSelector.getQueriedSongFields())
+        .where("link", videoID)
+        .first();
+
+    const daisukiMVEntry = await dbContext
+        .kpopVideos("app_kpop")
+        .where("vlink", videoID)
+        .first();
+
+    const daisukiAudioEntry = await dbContext
+        .kpopVideos("app_kpop_audio")
+        .where("vlink", videoID)
+        .first();
+
+    const daisukiSongEntry = daisukiMVEntry || daisukiAudioEntry;
+    if (!daisukiSongEntry) {
+        await sendErrorMessage(messageContext, {
+            title: LocalizationManager.localizer.translate(
+                guildID,
+                "command.lookup.notFound.title"
+            ),
+            description: LocalizationManager.localizer.translate(
+                guildID,
+                "command.lookup.notFound.description"
+            ),
+            thumbnailUrl: KmqImages.DEAD,
+        });
+
+        logger.info(
+            `${getDebugLogHeader(
+                messageContext
+            )} | Could not find song by videoID. videoID = ${videoID}.`
+        );
+        return;
+    }
+
+    const daisukiLink = getDaisukiLink(daisukiSongEntry.id, !!daisukiMVEntry);
+
+    let description: string;
+    let songName: string;
+    let artistName: string;
+    let songAliases: string;
+    let artistAliases: string;
+    let views: number;
+    let publishDate: Date;
+    let songDuration: string;
+    let includedInOptions = false;
+
+    if (kmqSongEntry) {
+        description = LocalizationManager.localizer.translate(
+            guildID,
+            "command.lookup.inKMQ",
+            { link: daisukiLink }
+        );
+        songName = getLocalizedSongName(kmqSongEntry, locale);
+        artistName = getLocalizedArtistName(kmqSongEntry, locale);
+        songAliases = State.aliases.song[videoID]?.join(", ");
+        artistAliases =
+            State.aliases.artist[kmqSongEntry.artistName]?.join(", ");
+        views = kmqSongEntry.views;
+        publishDate = kmqSongEntry.publishDate;
+
+        const durationInSeconds = (
+            await dbContext
+                .kmq("cached_song_duration")
+                .where("vlink", videoID)
+                .first()
+        )?.duration;
+
+        // duration in minutes and seconds
+        if (durationInSeconds) {
+            const minutes = Math.floor(durationInSeconds / 60);
+            const seconds = durationInSeconds % 60;
+            songDuration = `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
+        }
+
+        const session = Session.getSession(guildID);
+        includedInOptions = [
+            ...(
+                await SongSelector.getFilteredSongList(
+                    await GuildPreference.getGuildPreference(guildID),
+                    await isPremiumRequest(session, message.author.id)
+                )
+            ).songs,
+        ]
+            .map((x) => x.youtubeLink)
+            .includes(videoID);
+
+        logger.info(
+            `${getDebugLogHeader(
+                message
+            )} | KMQ song lookup. videoID = ${videoID}. Included in options = ${includedInOptions}.`
+        );
+    } else {
+        description = LocalizationManager.localizer.translate(
+            guildID,
+            "command.lookup.notInKMQ",
+            { link: daisukiLink }
+        );
+        const isKorean = locale === LocaleType.KO;
+        songName =
+            daisukiSongEntry.kname && isKorean
+                ? daisukiSongEntry.kname
+                : daisukiSongEntry.name;
+
+        const artistNameQuery = await dbContext
+            .kpopVideos("app_kpop_group")
+            .select("name", "kname")
+            .where("id", daisukiSongEntry.id_artist)
+            .first();
+
+        artistName =
+            artistNameQuery.kname && isKorean
+                ? artistNameQuery.kname
+                : artistNameQuery.name;
+
+        songAliases = [...daisukiSongEntry.name_aka.split(";")].join(", ");
+        songAliases += songAliases
+            ? `, ${daisukiSongEntry.kname}`
+            : daisukiSongEntry.kname;
+
+        artistAliases = State.aliases.artist[artistNameQuery.name]?.join(", ");
+
+        views = daisukiSongEntry.views;
+        publishDate = new Date(daisukiSongEntry.publishedon);
+
+        logger.info(
+            `${getDebugLogHeader(
+                message
+            )} | Non-KMQ song lookup. videoID = ${videoID}.`
+        );
+    }
+
+    const viewsString = LocalizationManager.localizer.translate(
+        guildID,
+        "misc.views"
+    );
+
+    const fields = [
+        {
+            name: viewsString[0].toUpperCase() + viewsString.slice(1),
+            value: friendlyFormattedNumber(views),
+        },
+        {
+            name: LocalizationManager.localizer.translate(
+                guildID,
+                "misc.releaseDate"
+            ),
+            value: friendlyFormattedDate(publishDate, guildID),
+        },
+        {
+            name: LocalizationManager.localizer.translate(
+                guildID,
+                "misc.songAliases"
+            ),
+            value:
+                songAliases ||
+                LocalizationManager.localizer.translate(guildID, "misc.none"),
+        },
+        {
+            name: LocalizationManager.localizer.translate(
+                guildID,
+                "misc.artistAliases"
+            ),
+            value:
+                artistAliases ||
+                LocalizationManager.localizer.translate(guildID, "misc.none"),
+        },
+    ];
+
+    if (kmqSongEntry) {
+        fields.push(
+            {
+                name: LocalizationManager.localizer.translate(
+                    guildID,
+                    "misc.duration"
+                ),
+                value:
+                    songDuration ||
+                    LocalizationManager.localizer.translate(
+                        guildID,
+                        "misc.notApplicable"
+                    ),
+            },
+            {
+                name: LocalizationManager.localizer.translate(
+                    guildID,
+                    "command.lookup.inCurrentGameOptions"
+                ),
+                value: LocalizationManager.localizer.translate(
+                    guildID,
+                    includedInOptions ? "misc.yes" : "misc.no"
+                ),
+            }
+        );
+    }
+
+    sendInfoMessage(messageContext, {
+        title: `${songName} - ${artistName}`,
+        url: `https://youtu.be/${videoID}`,
+        description,
+        thumbnailUrl: `https://img.youtube.com/vi/${videoID}/hqdefault.jpg`,
+        fields: fields.map((x) => ({
+            name: x.name,
+            value: x.value,
+            inline: true,
+        })),
+    });
+}
+
+async function lookupBySongName(
+    songName: string,
+    locale: LocaleType,
+    message: GuildTextableMessage,
+    guildID: string
+): Promise<void> {
+    const messageContext = MessageContext.fromMessage(message);
+    const kmqSongEntries: QueriedSong[] = await dbContext
+        .kmq("available_songs")
+        .select(SongSelector.getQueriedSongFields())
+        .whereRaw(`song_name_en LIKE "%${songName}%"`)
+        .orWhereRaw(`song_name_ko LIKE "%${songName}%"`)
+        .orderByRaw("CHAR_LENGTH(song_name_en) ASC")
+        .orderBy("views", "DESC")
+        .limit(100);
+
+    if (kmqSongEntries.length === 0) {
+        await sendInfoMessage(messageContext, {
+            title: "Lookup Results",
+            description: "Could not find any songs by that name",
+        });
+        logger.info(`Could not find song by song name. songName = ${songName}`);
+        return;
+    }
+
+    if (kmqSongEntries.length === 1) {
+        await lookupByYoutubeID(
+            message,
+            kmqSongEntries[0].youtubeLink,
+            guildID,
+            locale
+        );
+        return;
+    }
+
+    const songEmbeds = kmqSongEntries.map((entry) => ({
+        name: `**"${getLocalizedSongName(
+            entry,
+            locale
+        )}"** - ${getLocalizedArtistName(entry, locale)}`,
+        value: `https://youtu.be/${entry.youtubeLink}`,
+    }));
+
+    const embedFieldSubsets = chunkArray(songEmbeds, 5);
+    const embeds: Array<EmbedOptions> = embedFieldSubsets.map(
+        (embedFieldsSubset) => ({
+            title: LocalizationManager.localizer.translate(
+                guildID,
+                "command.lookup.songNameSearchResult.title"
+            ),
+            description: LocalizationManager.localizer.translate(
+                guildID,
+                "command.lookup.songNameSearchResult.description"
+            ),
+            fields: embedFieldsSubset,
+        })
+    );
+
+    await sendPaginationedEmbed(message, embeds);
+}
+
 export default class LookupCommand implements BaseCommand {
     aliases = ["songinfo", "songlookup"];
     validations = {
         minArgCount: 1,
-        maxArgCount: 1,
         arguments: [],
     };
 
@@ -56,11 +340,11 @@ export default class LookupCommand implements BaseCommand {
         usage: ",lookup [youtube_id]",
         examples: [
             {
-                example: "`,lookup IHNzOHi8sJs`",
+                example: "`,lookup love dive`",
                 explanation: LocalizationManager.localizer.translate(
                     guildID,
                     "command.lookup.help.example.song",
-                    { song: "Ddu-du Ddu-du", artist: "Blackpink" }
+                    { song: "Love Dive", artist: "IVE" }
                 ),
             },
             {
@@ -78,263 +362,51 @@ export default class LookupCommand implements BaseCommand {
 
     call = async ({ parsedMessage, message }: CommandArgs): Promise<void> => {
         const guildID = message.guildID;
-        const messageContext = MessageContext.fromMessage(message);
         let arg = parsedMessage.components[0];
-        if (arg.startsWith("<") && arg.endsWith(">")) {
-            // Trim <> if user didn't want to show YouTube embed
-            arg = arg.slice(1, -1);
-        }
-
-        if (arg.startsWith("youtube.com") || arg.startsWith("youtu.be")) {
-            // ytdl::getVideoID() requires URLs start with "https://"
-            arg = `https://${arg}`;
-        }
-
-        let videoID: string;
-        try {
-            videoID = getVideoID(arg);
-        } catch {
-            await sendValidationErrorMessage(
-                message,
-                LocalizationManager.localizer.translate(
-                    guildID,
-                    "command.lookup.validation.invalidYouTubeID"
-                ),
-                parsedMessage.components[0],
-                this.help(guildID).usage
-            );
-
-            logger.info(
-                `${getDebugLogHeader(
-                    message
-                )} | Invalid YouTube ID passed. arg = ${arg}.`
-            );
-            return;
-        }
-
-        const kmqSongEntry: QueriedSong = await dbContext
-            .kmq("available_songs")
-            .select(SongSelector.getQueriedSongFields())
-            .where("link", videoID)
-            .first();
-
-        const daisukiMVEntry = await dbContext
-            .kpopVideos("app_kpop")
-            .where("vlink", videoID)
-            .first();
-
-        const daisukiAudioEntry = await dbContext
-            .kpopVideos("app_kpop_audio")
-            .where("vlink", videoID)
-            .first();
-
-        const daisukiSongEntry = daisukiMVEntry || daisukiAudioEntry;
-        if (!daisukiSongEntry) {
-            await sendErrorMessage(messageContext, {
-                title: LocalizationManager.localizer.translate(
-                    guildID,
-                    "command.lookup.notFound.title"
-                ),
-                description: LocalizationManager.localizer.translate(
-                    guildID,
-                    "command.lookup.notFound.description"
-                ),
-                thumbnailUrl: KmqImages.DEAD,
-            });
-
-            logger.info(
-                `${getDebugLogHeader(
-                    message
-                )} | Song lookup failed. videoID = ${videoID}.`
-            );
-            return;
-        }
-
-        const daisukiLink = getDaisukiLink(
-            daisukiSongEntry.id,
-            !!daisukiMVEntry
-        );
 
         const locale = State.getGuildLocale(guildID);
-        let description: string;
-        let songName: string;
-        let artistName: string;
-        let songAliases: string;
-        let artistAliases: string;
-        let views: number;
-        let publishDate: Date;
-        let songDuration: string;
-        let includedInOptions = false;
 
-        if (kmqSongEntry) {
-            description = LocalizationManager.localizer.translate(
-                guildID,
-                "command.lookup.inKMQ",
-                { link: daisukiLink }
-            );
-            songName = getLocalizedSongName(kmqSongEntry, locale);
-            artistName = getLocalizedArtistName(kmqSongEntry, locale);
-            songAliases = State.aliases.song[videoID]?.join(", ");
-            artistAliases =
-                State.aliases.artist[kmqSongEntry.artistName]?.join(", ");
-            views = kmqSongEntry.views;
-            publishDate = kmqSongEntry.publishDate;
-
-            const durationInSeconds = (
-                await dbContext
-                    .kmq("cached_song_duration")
-                    .where("vlink", videoID)
-                    .first()
-            )?.duration;
-
-            // duration in minutes and seconds
-            if (durationInSeconds) {
-                const minutes = Math.floor(durationInSeconds / 60);
-                const seconds = durationInSeconds % 60;
-                songDuration = `${minutes}:${
-                    seconds < 10 ? "0" : ""
-                }${seconds}`;
+        if (isValidURL(arg)) {
+            let videoID: string = null;
+            if (arg.startsWith("<") && arg.endsWith(">")) {
+                // Trim <> if user didn't want to show YouTube embed
+                arg = arg.slice(1, -1);
             }
 
-            const session = Session.getSession(guildID);
-            includedInOptions = [
-                ...(
-                    await SongSelector.getFilteredSongList(
-                        await GuildPreference.getGuildPreference(guildID),
-                        await isPremiumRequest(session, message.author.id)
-                    )
-                ).songs,
-            ]
-                .map((x) => x.youtubeLink)
-                .includes(videoID);
+            if (arg.startsWith("youtube.com") || arg.startsWith("youtu.be")) {
+                // ytdl::getVideoID() requires URLs start with "https://"
+                arg = `https://${arg}`;
+            }
 
-            logger.info(
-                `${getDebugLogHeader(
-                    message
-                )} | KMQ song lookup. videoID = ${videoID}. Included in options = ${includedInOptions}.`
-            );
+            try {
+                videoID = getVideoID(arg);
+            } catch {
+                await sendValidationErrorMessage(
+                    message,
+                    LocalizationManager.localizer.translate(
+                        guildID,
+                        "command.lookup.validation.invalidYouTubeID"
+                    ),
+                    parsedMessage.components[0],
+                    this.help(guildID).usage
+                );
+
+                logger.info(
+                    `${getDebugLogHeader(
+                        message
+                    )} | Invalid YouTube ID passed. arg = ${arg}.`
+                );
+                return;
+            }
+
+            await lookupByYoutubeID(message, videoID, guildID, locale);
         } else {
-            description = LocalizationManager.localizer.translate(
-                guildID,
-                "command.lookup.notInKMQ",
-                { link: daisukiLink }
-            );
-
-            const isKorean = locale === LocaleType.KO;
-            songName =
-                daisukiSongEntry.kname && isKorean
-                    ? daisukiSongEntry.kname
-                    : daisukiSongEntry.name;
-
-            const artistNameQuery = await dbContext
-                .kpopVideos("app_kpop_group")
-                .select("name", "kname")
-                .where("id", daisukiSongEntry.id_artist)
-                .first();
-
-            artistName =
-                artistNameQuery.kname && isKorean
-                    ? artistNameQuery.kname
-                    : artistNameQuery.name;
-
-            songAliases = [...daisukiSongEntry.name_aka.split(";")].join(", ");
-            songAliases += songAliases
-                ? `, ${daisukiSongEntry.kname}`
-                : daisukiSongEntry.kname;
-
-            artistAliases =
-                State.aliases.artist[artistNameQuery.name]?.join(", ");
-
-            views = daisukiSongEntry.views;
-            publishDate = new Date(daisukiSongEntry.publishedon);
-
-            logger.info(
-                `${getDebugLogHeader(
-                    message
-                )} | Non-KMQ song lookup. videoID = ${videoID}.`
+            await lookupBySongName(
+                parsedMessage.argument,
+                locale,
+                message,
+                guildID
             );
         }
-
-        const viewsString = LocalizationManager.localizer.translate(
-            guildID,
-            "misc.views"
-        );
-
-        const fields = [
-            {
-                name: viewsString[0].toUpperCase() + viewsString.slice(1),
-                value: friendlyFormattedNumber(views),
-            },
-            {
-                name: LocalizationManager.localizer.translate(
-                    guildID,
-                    "misc.releaseDate"
-                ),
-                value: friendlyFormattedDate(publishDate, guildID),
-            },
-            {
-                name: LocalizationManager.localizer.translate(
-                    guildID,
-                    "misc.songAliases"
-                ),
-                value:
-                    songAliases ||
-                    LocalizationManager.localizer.translate(
-                        guildID,
-                        "misc.none"
-                    ),
-            },
-            {
-                name: LocalizationManager.localizer.translate(
-                    guildID,
-                    "misc.artistAliases"
-                ),
-                value:
-                    artistAliases ||
-                    LocalizationManager.localizer.translate(
-                        guildID,
-                        "misc.none"
-                    ),
-            },
-        ];
-
-        if (kmqSongEntry) {
-            fields.push(
-                {
-                    name: LocalizationManager.localizer.translate(
-                        guildID,
-                        "misc.duration"
-                    ),
-                    value:
-                        songDuration ||
-                        LocalizationManager.localizer.translate(
-                            guildID,
-                            "misc.notApplicable"
-                        ),
-                },
-                {
-                    name: LocalizationManager.localizer.translate(
-                        guildID,
-                        "command.lookup.inCurrentGameOptions"
-                    ),
-                    value: LocalizationManager.localizer.translate(
-                        guildID,
-                        includedInOptions ? "misc.yes" : "misc.no"
-                    ),
-                }
-            );
-        }
-
-        sendInfoMessage(messageContext, {
-            title: `${songName} - ${artistName}`,
-            url: `https://youtu.be/${videoID}`,
-            description,
-            thumbnailUrl: `https://img.youtube.com/vi/${videoID}/hqdefault.jpg`,
-            fields: fields.map((x) => ({
-                name: x.name,
-                value: x.value,
-                inline: true,
-            })),
-        });
     };
 }

--- a/src/commands/game_commands/lookup.ts
+++ b/src/commands/game_commands/lookup.ts
@@ -337,7 +337,7 @@ export default class LookupCommand implements BaseCommand {
             guildID,
             "command.lookup.help.description"
         ),
-        usage: ",lookup [youtube_id]",
+        usage: ",lookup [song_name | youtube_id]",
         examples: [
             {
                 example: "`,lookup love dive`",

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -437,3 +437,17 @@ export function isPrimaryInstance(): boolean {
 export function shouldSkipSeed(): boolean {
     return fs.existsSync(path.join(__dirname, "../../data/skip_seed"));
 }
+
+/**
+ * @param url - the URL
+ * @returns whether the URL is valid
+ */
+export function isValidURL(url: string): boolean {
+    try {
+        // eslint-disable-next-line no-new
+        new URL(url);
+        return true;
+    } catch (err) {
+        return false;
+    }
+}


### PR DESCRIPTION
If user provides a valid URL, we assume that they are providing a youtube link and look up by youtube video ID
Otherwise, we assume they're providing a song name, and we search using song name against `available_songs.` If there are multiple results, we list the matched songs, including pagination if needed. Matches are sorted by song name length, then by views.

![image](https://user-images.githubusercontent.com/13823855/166641172-918e75ef-de41-4e5c-863c-440bb49160d7.png)

If there is only one result, we return a response similar to searching by video ID