### PR TITLE
Add --trace-warnings flag

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -24,10 +24,10 @@ node build/seed/bootstrap.js
 echo "Starting bot..."
 cd build/
 if [ "${NODE_ENV}" == "dry-run" ] || [ "${NODE_ENV}" == "ci" ]; then
-    exec node "${PWD}/kmq.js"
+    exec node --trace-warnings "${PWD}/kmq.js"
 elif [ "${NODE_ENV}" == "development" ]; then
-    exec node --inspect=9229 "${PWD}/kmq.js"
+    exec node --trace-warnings --inspect=9229 "${PWD}/kmq.js"
 elif [ "${NODE_ENV}" == "production" ]; then
     git log -n 1 --pretty=format:"%H" > ../version
-    exec node "${PWD}/kmq.js"
+    exec node --trace-warnings "${PWD}/kmq.js"
 fi


### PR DESCRIPTION
This would give us a stack trace for 
```
Timeout duration was set to 1.
(node:2494510) TimeoutOverflowWarning: 18446744073425852000 does not fit into a 32-bit signed integer.
```