### PR TITLE
Update reviewers upon branch push

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,24 @@
+reviewers:
+    # The default reviewers
+    defaults:
+        - repository-owners # group
+
+    # Reviewer groups each of which has a list of GitHub usernames
+    groups:
+        repository-owners:
+            - brainicism
+            - taahamahdi
+
+files:
+    # Keys are glob expressions.
+    # You can assign groups defined above as well as GitHub usernames.
+    "**":
+        - repository-owners
+    "i18n/ko.json":
+        - hoehoetvhss
+
+options:
+    ignore_draft: true
+    ignored_keywords:
+        - DO NOT REVIEW
+    enable_group_assignment: false

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -6,7 +6,7 @@ reviewers:
     # Reviewer groups each of which has a list of GitHub usernames
     groups:
         repository-owners:
-            - brainicism
+            - Brainicism
             - taahamahdi
 
 files:

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,16 @@
+name: Auto Request Review
+
+on:
+    pull_request:
+        types: [opened, ready_for_review, reopened]
+
+jobs:
+    auto-request-review:
+        name: Auto Request Review
+        runs-on: ubuntu-latest
+        steps:
+            - name: Request review based on files changes and/or groups the author belongs to
+              uses: necojackarc/auto-request-review@v0.7.0
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  config: .github/reviewers.yml # Config file location override

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -2,7 +2,7 @@ name: Auto Request Review
 
 on:
     pull_request:
-        types: [opened, ready_for_review, reopened]
+        types: [opened, ready_for_review, reopened, synchronize]
 
 jobs:
     auto-request-review:


### PR DESCRIPTION
synchronize: Triggered when a pull request's head branch is updated. For example, when the head branch is updated from the base branch, when new commits are pushed to the head branch, or when the base branch is changed.