### PR TITLE
Ignore voiceChannelLeave event for bot user

### DIFF
--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -21,6 +21,10 @@ export default async function voiceChannelLeaveHandler(
         return;
     }
 
+    if (member.id === process.env.BOT_CLIENT_ID) {
+        return;
+    }
+
     if (checkBotIsAlone(guildID)) {
         session.endSession(
             "Voice channel is empty, during voice channel leave"


### PR DESCRIPTION
When bot is disconnected from it's websocket connection, it emits a voiceChannelLeave event. This goes into the `checkBotIsAlone()` call which checks for a valid voice connection. Since there is no voice connection, it considers the bot alone, and ends the session. 