### PR TITLE
Update Python version in GCI

### DIFF
--- a/.github/workflows/gci-tests.yml
+++ b/.github/workflows/gci-tests.yml
@@ -29,10 +29,10 @@ jobs:
               uses: actions/checkout@v2
             - name: Check for undocumented game option commands
               run: src/ci_checks/check_help.sh
-            - name: Setup Python 3.6
+            - name: Setup Python
               uses: actions/setup-python@v2
               with:
-                  python-version: "3.6"
+                  python-version: "3.10"
             - name: Setup MariaDB
               uses: getong/mariadb-action@v1.1
               with:


### PR DESCRIPTION
3.6 is no longer supported.

Run actions/setup-python@v2
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json