### PR TITLE
Cache username on Player creation

### DIFF
--- a/src/structures/elimination_player.ts
+++ b/src/structures/elimination_player.ts
@@ -17,6 +17,7 @@ export default class EliminationPlayer extends Player {
             guildID,
             user.avatarURL,
             score,
+            State.client.users.get(userID).username,
             firstGameOfDay,
             premium
         );

--- a/src/structures/player.ts
+++ b/src/structures/player.ts
@@ -7,6 +7,9 @@ export default class Player {
     /** The Discord user ID of the player */
     public readonly id: string;
 
+    /** The Discord username of the player */
+    public readonly username: string;
+
     /** Whether the player has premium features */
     public readonly premium: boolean;
 
@@ -36,17 +39,19 @@ export default class Player {
         guildID: string,
         avatarURL: string,
         points: number,
+        username: string,
         firstGameOfTheDay = false,
         premium = false
     ) {
         this.id = id;
         this.guildID = guildID;
-        this.inVC = true;
-        this.score = points;
         this.avatarURL = avatarURL;
-        this.expGain = 0;
+        this.score = points;
+        this.username = username;
         this.firstGameOfTheDay = firstGameOfTheDay;
         this.premium = premium;
+        this.inVC = true;
+        this.expGain = 0;
         this.previousRoundRanking = null;
     }
 
@@ -64,6 +69,7 @@ export default class Player {
             guildID,
             user.avatarURL,
             score,
+            State.client.users.get(userID).username,
             firstGameOfDay,
             premium
         );
@@ -106,7 +112,7 @@ export default class Player {
     getName(): string {
         return (
             State.client.guilds.get(this.guildID).members.get(this.id).nick ??
-            State.client.users.get(this.id).username
+            this.username
         );
     }
 

--- a/src/structures/team.ts
+++ b/src/structures/team.ts
@@ -5,7 +5,7 @@ export default class Team extends Player {
     private players: { [userID: string]: Player };
 
     constructor(name: string, player: Player) {
-        super(name, null, null, 0);
+        super(name, null, null, 0, name);
         this.players = {};
         this.players[player.id] = player;
     }

--- a/src/test/ci/begin.test.ts
+++ b/src/test/ci/begin.test.ts
@@ -90,7 +90,7 @@ describe("begin command", () => {
                     const scoreboard = gameSession.scoreboard as TeamScoreboard;
                     scoreboard.addTeam(
                         "Loona",
-                        new Player(null, null, null, 0)
+                        new Player(null, null, null, 0, null)
                     );
 
                     assert.strictEqual(
@@ -100,7 +100,7 @@ describe("begin command", () => {
 
                     scoreboard.addTeam(
                         "Loona2",
-                        new Player(null, null, null, 0)
+                        new Player(null, null, null, 0, null)
                     );
 
                     assert.strictEqual(

--- a/src/test/ci/elimination_player.test.ts
+++ b/src/test/ci/elimination_player.test.ts
@@ -11,7 +11,8 @@ describe("elimination player", () => {
                     "12345",
                     "guildID",
                     "someurl",
-                    5
+                    5,
+                    "ohmi"
                 );
                 player.decrementLives();
                 assert.strictEqual(player.getLives(), 4);
@@ -24,7 +25,8 @@ describe("elimination player", () => {
                     "12345",
                     "guildID",
                     "someurl",
-                    0
+                    0,
+                    "ohmi"
                 );
                 player.decrementLives();
                 assert.strictEqual(player.getLives(), 0);
@@ -39,7 +41,8 @@ describe("elimination player", () => {
                     "12345",
                     "guildID",
                     "someurl",
-                    5
+                    5,
+                    "ohmi"
                 );
                 assert.strictEqual(player.isEliminated(), false);
             });
@@ -51,7 +54,8 @@ describe("elimination player", () => {
                     "12345",
                     "guildID",
                     "someurl",
-                    0
+                    0,
+                    "ohmi"
                 );
                 assert.strictEqual(player.isEliminated(), true);
             });

--- a/src/test/ci/elimination_scoreboard.test.ts
+++ b/src/test/ci/elimination_scoreboard.test.ts
@@ -9,7 +9,7 @@ function getMockEliminationPlayer(
     id: string,
     lives = DEFAULT_LIVES
 ): EliminationPlayer {
-    return new EliminationPlayer(id, null, null, lives);
+    return new EliminationPlayer(id, null, null, lives, null);
 }
 
 describe("elimination scoreboard", () => {

--- a/src/test/ci/leaderboard.test.ts
+++ b/src/test/ci/leaderboard.test.ts
@@ -270,7 +270,13 @@ describe("leaderboard command", () => {
 
                     [...Array(INITIAL_TOTAL_ENTRIES).keys()].map((i) =>
                         gameSession.scoreboard.addPlayer(
-                            new Player(i.toString(), null, null, 0)
+                            new Player(
+                                i.toString(),
+                                null,
+                                null,
+                                0,
+                                i.toString()
+                            )
                         )
                     );
 
@@ -625,7 +631,13 @@ describe("leaderboard command", () => {
                         .filter((x) => x !== 0)
                         .map((i) =>
                             gameSession.scoreboard.addPlayer(
-                                new Player(i.toString(), null, null, 0)
+                                new Player(
+                                    i.toString(),
+                                    null,
+                                    null,
+                                    0,
+                                    i.toString()
+                                )
                             )
                         );
                 });

--- a/src/test/ci/player.test.ts
+++ b/src/test/ci/player.test.ts
@@ -6,7 +6,7 @@ import assert from "assert";
 describe("player", () => {
     let player: Player;
     beforeEach(() => {
-        player = new Player("12345", "guildID", "someurl", 0);
+        player = new Player("12345", "guildID", "someurl", 0, "ohmi");
     });
 
     describe("increment score", () => {
@@ -38,7 +38,14 @@ describe("player", () => {
 
         describe("first game of the day", () => {
             beforeEach(() => {
-                player = new Player("12345", "guildID", "someurl", 0, true);
+                player = new Player(
+                    "12345",
+                    "guildID",
+                    "someurl",
+                    0,
+                    "ohmi",
+                    true
+                );
             });
 
             describe("player's exp is incremented multiple times", () => {

--- a/src/test/ci/scoreboard.test.ts
+++ b/src/test/ci/scoreboard.test.ts
@@ -10,7 +10,9 @@ describe("scoreboard", () => {
     let scoreboard: Scoreboard;
     beforeEach(() => {
         scoreboard = new Scoreboard();
-        userIDs.map((x) => scoreboard.addPlayer(new Player(x, null, null, 0)));
+        userIDs.map((x) =>
+            scoreboard.addPlayer(new Player(x, null, null, 0, x))
+        );
     });
 
     let guildPreference: GuildPreference;
@@ -141,9 +143,9 @@ describe("scoreboard", () => {
         describe("position changes", () => {
             it("should return the correct ranking of every player", () => {
                 const players = {
-                    ohmiID: new Player("ohmiID", "guildID", "", 2),
-                    12345: new Player("12345", "guildID", "", 2),
-                    jisooID: new Player("jisooID", "guildID", "", 3),
+                    ohmiID: new Player("ohmiID", "guildID", "", 2, "ohmi"),
+                    12345: new Player("12345", "guildID", "", 2, "cool"),
+                    jisooID: new Player("jisooID", "guildID", "", 3, "jisoo"),
                 };
 
                 const sb = new Scoreboard();
@@ -157,7 +159,7 @@ describe("scoreboard", () => {
                     [players["ohmiID"].getScore()]: 1,
                 });
 
-                const newPlayer = new Player("1234", "guildID", "", 1);
+                const newPlayer = new Player("1234", "guildID", "", 1, "new");
                 sb.addPlayer(newPlayer);
                 players["1234"] = newPlayer;
 
@@ -171,9 +173,9 @@ describe("scoreboard", () => {
 
             it("should return the same ranking when all players have the same score", () => {
                 const players = {
-                    ohmiID: new Player("ohmiID", "guildID", "", 2),
-                    12345: new Player("12345", "guildID", "", 2),
-                    jisooID: new Player("jisooID", "guildID", "", 2),
+                    ohmiID: new Player("ohmiID", "guildID", "", 2, "ohmi"),
+                    12345: new Player("12345", "guildID", "", 2, "cool"),
+                    jisooID: new Player("jisooID", "guildID", "", 2, "jisoo"),
                 };
 
                 const sb = new Scoreboard();
@@ -186,9 +188,9 @@ describe("scoreboard", () => {
 
             it("should return different rankings when all players have different scores", () => {
                 const players = {
-                    ohmiID: new Player("ohmiID", "guildID", "", 1),
-                    12345: new Player("12345", "guildID", "", 2),
-                    jisooID: new Player("jisooID", "guildID", "", 3),
+                    ohmiID: new Player("ohmiID", "guildID", "", 1, "ohmi"),
+                    12345: new Player("12345", "guildID", "", 2, "cool"),
+                    jisooID: new Player("jisooID", "guildID", "", 3, "jisoo"),
                 };
 
                 const sb = new Scoreboard();
@@ -203,25 +205,26 @@ describe("scoreboard", () => {
         });
 
         describe("player's prefix should change based on new ranking", () => {
-            const previousRanking = ["12345", "jisoo", "ohmi"];
-            const newRanking = ["ohmi", "jisoo", "12345"];
+            const previousRanking = ["12345", "jisooID", "ohmiID"];
+            const newRanking = ["ohmiID", "jisooID", "12345"];
 
             describe("player moved ahead in ranking", () => {
                 it("should show the player has gained ranking", () => {
                     const winningPlayer = new Player(
-                        "ohmi",
+                        "ohmiID",
                         "guildID",
                         null,
-                        0
+                        0,
+                        "ohmi"
                     );
 
                     winningPlayer.setPreviousRanking(
-                        previousRanking.indexOf("ohmi")
+                        previousRanking.indexOf("ohmiID")
                     );
 
                     assert.strictEqual(
                         winningPlayer.getRankingPrefix(
-                            newRanking.indexOf("ohmi"),
+                            newRanking.indexOf("ohmiID"),
                             true
                         ),
                         "↑ 1."
@@ -235,7 +238,8 @@ describe("scoreboard", () => {
                         "12345",
                         "guildID",
                         null,
-                        0
+                        0,
+                        "cool"
                     );
 
                     losingPlayer.setPreviousRanking(
@@ -254,14 +258,21 @@ describe("scoreboard", () => {
 
             describe("player didn't change position in ranking", () => {
                 it("should not show any ranking change", () => {
-                    const samePlayer = new Player("jisoo", "guildID", null, 0);
+                    const samePlayer = new Player(
+                        "jisooID",
+                        "guildID",
+                        null,
+                        0,
+                        "jisoo"
+                    );
+
                     samePlayer.setPreviousRanking(
-                        previousRanking.indexOf("jisoo")
+                        previousRanking.indexOf("jisooID")
                     );
 
                     assert.strictEqual(
                         samePlayer.getRankingPrefix(
-                            newRanking.indexOf("jisoo"),
+                            newRanking.indexOf("jisooID"),
                             true
                         ),
                         "2."
@@ -272,19 +283,20 @@ describe("scoreboard", () => {
             describe("the game has ended", () => {
                 it("should not show any ranking change, even if there was one", () => {
                     const winningPlayer = new Player(
-                        "ohmi",
+                        "ohmiID",
                         "guildID",
                         null,
-                        0
+                        0,
+                        "ohmi"
                     );
 
                     winningPlayer.setPreviousRanking(
-                        previousRanking.indexOf("ohmi")
+                        previousRanking.indexOf("ohmiID")
                     );
 
                     assert.strictEqual(
                         winningPlayer.getRankingPrefix(
-                            newRanking.indexOf("ohmi"),
+                            newRanking.indexOf("ohmiID"),
                             false
                         ),
                         "1."

--- a/src/test/ci/team.test.ts
+++ b/src/test/ci/team.test.ts
@@ -9,13 +9,14 @@ describe("team", () => {
     let firstOnLeaderboardPlayer: Player;
 
     beforeEach(() => {
-        goodPlayer = new Player("12345", "guildID", "ohmipic", 0);
-        subparPlayer = new Player("12", "guildID", "url", 0);
+        goodPlayer = new Player("12345", "guildID", "ohmipic", 0, "ohmi");
+        subparPlayer = new Player("12", "guildID", "url", 0, "cool");
         firstOnLeaderboardPlayer = new Player(
             "121212",
             "guildID",
             "kpop_pfp",
-            0
+            0,
+            "kpopper"
         );
         team = new Team("kmq", goodPlayer);
     });

--- a/src/test/ci/team_scoreboard.test.ts
+++ b/src/test/ci/team_scoreboard.test.ts
@@ -9,6 +9,7 @@ const FIRST_TEAM_NAME = "kmq team";
 const SECOND_TEAM_NAME = "not kmqer";
 
 const USER_IDS = ["12345", "23456", "252525", "1000000"];
+const USERNAMES = ["ohmi", "cool", "kpopper", "kmq player"];
 
 const AVATAR_URL = null;
 const GUILD_ID = null;
@@ -21,13 +22,19 @@ describe("team scoreboard", () => {
         scoreboard = new TeamScoreboard();
         firstTeam = scoreboard.addTeam(
             FIRST_TEAM_NAME,
-            new Player(USER_IDS[0], GUILD_ID, AVATAR_URL, 0)
+            new Player(USER_IDS[0], GUILD_ID, AVATAR_URL, 0, USERNAMES[0])
         );
     });
 
     describe("add a team", () => {
         it("should add the team to the scoreboard", () => {
-            const player = new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0);
+            const player = new Player(
+                USER_IDS[1],
+                GUILD_ID,
+                AVATAR_URL,
+                0,
+                USERNAMES[1]
+            );
 
             assert.strictEqual(scoreboard.hasTeam(SECOND_TEAM_NAME), false);
             const secondTeam = scoreboard.addTeam(SECOND_TEAM_NAME, player);
@@ -51,7 +58,13 @@ describe("team scoreboard", () => {
             );
             assert.strictEqual(scoreboard.getTeamOfPlayer(USER_IDS[1]), null);
 
-            const player = new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0);
+            const player = new Player(
+                USER_IDS[1],
+                GUILD_ID,
+                AVATAR_URL,
+                0,
+                USERNAMES[1]
+            );
 
             const secondTeam = scoreboard.addTeam(SECOND_TEAM_NAME, player);
             assert.deepStrictEqual(
@@ -63,18 +76,32 @@ describe("team scoreboard", () => {
 
     describe("team deletion", () => {
         it("should delete a team when it has no players in it", () => {
-            const player = new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0);
+            const player = new Player(
+                USER_IDS[1],
+                GUILD_ID,
+                AVATAR_URL,
+                0,
+                USERNAMES[1]
+            );
 
             const secondTeam = scoreboard.addTeam(SECOND_TEAM_NAME, player);
             const anotherPlayer = new Player(
                 USER_IDS[2],
                 GUILD_ID,
                 AVATAR_URL,
-                0
+                0,
+                USERNAMES[2]
             );
 
             scoreboard.addTeamPlayer(SECOND_TEAM_NAME, anotherPlayer);
-            const bestPlayer = new Player(USER_IDS[3], GUILD_ID, AVATAR_URL, 0);
+            const bestPlayer = new Player(
+                USER_IDS[3],
+                GUILD_ID,
+                AVATAR_URL,
+                0,
+                USERNAMES[3]
+            );
+
             scoreboard.addTeamPlayer(FIRST_TEAM_NAME, bestPlayer);
             scoreboard.removePlayer(bestPlayer.id);
             scoreboard.removePlayer(player.id);
@@ -132,7 +159,13 @@ describe("team scoreboard", () => {
             beforeEach(() => {
                 scoreboard.addTeamPlayer(
                     FIRST_TEAM_NAME,
-                    new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0)
+                    new Player(
+                        USER_IDS[1],
+                        GUILD_ID,
+                        AVATAR_URL,
+                        0,
+                        USERNAMES[1]
+                    )
                 );
             });
 
@@ -211,17 +244,35 @@ describe("team scoreboard", () => {
             beforeEach(() => {
                 scoreboard.addTeamPlayer(
                     FIRST_TEAM_NAME,
-                    new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0)
+                    new Player(
+                        USER_IDS[1],
+                        GUILD_ID,
+                        AVATAR_URL,
+                        0,
+                        USERNAMES[1]
+                    )
                 );
 
                 secondTeam = scoreboard.addTeam(
                     SECOND_TEAM_NAME,
-                    new Player(USER_IDS[2], GUILD_ID, AVATAR_URL, 0)
+                    new Player(
+                        USER_IDS[2],
+                        GUILD_ID,
+                        AVATAR_URL,
+                        0,
+                        USERNAMES[2]
+                    )
                 );
 
                 scoreboard.addTeamPlayer(
                     SECOND_TEAM_NAME,
-                    new Player(USER_IDS[3], GUILD_ID, AVATAR_URL, 0)
+                    new Player(
+                        USER_IDS[3],
+                        GUILD_ID,
+                        AVATAR_URL,
+                        0,
+                        USERNAMES[3]
+                    )
                 );
             });
 
@@ -324,17 +375,35 @@ describe("team scoreboard", () => {
             beforeEach(() => {
                 scoreboard.addTeamPlayer(
                     FIRST_TEAM_NAME,
-                    new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0)
+                    new Player(
+                        USER_IDS[1],
+                        GUILD_ID,
+                        AVATAR_URL,
+                        0,
+                        USERNAMES[1]
+                    )
                 );
 
                 secondTeam = scoreboard.addTeam(
                     SECOND_TEAM_NAME,
-                    new Player(USER_IDS[2], GUILD_ID, AVATAR_URL, 0)
+                    new Player(
+                        USER_IDS[2],
+                        GUILD_ID,
+                        AVATAR_URL,
+                        0,
+                        USERNAMES[2]
+                    )
                 );
 
                 scoreboard.addTeamPlayer(
                     SECOND_TEAM_NAME,
-                    new Player(USER_IDS[3], GUILD_ID, AVATAR_URL, 0)
+                    new Player(
+                        USER_IDS[3],
+                        GUILD_ID,
+                        AVATAR_URL,
+                        0,
+                        USERNAMES[3]
+                    )
                 );
 
                 scoreboard.update([
@@ -373,17 +442,17 @@ describe("team scoreboard", () => {
         beforeEach(() => {
             scoreboard.addTeamPlayer(
                 FIRST_TEAM_NAME,
-                new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0)
+                new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0, USERNAMES[1])
             );
 
             secondTeam = scoreboard.addTeam(
                 SECOND_TEAM_NAME,
-                new Player(USER_IDS[2], GUILD_ID, AVATAR_URL, 0)
+                new Player(USER_IDS[2], GUILD_ID, AVATAR_URL, 0, USERNAMES[2])
             );
 
             scoreboard.addTeamPlayer(
                 SECOND_TEAM_NAME,
-                new Player(USER_IDS[3], GUILD_ID, AVATAR_URL, 0)
+                new Player(USER_IDS[3], GUILD_ID, AVATAR_URL, 0, USERNAMES[3])
             );
         });
 
@@ -497,12 +566,12 @@ describe("team scoreboard", () => {
             guildPreference.setGoal(5);
             scoreboard.addTeam(
                 FIRST_TEAM_NAME,
-                new Player(USER_IDS[0], GUILD_ID, AVATAR_URL, 0)
+                new Player(USER_IDS[0], GUILD_ID, AVATAR_URL, 0, USERNAMES[0])
             );
 
             scoreboard.addTeam(
                 SECOND_TEAM_NAME,
-                new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0)
+                new Player(USER_IDS[1], GUILD_ID, AVATAR_URL, 0, USERNAMES[1])
             );
         });
 


### PR DESCRIPTION
If a player is uncached (e.g. they leave the server), then accessing their username from the bot's cache will fail. Instead, we store the username once at the start of each game