### PR TITLE
Fix premium awarding code bugs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -142,7 +142,7 @@ export const EMBED_ERROR_COLOR = 0xed4245; // Red
 export const EMBED_SUCCESS_COLOR = 0x57f287; // Green
 export const EMBED_SUCCESS_BONUS_COLOR = 0xfee75c; // Gold
 
-export const PATREON_SUPPORTER_BADGE = "🎧 Premium Supporter";
+export const PATREON_SUPPORTER_BADGE_ID = 23;
 
 export const DATABASE_DOWNLOAD_DIR = path.join(
     __dirname,

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -1,5 +1,5 @@
 import { IPCLogger } from "../logger";
-import { PATREON_SUPPORTER_BADGE } from "../constants";
+import { PATREON_SUPPORTER_BADGE_ID } from "../constants";
 import { cleanArtistName, cleanSongName } from "../structures/game_round";
 import { containsHangul, md5Hash } from "./utils";
 import AnswerType from "../enums/option_types/answer_type";
@@ -438,6 +438,10 @@ export async function isUserPremium(userID: string): Promise<boolean> {
  * @param patrons - The users to grant premium membership
  */
 export async function addPremium(patrons: Array<Patron>): Promise<void> {
+    if (patrons.length === 0) {
+        return;
+    }
+
     await dbContext.kmq.transaction(async (trx) => {
         await dbContext
             .kmq("premium_users")
@@ -456,8 +460,8 @@ export async function addPremium(patrons: Array<Patron>): Promise<void> {
             .kmq("badges_players")
             .insert(
                 patrons.map((x) => ({
-                    badge_name: PATREON_SUPPORTER_BADGE,
                     user_id: x.discordID,
+                    badge_id: PATREON_SUPPORTER_BADGE_ID,
                 }))
             )
             .onConflict(["user_id", "badge_name"])
@@ -470,17 +474,17 @@ export async function addPremium(patrons: Array<Patron>): Promise<void> {
  * @param userIDs - The users to revoke premium membership from
  */
 export function removePremium(userIDs: string[]): void {
-    dbContext.kmq.transaction((trx) => {
-        dbContext
+    dbContext.kmq.transaction(async (trx) => {
+        await dbContext
             .kmq("premium_users")
             .whereIn("user_id", userIDs)
             .update({ active: false })
             .transacting(trx);
 
-        dbContext
-            .kmq("badges")
+        await dbContext
+            .kmq("badges_players")
             .whereIn("user_id", userIDs)
-            .andWhere("badge_name", "=", PATREON_SUPPORTER_BADGE)
+            .andWhere("badge_id", "=", PATREON_SUPPORTER_BADGE_ID)
             .del()
             .transacting(trx);
     });

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -372,9 +372,6 @@ export function registerIntervals(clusterID: number): void {
         if (await isPrimaryInstance()) {
             // Store per-cluster stats
             await updateSystemStats(clusterID);
-
-            // Sync state with Patreon subscribers
-            updatePremiumUsers();
         }
     });
 
@@ -387,6 +384,11 @@ export function registerIntervals(clusterID: number): void {
         if (timeUntilRestart) {
             updateBotStatus();
             await checkRestartNotification(timeUntilRestart);
+        }
+
+        // Sync state with Patreon subscribers
+        if (await isPrimaryInstance()) {
+            updatePremiumUsers();
         }
     });
 }


### PR DESCRIPTION
Closes #1338.

* Use 23 as the badge ID for Premium Supporter (table definition changed since premium was created) -- "🎧 Premium Supporter" = 23 on prod already
* Fix bug where empty query error thrown in addPremium when no premium users
* Correctly await removePremium db calls
* Update premium status every minute instead of every 5 minutes