### PR TITLE
Use whereILike instead of whereRaw

### DIFF
--- a/src/commands/game_commands/lookup.ts
+++ b/src/commands/game_commands/lookup.ts
@@ -273,8 +273,8 @@ async function lookupBySongName(
     const kmqSongEntries: QueriedSong[] = await dbContext
         .kmq("available_songs")
         .select(SongSelector.getQueriedSongFields())
-        .whereRaw(`song_name_en LIKE "%${songName}%"`)
-        .orWhereRaw(`song_name_ko LIKE "%${songName}%"`)
+        .whereILike("song_name_en", `%${songName}%`)
+        .orWhereILike("song_name_ko", `%${songName}%`)
         .orderByRaw("CHAR_LENGTH(song_name_en) ASC")
         .orderBy("views", "DESC")
         .limit(100);

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -127,8 +127,8 @@ export async function getSimilarGroupNames(
     const similarGroups = await dbContext
         .kpopVideos("app_kpop_group")
         .select(["id", "name", "kname"])
-        .whereRaw(`name LIKE "%${groupName}%"`)
-        .orWhereRaw(`kname LIKE "%${groupName}%"`)
+        .whereILike("name", `%${groupName}%`)
+        .orWhereILike("kname", `%${groupName}%`)
         .orderByRaw("CHAR_LENGTH(name) ASC")
         .limit(5);
 


### PR DESCRIPTION
Was using `whereRaw` because `whereLike` is broken (https://github.com/knex/knex/issues/5143). `whereILike` should work for our usecase too