### PR TITLE
Remove usage from full /help

### DIFF
--- a/src/commands/game_commands/help.ts
+++ b/src/commands/game_commands/help.ts
@@ -23,8 +23,8 @@ import type CommandArgs from "../../interfaces/command_args";
 import type HelpDocumentation from "../../interfaces/help";
 
 const logger = new IPCLogger("help");
-const FIELDS_PER_EMBED = 6;
-const excludedCommands = ["premium"];
+const FIELDS_PER_EMBED = 8;
+const excludedCommands = [];
 
 export default class HelpCommand implements BaseCommand {
     help = (guildID: string): HelpDocumentation => ({
@@ -216,11 +216,8 @@ export default class HelpCommand implements BaseCommand {
             embedFields = commandsWithHelp.map((command) => {
                 const helpManual = command.help(messageContext.guildID);
                 return {
-                    name: helpManual.name,
-                    value: `${helpManual.description}\n${i18n.translate(
-                        messageContext.guildID,
-                        "misc.usage"
-                    )}: \`${helpManual.usage}\``,
+                    name: `/${helpManual.name}`,
+                    value: helpManual.description,
                 };
             });
 


### PR DESCRIPTION
Increased commands shown on per-embed to 8 due to more space

The newlines for each command make the output too long, and with slash commands the usage is self-explanatory. With /help [action], the usage still shows

Also,

* Added / to the start of each command name in /help
* Removed /premium from excluded commands

![Screenshot from 2022-12-31 01-45-43](https://user-images.githubusercontent.com/14286913/210127968-81fab859-f42f-4814-bbcd-457b632ba86f.png)

![Screenshot from 2022-12-31 01-44-37](https://user-images.githubusercontent.com/14286913/210127945-580c86f4-61a0-4804-a354-29d4cd4f1af3.png)
