### PR TITLE
Configure guildsPerShard

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -237,3 +237,8 @@ export const TEST_DB_CACHED_EXPORT = path.join(
     __dirname,
     "../sql_dumps/kmq-test-cached.sql"
 );
+
+export const IGNORED_WARNING_SUBSTRINGS = [
+    "Unhandled MESSAGE_CREATE type",
+    "Unknown guild text channel type",
+];

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -26,5 +26,6 @@ declare namespace NodeJS {
         PATREON_CREATOR_ACCESS_TOKEN?: string;
         PATREON_CAMPAIGN_ID?: string;
         DAISUKI_SEED_CRON_JOB?: string;
+        GUILDS_PER_SHARD?: number;
     }
 }

--- a/src/events/client/warn.ts
+++ b/src/events/client/warn.ts
@@ -1,10 +1,7 @@
+import { IGNORED_WARNING_SUBSTRINGS } from "../../constants";
 import { IPCLogger } from "../../logger";
 
 const logger = new IPCLogger("warn");
-const IGNORED_WARNING_SUBSTRINGS = [
-    "Unhandled MESSAGE_CREATE type",
-    "Unknown guild text channel type",
-];
 
 /**
  * Handles the 'warn' event


### PR DESCRIPTION
Discord's recommended 1000 guilds per shard is too aggressive and spawns an unnecessary number of ws connections, as well as increasing startup time. Recommended upper limit is 2500 guilds per shard, so set 2000 as default with 500 per shard as padding. 

At current 50000 guilds, this would create 25 shards. This means that it would take an increase of 500/(1/25) = 12500 in server growth before needing to re-shard. This would take over 3 months assuming aggressive growth of 120 servers per day.