### PR TITLE
Fix guild preference creation race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@types/node-schedule": "^1.3.2",
         "@types/pluralize": "^0.0.29",
         "@types/sinon": "^10.0.10",
+        "async-mutex": "^0.4.0",
         "axios": "^0.26.1",
         "bufferutil": "^4.0.6",
         "commander": "^9.0.0",

--- a/src/structures/guild_preference.ts
+++ b/src/structures/guild_preference.ts
@@ -17,11 +17,13 @@ import {
     GameOptionInternal,
 } from "../constants";
 import { IPCLogger } from "../logger";
+import { Mutex } from "async-mutex";
 import AnswerType from "../enums/option_types/answer_type";
 import GameOption from "../enums/game_option_name";
 import Gender from "../enums/option_types/gender";
 import _ from "lodash";
 import dbContext from "../database_context";
+import type { MutexInterface } from "async-mutex";
 import type ArtistType from "../enums/option_types/artist_type";
 import type GameOptions from "../interfaces/game_options";
 import type GuessModeType from "../enums/option_types/guess_mode_type";
@@ -190,6 +192,9 @@ export default class GuildPreference {
     /** The guild preference cache */
     private static guildPreferencesCache = {};
 
+    /** Locks for generating GuildPreference */
+    private static locks: Map<string, MutexInterface> = new Map();
+
     constructor(guildID: string, options?: GameOptions) {
         this.guildID = guildID;
         this.gameOptions = options || { ...GuildPreference.DEFAULT_OPTIONS };
@@ -217,39 +222,47 @@ export default class GuildPreference {
     }
 
     static async getGuildPreference(guildID: string): Promise<GuildPreference> {
-        if (guildID in GuildPreference.guildPreferencesCache) {
-            return GuildPreference.guildPreferencesCache[guildID];
+        if (!this.locks.has(guildID)) {
+            this.locks.set(guildID, new Mutex());
         }
 
-        const guildPreferences = await dbContext
-            .kmq("guilds")
-            .select("*")
-            .where("guild_id", "=", guildID);
+        return this.locks.get(guildID).runExclusive(async () => {
+            if (guildID in GuildPreference.guildPreferencesCache) {
+                return GuildPreference.guildPreferencesCache[guildID];
+            }
 
-        if (guildPreferences.length === 0) {
-            const guildPreference = GuildPreference.fromGuild(guildID);
-            await dbContext
+            const guildPreferences = await dbContext
                 .kmq("guilds")
-                .insert({ guild_id: guildID, join_date: new Date() });
+                .select("*")
+                .where("guild_id", "=", guildID);
+
+            if (guildPreferences.length === 0) {
+                const guildPreference = GuildPreference.fromGuild(guildID);
+                await dbContext
+                    .kmq("guilds")
+                    .insert({ guild_id: guildID, join_date: new Date() });
+                return guildPreference;
+            }
+
+            const gameOptionPairs = (
+                await dbContext.kmq("game_options").select("*").where({
+                    guild_id: guildID,
+                    client_id: process.env.BOT_CLIENT_ID,
+                })
+            )
+                .map((x) => ({
+                    [x["option_name"]]: JSON.parse(x["option_value"]),
+                }))
+                .reduce((total, curr) => Object.assign(total, curr), {});
+
+            const guildPreference = GuildPreference.fromGuild(
+                guildPreferences[0].guild_id,
+                gameOptionPairs
+            );
+
+            GuildPreference.guildPreferencesCache[guildID] = guildPreference;
             return guildPreference;
-        }
-
-        const gameOptionPairs = (
-            await dbContext.kmq("game_options").select("*").where({
-                guild_id: guildID,
-                client_id: process.env.BOT_CLIENT_ID,
-            })
-        )
-            .map((x) => ({ [x["option_name"]]: JSON.parse(x["option_value"]) }))
-            .reduce((total, curr) => Object.assign(total, curr), {});
-
-        const guildPreference = GuildPreference.fromGuild(
-            guildPreferences[0].guild_id,
-            gameOptionPairs
-        );
-
-        GuildPreference.guildPreferencesCache[guildID] = guildPreference;
-        return guildPreference;
+        });
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,6 +529,13 @@ array.prototype.flat@^1.2.5:
     es-abstract "^1.19.2"
     es-shim-unscopables "^1.0.0"
 
+async-mutex@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.4.0.tgz#ae8048cd4d04ace94347507504b3cf15e631c25f"
+  integrity sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==
+  dependencies:
+    tslib "^2.4.0"
+
 async@>=0.2.9, async@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
@@ -3124,7 +3131,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.3.1:
+tslib@^2.0.1, tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
Causing stale guild preference reference in game session when `,play` and game option update calls `getGuildPreference()` at the same time. If the database query to retrieve the game options finishes in the wrong order, it causes the game session to hold onto a stale guild preference, while `GuildPreference.getGuildPreference()` returns the new one. Game option updates happen on the new game options, not the GameSession's reference. 

Issue resolves itself if the user restarts the session.