### PR TITLE
Fix race condition between end round and song guess

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -295,6 +295,7 @@ export default class GameSession extends Session {
         }
 
         const round = this.round;
+        await super.endRound(messageContext);
 
         round.interactionMarkAnswers(guessResult.correctGuessers?.length);
 
@@ -315,6 +316,7 @@ export default class GameSession extends Session {
 
             this.guessTimes.push(timePlayed);
             await this.updateScoreboard(
+                round,
                 guessResult,
                 this.guildPreference,
                 timePlayed,
@@ -405,7 +407,6 @@ export default class GameSession extends Session {
         }
 
         this.updateBookmarkSongList();
-        await super.endRound(messageContext);
 
         if (this.scoreboard.gameFinished(this.guildPreference)) {
             this.endSession();
@@ -1331,13 +1332,13 @@ export default class GameSession extends Session {
     }
 
     private async updateScoreboard(
+        round: GameRound,
         guessResult: GuessResult,
         guildPreference: GuildPreference,
         timePlayed: number,
         messageContext: MessageContext
     ): Promise<void> {
         // update scoreboard
-        const round = this.round;
         const lastGuesserStreak = this.lastGuesser.streak;
         const playerRoundResults = await Promise.all(
             guessResult.correctGuessers.map(async (correctGuesser, idx) => {


### PR DESCRIPTION
Base class' `endRound` sets `this.round = null`, which is checked as a pre-condition in `gameSession.guessSong()`. Moved it to beginning of derived class' `endRound`