### PR TITLE
Localize option description fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "damerau-levenshtein": "^1.0.8",
         "dotenv": "^16.0.3",
         "ejs": "^3.1.8",
-        "eris": "https://github.com/Brainicism/eris.git#8d7f4f3",
+        "eris": "https://github.com/Brainicism/eris.git#100a47ba814b21e18a403c349ecf9a16b1ecb7d0",
         "eris-fleet": "https://github.com/Brainicism/eris-fleet#feature/soft-kill-warning",
         "eris-pagination": "https://github.com/Brainicism/eris-pagination#9a112cb",
         "erlpack": "https://github.com/abalabahaha/erlpack.git",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "damerau-levenshtein": "^1.0.8",
         "dotenv": "^16.0.3",
         "ejs": "^3.1.8",
-        "eris": "https://github.com/Brainicism/eris.git#100a47ba814b21e18a403c349ecf9a16b1ecb7d0",
+        "eris": "https://github.com/Brainicism/eris.git#dev",
         "eris-fleet": "https://github.com/Brainicism/eris-fleet#feature/soft-kill-warning",
         "eris-pagination": "https://github.com/Brainicism/eris-pagination#9a112cb",
         "erlpack": "https://github.com/abalabahaha/erlpack.git",

--- a/src/commands/game_commands/help.ts
+++ b/src/commands/game_commands/help.ts
@@ -65,6 +65,12 @@ export default class HelpCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.help.interaction.action"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.help.interaction.action"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes.STRING,
                     required: false,
                     autocomplete: true,

--- a/src/commands/game_commands/leaderboard.ts
+++ b/src/commands/game_commands/leaderboard.ts
@@ -138,6 +138,12 @@ export default class LeaderboardCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.leaderboard.help.example.enroll"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.leaderboard.help.example.enroll"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                 },
@@ -147,6 +153,12 @@ export default class LeaderboardCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.leaderboard.help.example.unenroll"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.leaderboard.help.example.unenroll"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                 },
@@ -156,6 +168,12 @@ export default class LeaderboardCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.leaderboard.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.leaderboard.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -165,6 +183,12 @@ export default class LeaderboardCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.leaderboard.interaction.type"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.leaderboard.interaction.type"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             choices: Object.values(LeaderboardType).map(
@@ -181,6 +205,12 @@ export default class LeaderboardCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.leaderboard.interaction.duration"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.leaderboard.interaction.duration"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             choices: [
@@ -202,6 +232,12 @@ export default class LeaderboardCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.leaderboard.interaction.scope"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.leaderboard.interaction.scope"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             choices: Object.values(LeaderboardScope).map(
@@ -218,6 +254,12 @@ export default class LeaderboardCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.leaderboard.interaction.page"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.leaderboard.interaction.page"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .INTEGER,
                         },

--- a/src/commands/game_commands/list.ts
+++ b/src/commands/game_commands/list.ts
@@ -92,6 +92,12 @@ export default class ListCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.list.interaction.listType"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.list.interaction.listType"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes.STRING,
                     required: true,
                     choices: [

--- a/src/commands/game_commands/locale.ts
+++ b/src/commands/game_commands/locale.ts
@@ -104,6 +104,12 @@ export default class LocaleTypeCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.locale.help.interaction.language"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.locale.help.interaction.language"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes.STRING,
                     required: true,
                     choices: Object.keys(LanguageNameToLocaleType).map(

--- a/src/commands/game_commands/lookup.ts
+++ b/src/commands/game_commands/lookup.ts
@@ -379,6 +379,12 @@ export default class LookupCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.lookup.help.interaction.byName.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.lookup.help.interaction.byName.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -388,6 +394,12 @@ export default class LookupCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.lookup.help.interaction.byName.field.song"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.lookup.help.interaction.byName.field.song"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             autocomplete: true,
@@ -398,6 +410,12 @@ export default class LookupCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.lookup.help.interaction.byName.field.artist"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.lookup.help.interaction.byName.field.artist"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             autocomplete: true,
@@ -410,6 +428,12 @@ export default class LookupCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.lookup.help.interaction.byLink.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.lookup.help.interaction.byLink.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -419,6 +443,12 @@ export default class LookupCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.lookup.help.interaction.byLink.field"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.lookup.help.interaction.byLink.field"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -243,6 +243,12 @@ export default class PlayCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.play.help.example.classic"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.play.help.example.classic"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandTypes.CHAT_INPUT,
                 },
                 {
@@ -254,6 +260,15 @@ export default class PlayCommand implements BaseCommand {
                             lives: `${ELIMINATION_DEFAULT_LIVES}`,
                         }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.play.help.example.elimination",
+                            {
+                                lives: `${ELIMINATION_DEFAULT_LIVES}`,
+                            }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -263,6 +278,12 @@ export default class PlayCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.play.help.interaction.lives"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.play.help.interaction.lives"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .INTEGER,
                             min_value: ELIMINATION_MIN_LIVES as any,
@@ -276,6 +297,12 @@ export default class PlayCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.play.help.example.teams"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.play.help.example.teams"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND_GROUP,
                     options: [
@@ -285,6 +312,12 @@ export default class PlayCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.play.interaction.teams_create"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.play.interaction.teams_create"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .SUB_COMMAND,
                         },
@@ -294,6 +327,12 @@ export default class PlayCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.play.interaction.teams_begin"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.play.interaction.teams_begin"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .SUB_COMMAND,
                         },
@@ -303,6 +342,12 @@ export default class PlayCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.play.interaction.teams_join"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.play.interaction.teams_join"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .SUB_COMMAND,
                             options: [
@@ -312,6 +357,12 @@ export default class PlayCommand implements BaseCommand {
                                         LocaleType.EN,
                                         "command.play.interaction.teams_join_team_name"
                                     ),
+                                    description_localizations: {
+                                        [LocaleType.KO]: i18n.translate(
+                                            LocaleType.KO,
+                                            "command.play.interaction.teams_join_team_name"
+                                        ),
+                                    },
                                     type: Eris.Constants
                                         .ApplicationCommandOptionTypes.STRING,
                                     required: true,

--- a/src/commands/game_commands/preset.ts
+++ b/src/commands/game_commands/preset.ts
@@ -251,6 +251,12 @@ export default class PresetCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.preset.help.example.list"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.preset.help.example.list"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                 },
@@ -260,6 +266,12 @@ export default class PresetCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.preset.help.example.save"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.preset.help.example.save"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -269,6 +281,12 @@ export default class PresetCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.preset.interaction.save.presetName"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.preset.interaction.save.presetName"
+                                ),
+                            },
                             required: true,
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
@@ -282,6 +300,13 @@ export default class PresetCommand implements BaseCommand {
                         "command.preset.help.example.load",
                         { exampleIdentifier: "KMQ-XXXXX-..." }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.preset.help.example.load",
+                            { exampleIdentifier: "KMQ-XXXXX-..." }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -291,6 +316,12 @@ export default class PresetCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.preset.interaction.load.presetName"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.preset.interaction.load.presetName"
+                                ),
+                            },
                             required: true,
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
@@ -304,6 +335,12 @@ export default class PresetCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.preset.help.example.delete"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.preset.help.example.delete"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -313,6 +350,12 @@ export default class PresetCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.preset.interaction.delete.presetName"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.preset.interaction.delete.presetName"
+                                ),
+                            },
                             required: true,
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
@@ -326,6 +369,12 @@ export default class PresetCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.preset.help.example.replace"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.preset.help.example.replace"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -335,6 +384,12 @@ export default class PresetCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.preset.interaction.replace.presetName"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.preset.interaction.replace.presetName"
+                                ),
+                            },
                             required: true,
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
@@ -348,6 +403,12 @@ export default class PresetCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.preset.help.example.export"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.preset.help.example.export"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -357,6 +418,12 @@ export default class PresetCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.preset.interaction.export.presetName"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.preset.interaction.export.presetName"
+                                ),
+                            },
                             required: true,
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
@@ -370,6 +437,12 @@ export default class PresetCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.preset.help.example.import"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.preset.help.example.import"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -379,6 +452,12 @@ export default class PresetCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.preset.interaction.import.exportedPresetID"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.preset.interaction.import.exportedPresetID"
+                                ),
+                            },
                             required: true,
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
@@ -389,6 +468,12 @@ export default class PresetCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.preset.interaction.import.presetName"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.preset.interaction.import.presetName"
+                                ),
+                            },
                             required: true,
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,

--- a/src/commands/game_commands/profile.ts
+++ b/src/commands/game_commands/profile.ts
@@ -297,6 +297,12 @@ export default class ProfileCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.profile.interaction.userMention"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.profile.interaction.userMention"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .MENTIONABLE,
                     required: false,
@@ -308,6 +314,12 @@ export default class ProfileCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.profile.interaction.userID"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.profile.interaction.userID"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes.STRING,
                     required: false,
                 },

--- a/src/commands/game_options/answer.ts
+++ b/src/commands/game_options/answer.ts
@@ -135,6 +135,12 @@ export default class AnswerCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.answer.help.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.answer.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -144,6 +150,12 @@ export default class AnswerCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.answer.help.interaction.answerOption"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.answer.help.interaction.answerOption"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -163,6 +175,13 @@ export default class AnswerCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "answer" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "answer" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/artisttype.ts
+++ b/src/commands/game_options/artisttype.ts
@@ -98,6 +98,12 @@ export default class ArtistTypeCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.artisttype.help.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.artisttype.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -107,6 +113,12 @@ export default class ArtistTypeCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.artisttype.help.interaction.artistTypeOption"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.artisttype.help.interaction.artistTypeOption"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -126,6 +138,13 @@ export default class ArtistTypeCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "artist type" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "artist type" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/cutoff.ts
+++ b/src/commands/game_options/cutoff.ts
@@ -113,6 +113,12 @@ export default class CutoffCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.cutoff.help.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.cutoff.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND_GROUP,
                     options: [
@@ -122,6 +128,12 @@ export default class CutoffCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.cutoff.help.interaction.earliestOption"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.cutoff.help.interaction.earliestOption"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .SUB_COMMAND,
                             options: [
@@ -131,6 +143,12 @@ export default class CutoffCommand implements BaseCommand {
                                         LocaleType.EN,
                                         "command.cutoff.help.interaction.beginningYear"
                                     ),
+                                    description_localizations: {
+                                        [LocaleType.KO]: i18n.translate(
+                                            LocaleType.KO,
+                                            "command.cutoff.help.interaction.beginningYear"
+                                        ),
+                                    },
                                     type: Eris.Constants
                                         .ApplicationCommandOptionTypes.INTEGER,
                                     required: true,
@@ -145,6 +163,12 @@ export default class CutoffCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.cutoff.help.interaction.rangeOption"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.cutoff.help.interaction.rangeOption"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .SUB_COMMAND,
                             options: [
@@ -154,6 +178,12 @@ export default class CutoffCommand implements BaseCommand {
                                         LocaleType.EN,
                                         "command.cutoff.help.interaction.beginningYear"
                                     ),
+                                    description_localizations: {
+                                        [LocaleType.KO]: i18n.translate(
+                                            LocaleType.KO,
+                                            "command.cutoff.help.interaction.beginningYear"
+                                        ),
+                                    },
                                     type: Eris.Constants
                                         .ApplicationCommandOptionTypes.INTEGER,
                                     required: true,
@@ -166,6 +196,12 @@ export default class CutoffCommand implements BaseCommand {
                                         LocaleType.EN,
                                         "command.cutoff.help.interaction.endingYear"
                                     ),
+                                    description_localizations: {
+                                        [LocaleType.KO]: i18n.translate(
+                                            LocaleType.KO,
+                                            "command.cutoff.help.interaction.endingYear"
+                                        ),
+                                    },
                                     type: Eris.Constants
                                         .ApplicationCommandOptionTypes.INTEGER,
                                     required: true,
@@ -183,6 +219,13 @@ export default class CutoffCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "cutoff" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "cutoff" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                 },

--- a/src/commands/game_options/duration.ts
+++ b/src/commands/game_options/duration.ts
@@ -127,6 +127,13 @@ export default class DurationCommand implements BaseCommand {
                         "command.duration.help.example.set",
                         { duration: "[duration]" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.duration.help.example.set",
+                            { duration: "[duration]" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -136,6 +143,12 @@ export default class DurationCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.duration.interaction.durationSet"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.duration.interaction.durationSet"
+                                ),
+                            },
                             required: true,
                             min_value: DURATION_DELTA_MIN,
                             max_value: DURATION_DELTA_MAX,
@@ -151,6 +164,13 @@ export default class DurationCommand implements BaseCommand {
                         "command.duration.help.example.increment",
                         { duration: "[duration]" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.duration.help.example.increment",
+                            { duration: "[duration]" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -160,6 +180,12 @@ export default class DurationCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.duration.interaction.durationAdd"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.duration.interaction.durationAdd"
+                                ),
+                            },
                             required: true,
                             min_value: DURATION_DELTA_MIN,
                             max_value: DURATION_DELTA_MAX,
@@ -175,6 +201,13 @@ export default class DurationCommand implements BaseCommand {
                         "command.duration.help.example.decrement",
                         { duration: "[duration]" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.duration.help.example.decrement",
+                            { duration: "[duration]" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -184,6 +217,12 @@ export default class DurationCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.duration.interaction.durationRemove"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.duration.interaction.durationRemove"
+                                ),
+                            },
                             required: true,
                             min_value: DURATION_DELTA_MIN,
                             max_value: DURATION_DELTA_MAX,
@@ -199,6 +238,13 @@ export default class DurationCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "duration" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "duration" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandTypes.CHAT_INPUT,
                 },
             ],

--- a/src/commands/game_options/exclude.ts
+++ b/src/commands/game_options/exclude.ts
@@ -124,6 +124,12 @@ export default class ExcludeCommand implements BaseCommand {
                     LocaleType.EN,
                     `command.exclude.help.interaction.${action}.description`
                 ),
+                description_localizations: {
+                    [LocaleType.KO]: i18n.translate(
+                        LocaleType.KO,
+                        `command.exclude.help.interaction.${action}.description`
+                    ),
+                },
                 type: Eris.Constants.ApplicationCommandOptionTypes.SUB_COMMAND,
                 options:
                     action === GroupAction.RESET
@@ -135,6 +141,13 @@ export default class ExcludeCommand implements BaseCommand {
                                   `command.exclude.help.interaction.${action}.perGroupDescription`,
                                   { ordinalNum: getOrdinalNum(x + 1) }
                               ),
+                              description_localizations: {
+                                  [LocaleType.KO]: i18n.translate(
+                                      LocaleType.KO,
+                                      `command.exclude.help.interaction.${action}.perGroupDescription`,
+                                      { ordinalNum: getOrdinalNum(x + 1) }
+                                  ),
+                              },
                               type: Eris.Constants.ApplicationCommandOptionTypes
                                   .STRING,
                               autocomplete: true,

--- a/src/commands/game_options/gender.ts
+++ b/src/commands/game_options/gender.ts
@@ -115,6 +115,12 @@ export default class GenderCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.gender.help.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.gender.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [...Array(4).keys()].map((x) => ({
@@ -123,6 +129,12 @@ export default class GenderCommand implements BaseCommand {
                             LocaleType.EN,
                             "command.gender.help.interaction.gender"
                         ),
+                        description_localizations: {
+                            [LocaleType.KO]: i18n.translate(
+                                LocaleType.KO,
+                                "command.gender.help.interaction.gender"
+                            ),
+                        },
                         type: Eris.Constants.ApplicationCommandOptionTypes
                             .STRING,
                         choices: Object.values(Gender)
@@ -144,6 +156,13 @@ export default class GenderCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "gender" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "gender" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/goal.ts
+++ b/src/commands/game_options/goal.ts
@@ -80,6 +80,12 @@ export default class GoalCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.goal.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.goal.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -89,6 +95,12 @@ export default class GoalCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.goal.interaction.score"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.goal.help.interaction.score"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .INTEGER,
                             required: true,
@@ -103,6 +115,13 @@ export default class GoalCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "goal" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "goal" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/groups.ts
+++ b/src/commands/game_options/groups.ts
@@ -119,6 +119,12 @@ export default class GroupsCommand implements BaseCommand {
                     LocaleType.EN,
                     `command.groups.help.interaction.${action}.description`
                 ),
+                description_localizations: {
+                    [LocaleType.KO]: i18n.translate(
+                        LocaleType.KO,
+                        `command.groups.help.interaction.${action}.description`
+                    ),
+                },
                 type: Eris.Constants.ApplicationCommandOptionTypes.SUB_COMMAND,
                 options:
                     action === GroupAction.RESET
@@ -130,6 +136,13 @@ export default class GroupsCommand implements BaseCommand {
                                   `command.groups.help.interaction.${action}.perGroupDescription`,
                                   { ordinalNum: getOrdinalNum(x + 1) }
                               ),
+                              description_localizations: {
+                                  [LocaleType.KO]: i18n.translate(
+                                      LocaleType.KO,
+                                      `command.groups.help.interaction.${action}.perGroupDescription`,
+                                      { ordinalNum: getOrdinalNum(x + 1) }
+                                  ),
+                              },
                               type: Eris.Constants.ApplicationCommandOptionTypes
                                   .STRING,
                               autocomplete: true,

--- a/src/commands/game_options/guessmode.ts
+++ b/src/commands/game_options/guessmode.ts
@@ -96,6 +96,12 @@ export default class GuessModeCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.guessmode.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.guessmode.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -105,6 +111,12 @@ export default class GuessModeCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.guessmode.interaction.guessMode"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.guessmode.interaction.guessMode"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -124,6 +136,13 @@ export default class GuessModeCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "guess mode" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "guess mode" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/include.ts
+++ b/src/commands/game_options/include.ts
@@ -124,6 +124,12 @@ export default class IncludeCommand implements BaseCommand {
                     LocaleType.EN,
                     `command.include.help.interaction.${action}.description`
                 ),
+                description_localizations: {
+                    [LocaleType.KO]: i18n.translate(
+                        LocaleType.KO,
+                        `command.include.help.interaction.${action}.description`
+                    ),
+                },
                 type: Eris.Constants.ApplicationCommandOptionTypes.SUB_COMMAND,
                 options:
                     action === GroupAction.RESET
@@ -135,6 +141,13 @@ export default class IncludeCommand implements BaseCommand {
                                   `command.include.help.interaction.${action}.perGroupDescription`,
                                   { ordinalNum: getOrdinalNum(x + 1) }
                               ),
+                              description_localizations: {
+                                  [LocaleType.KO]: i18n.translate(
+                                      LocaleType.KO,
+                                      `command.include.help.interaction.${action}.perGroupDescription`,
+                                      { ordinalNum: getOrdinalNum(x + 1) }
+                                  ),
+                              },
                               type: Eris.Constants.ApplicationCommandOptionTypes
                                   .STRING,
                               autocomplete: true,

--- a/src/commands/game_options/language.ts
+++ b/src/commands/game_options/language.ts
@@ -85,6 +85,12 @@ export default class LanguageCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.language.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.language.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -94,6 +100,12 @@ export default class LanguageCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.language.interaction.language"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.language.interaction.language"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -113,6 +125,13 @@ export default class LanguageCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "language" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "language" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/limit.ts
+++ b/src/commands/game_options/limit.ts
@@ -98,11 +98,17 @@ export default class LimitCommand implements BaseCommand {
             type: Eris.Constants.ApplicationCommandTypes.CHAT_INPUT,
             options: [
                 {
-                    name: "set",
+                    name: OptionAction.SET,
                     description: i18n.translate(
                         LocaleType.EN,
                         "command.limit.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.limit.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND_GROUP,
                     options: [
@@ -112,6 +118,12 @@ export default class LimitCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.limit.interaction.description_top"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.limit.help.interaction.description_top"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .SUB_COMMAND,
                             options: [
@@ -121,6 +133,12 @@ export default class LimitCommand implements BaseCommand {
                                         LocaleType.EN,
                                         "command.limit.interaction.limit"
                                     ),
+                                    description_localizations: {
+                                        [LocaleType.KO]: i18n.translate(
+                                            LocaleType.KO,
+                                            "command.limit.help.interaction.limit"
+                                        ),
+                                    },
                                     type: Eris.Constants
                                         .ApplicationCommandOptionTypes.INTEGER,
                                     required: true,
@@ -135,6 +153,12 @@ export default class LimitCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.limit.interaction.description_range"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.limit.help.interaction.description_range"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .SUB_COMMAND,
                             options: [
@@ -144,6 +168,12 @@ export default class LimitCommand implements BaseCommand {
                                         LocaleType.EN,
                                         "command.limit.interaction.limit_start"
                                     ),
+                                    description_localizations: {
+                                        [LocaleType.KO]: i18n.translate(
+                                            LocaleType.KO,
+                                            "command.limit.help.interaction.limit_start"
+                                        ),
+                                    },
                                     type: Eris.Constants
                                         .ApplicationCommandOptionTypes.INTEGER,
                                     required: true,
@@ -156,6 +186,12 @@ export default class LimitCommand implements BaseCommand {
                                         LocaleType.EN,
                                         "command.limit.interaction.limit_end"
                                     ),
+                                    description_localizations: {
+                                        [LocaleType.KO]: i18n.translate(
+                                            LocaleType.KO,
+                                            "command.limit.help.interaction.limit_end"
+                                        ),
+                                    },
                                     type: Eris.Constants
                                         .ApplicationCommandOptionTypes.INTEGER,
                                     required: true,
@@ -167,12 +203,19 @@ export default class LimitCommand implements BaseCommand {
                     ],
                 },
                 {
-                    name: "reset",
+                    name: OptionAction.RESET,
                     description: i18n.translate(
                         LocaleType.EN,
                         "command.limit.help.example.reset",
                         { defaultLimit: String(DEFAULT_LIMIT) }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.limit.help.example.reset",
+                            { defaultLimit: String(DEFAULT_LIMIT) }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandTypes.CHAT_INPUT,
                 },
             ],

--- a/src/commands/game_options/multiguess.ts
+++ b/src/commands/game_options/multiguess.ts
@@ -85,6 +85,12 @@ export default class MultiGuessCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.multiguess.help.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.multiguess.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -94,6 +100,12 @@ export default class MultiGuessCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.multiguess.help.interaction.multiguess"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.multiguess.help.interaction.multiguess"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -113,6 +125,13 @@ export default class MultiGuessCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "multiguess" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "multiguess" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/ost.ts
+++ b/src/commands/game_options/ost.ts
@@ -91,6 +91,12 @@ export default class OstCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.ost.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.ost.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -100,6 +106,12 @@ export default class OstCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.ost.interaction.ost"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.ost.interaction.ost"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -119,6 +131,13 @@ export default class OstCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "ost" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "ost" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/release.ts
+++ b/src/commands/game_options/release.ts
@@ -53,6 +53,12 @@ export default class ReleaseCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.release.help.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.release.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -62,6 +68,12 @@ export default class ReleaseCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.release.help.interaction.release"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.release.help.interaction.release"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -81,6 +93,13 @@ export default class ReleaseCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "release" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "release" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/seek.ts
+++ b/src/commands/game_options/seek.ts
@@ -91,6 +91,12 @@ export default class SeekCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.seek.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.seek.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -100,6 +106,12 @@ export default class SeekCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.seek.interaction.seek"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.seek.interaction.seek"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -119,6 +131,13 @@ export default class SeekCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "seek" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "seek" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/shuffle.ts
+++ b/src/commands/game_options/shuffle.ts
@@ -106,6 +106,12 @@ export default class ShuffleCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.shuffle.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.shuffle.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -115,6 +121,12 @@ export default class ShuffleCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.shuffle.interaction.shuffle"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.shuffle.interaction.shuffle"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -134,6 +146,13 @@ export default class ShuffleCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "shuffle" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "shuffle" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/special.ts
+++ b/src/commands/game_options/special.ts
@@ -123,6 +123,12 @@ export default class SpecialCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.special.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.special.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -132,6 +138,12 @@ export default class SpecialCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.special.interaction.special"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.special.interaction.special"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -151,6 +163,13 @@ export default class SpecialCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "special" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "special" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/spotify.ts
+++ b/src/commands/game_options/spotify.ts
@@ -56,6 +56,12 @@ export default class SpotifyCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.spotify.help.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.spotify.help.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -65,6 +71,12 @@ export default class SpotifyCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.spotify.help.interaction.playlistURL"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.spotify.help.interaction.playlistURL"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -78,6 +90,13 @@ export default class SpotifyCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "spotify" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "spotify" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/subunits.ts
+++ b/src/commands/game_options/subunits.ts
@@ -92,6 +92,13 @@ export default class SubunitsCommand implements BaseCommand {
                 "command.subunits.help.description",
                 { groups: "`/groups`" }
             ),
+            description_localizations: {
+                [LocaleType.KO]: i18n.translate(
+                    LocaleType.KO,
+                    "command.subunits.help.description",
+                    { groups: "`/groups`" }
+                ),
+            },
             type: Eris.Constants.ApplicationCommandTypes.CHAT_INPUT,
             options: [
                 {
@@ -103,6 +110,15 @@ export default class SubunitsCommand implements BaseCommand {
                             groups: "`/groups`",
                         }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.subunits.help.description",
+                            {
+                                groups: "`/groups`",
+                            }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -112,6 +128,12 @@ export default class SubunitsCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.subunits.interaction.subunits"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.subunits.interaction.subunits"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .STRING,
                             required: true,
@@ -131,6 +153,13 @@ export default class SubunitsCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "subunits" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "subunits" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/src/commands/game_options/timer.ts
+++ b/src/commands/game_options/timer.ts
@@ -81,6 +81,12 @@ export default class GuessTimeoutCommand implements BaseCommand {
                         LocaleType.EN,
                         "command.timer.interaction.description"
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "command.timer.help.interaction.description"
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [
@@ -90,6 +96,12 @@ export default class GuessTimeoutCommand implements BaseCommand {
                                 LocaleType.EN,
                                 "command.timer.interaction.timer"
                             ),
+                            description_localizations: {
+                                [LocaleType.KO]: i18n.translate(
+                                    LocaleType.KO,
+                                    "command.timer.help.interaction.timer"
+                                ),
+                            },
                             type: Eris.Constants.ApplicationCommandOptionTypes
                                 .INTEGER,
                             required: true,
@@ -105,6 +117,13 @@ export default class GuessTimeoutCommand implements BaseCommand {
                         "misc.interaction.resetOption",
                         { optionName: "timer" }
                     ),
+                    description_localizations: {
+                        [LocaleType.KO]: i18n.translate(
+                            LocaleType.KO,
+                            "misc.interaction.resetOption",
+                            { optionName: "timer" }
+                        ),
+                    },
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
                     options: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,9 +1077,9 @@ eris-reactions@^0.1.4:
   resolved "https://registry.yarnpkg.com/eris-reactions/-/eris-reactions-0.1.4.tgz#4b642f7411144f164b6097138c262eac6b03def1"
   integrity sha512-U2rMtfywnhh4TmqFcF7uo/ciyQN8vb9ptwSJMQs/uaY1a401f+t3sei1R3IR2gYqaFejJzgjTmzBMT6jIBPYYQ==
 
-"eris@https://github.com/Brainicism/eris.git#100a47ba814b21e18a403c349ecf9a16b1ecb7d0":
+"eris@https://github.com/Brainicism/eris.git#dev":
   version "0.17.1-dev"
-  resolved "https://github.com/Brainicism/eris.git#100a47ba814b21e18a403c349ecf9a16b1ecb7d0"
+  resolved "https://github.com/Brainicism/eris.git#fa4f23c5271019a2f5329de11c7a0641706947ef"
   dependencies:
     ws "^8.2.3"
   optionalDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,9 +1077,9 @@ eris-reactions@^0.1.4:
   resolved "https://registry.yarnpkg.com/eris-reactions/-/eris-reactions-0.1.4.tgz#4b642f7411144f164b6097138c262eac6b03def1"
   integrity sha512-U2rMtfywnhh4TmqFcF7uo/ciyQN8vb9ptwSJMQs/uaY1a401f+t3sei1R3IR2gYqaFejJzgjTmzBMT6jIBPYYQ==
 
-"eris@https://github.com/Brainicism/eris.git#8d7f4f3":
+"eris@https://github.com/Brainicism/eris.git#100a47ba814b21e18a403c349ecf9a16b1ecb7d0":
   version "0.17.1-dev"
-  resolved "https://github.com/Brainicism/eris.git#8d7f4f3adbd176e334580487b1f69c4d4b5c1241"
+  resolved "https://github.com/Brainicism/eris.git#100a47ba814b21e18a403c349ecf9a16b1ecb7d0"
   dependencies:
     ws "^8.2.3"
   optionalDependencies:


### PR DESCRIPTION
Associated PR in eris repo: https://github.com/Brainicism/eris/pull/11

For any commands with an `options` field, the `description` translations existed, but they weren't being passed to the slash command generators. This PR connects them. 

In the future, the `name` fields for each option also need to be translated, but that will require a larger code change, so it can be done afterwards.