### PR TITLE
Add round nullcheck in handleComponentInteraction

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -620,6 +620,7 @@ export default class GameSession extends Session {
         interaction: Eris.ComponentInteraction<Eris.TextableChannel>,
         messageContext: MessageContext
     ): Promise<void> {
+        if (!this.round) return;
         if (
             !this.handleInSessionInteractionFailures(
                 interaction,
@@ -667,7 +668,6 @@ export default class GameSession extends Session {
             messageContext.guildID
         );
 
-        if (!this.round) return;
         this.guessSong(
             messageContext,
             guildPreference.gameOptions.guessModeType !== GuessModeType.ARTIST

--- a/src/structures/listening_session.ts
+++ b/src/structures/listening_session.ts
@@ -134,6 +134,7 @@ export default class ListeningSession extends Session {
         interaction: Eris.ComponentInteraction,
         messageContext: MessageContext
     ): Promise<void> {
+        if (!this.round) return;
         if (
             interaction.data.custom_id !== "bookmark" &&
             !this.handleInSessionInteractionFailures(


### PR DESCRIPTION
2022-05-11T01:16:11.225Z [ERROR] - unhandledRejection | Cluster Unhandled Rejection at: Reason: TypeError: Cannot read properties of null (reading 'interactionIncorrectAnswerUUIDs'). Trace: TypeError: Cannot read properties of null (reading 'interactionIncorrectAnswerUUIDs')
    at GameSession.<anonymous> (/home/kmq/prod/build/structures/game_session.js:125:32)
    at Generator.next (<anonymous>)
    at fulfilled (/home/kmq/prod/build/structures/game_session.js:28:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)