### PR TITLE
Abort game/listening session setup if base startRound fails

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -152,7 +152,7 @@ export default class GameSession extends Session {
      * Starting a new GameRound
      * @param messageContext - An object containing relevant parts of Eris.Message
      */
-    async startRound(messageContext: MessageContext): Promise<void> {
+    async startRound(messageContext: MessageContext): Promise<boolean> {
         if (this.sessionInitialized) {
             // Only add a delay if the game has already started
             await delay(
@@ -163,10 +163,15 @@ export default class GameSession extends Session {
         }
 
         if (this.finished || this.round) {
-            return;
+            return false;
         }
 
-        await super.startRound(messageContext);
+        const startRoundResult = await super.startRound(messageContext);
+
+        if (!startRoundResult) {
+            return false;
+        }
+
         if (this.guildPreference.isMultipleChoiceMode()) {
             const locale = State.getGuildLocale(this.guildID);
             const randomSong = this.round.song;
@@ -260,6 +265,8 @@ export default class GameSession extends Session {
                 }
             );
         }
+
+        return true;
     }
 
     /**

--- a/src/structures/listening_session.ts
+++ b/src/structures/listening_session.ts
@@ -76,12 +76,16 @@ export default class ListeningSession extends Session {
      * Starting a new ListeningRound
      * @param messageContext - An object containing relevant parts of Eris.Message
      */
-    async startRound(messageContext: MessageContext): Promise<void> {
+    async startRound(messageContext: MessageContext): Promise<boolean> {
         if (this.finished || this.round) {
-            return;
+            return false;
         }
 
-        await super.startRound(messageContext);
+        const startRoundResult = await super.startRound(messageContext);
+
+        if (!startRoundResult) {
+            return false;
+        }
 
         if (messageContext) {
             const remainingDuration = this.getRemainingDuration(
@@ -102,6 +106,8 @@ export default class ListeningSession extends Session {
             this.round.roundMessageID = startRoundMessage?.id;
             this.updateBookmarkSongList();
         }
+
+        return true;
     }
 
     async endRound(

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -156,7 +156,7 @@ export default abstract class Session {
      * Starting a new Round
      * @param messageContext - An object containing relevant parts of Eris.Message
      */
-    async startRound(messageContext: MessageContext): Promise<void> {
+    async startRound(messageContext: MessageContext): Promise<boolean> {
         if (!this.sessionInitialized) {
             logger.info(
                 `${getDebugLogHeader(
@@ -189,7 +189,7 @@ export default abstract class Session {
                     )}`
                 );
                 await this.endSession();
-                return;
+                return false;
             }
         }
 
@@ -232,7 +232,7 @@ export default abstract class Session {
                 ),
             });
             await this.endSession();
-            return;
+            return false;
         }
 
         // create a new round with randomly chosen song
@@ -244,7 +244,7 @@ export default abstract class Session {
 
         if (!voiceChannel || voiceChannel.voiceMembers.size === 0) {
             await this.endSession();
-            return;
+            return false;
         }
 
         // join voice channel and start round
@@ -268,10 +268,11 @@ export default abstract class Session {
                     "misc.failure.vcJoin.description"
                 ),
             });
-            return;
+            return false;
         }
 
         this.playSong(messageContext);
+        return true;
     }
 
     /**


### PR DESCRIPTION
2022-05-07T17:19:01.672Z [ERROR] - messageCreate | Error while invoking command (play) | 16d436b0-cb84-42a2-93d0-b58d38f2a45c | Exception Name: TypeError. Reason: Cannot read properties of null (reading 'song'). Trace: TypeError: Cannot read properties of null (reading 'song')
    at GameSession.<anonymous> (/home/kmq/prod/build/structures/game_session.js:116:47)
    at Generator.next (<anonymous>)
    at fulfilled (/home/kmq/prod/build/structures/game_session.js:28:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)}