### PR TITLE
Replace comma with slash in docs/comments

### DIFF
--- a/src/command_prechecks.ts
+++ b/src/command_prechecks.ts
@@ -74,8 +74,8 @@ export default class CommandPrechecks {
                 gameSession.gameType === GameType.TEAMS
             ) {
                 if (!gameSession.sessionInitialized) {
-                    // The bot doesn't join the voice channel until after ,begin is called;
-                    // players should still be able ,end before that happens in these game modes
+                    // The bot doesn't join the voice channel until after /begin is called;
+                    // players should still be able /end before that happens in these game modes
                     return true;
                 }
             }

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -190,7 +190,7 @@ export default class PlayCommand implements BaseCommand {
     help = (guildID: string): HelpDocumentation => ({
         name: "play",
         description: i18n.translate(guildID, "command.play.help.description"),
-        usage: `/play classic\n\n,play elimination\nlives:{${i18n.translate(
+        usage: `/play classic\n\n/play elimination\nlives:{${i18n.translate(
             guildID,
             "command.play.help.usage.lives"
         )}}\n\n/play teams create\n\n/play teams join`,
@@ -841,7 +841,7 @@ export default class PlayCommand implements BaseCommand {
                 !gameSessions[guildID].sessionInitialized &&
                 gameType === GameType.TEAMS
             ) {
-                // User sent ,play teams twice, reset the GameSession
+                // User sent /play teams twice, reset the GameSession
                 Session.deleteSession(guildID);
                 logger.info(
                     `${getDebugLogHeader(
@@ -852,7 +852,7 @@ export default class PlayCommand implements BaseCommand {
         }
 
         // (1) No game session exists yet (create ELIMINATION, TEAMS, CLASSIC, or COMPETITION game), or
-        // (2) User attempting to ,play after a ,play teams that didn't start, start CLASSIC game
+        // (2) User attempting to /play after a /play teams that didn't start, start CLASSIC game
         const textChannel = await fetchChannel(messageContext.textChannelID);
         const gameOwner = new KmqMember(messageContext.author.id);
         let gameSession: GameSession;
@@ -939,7 +939,7 @@ export default class PlayCommand implements BaseCommand {
                 logger.warn(
                     `${getDebugLogHeader(
                         messageContext
-                    )} | User attempted ,play on a mode that requires player joins.`
+                    )} | User attempted /play on a mode that requires player joins.`
                 );
 
                 await sendErrorMessage(

--- a/src/commands/game_commands/preset.ts
+++ b/src/commands/game_commands/preset.ts
@@ -182,7 +182,7 @@ export default class PresetCommand implements BaseCommand {
                 example: `\`/preset load preset_name:[${i18n.translate(
                     guildID,
                     "command.preset.help.usage.presetName"
-                )}]\n,preset load preset_identifier:[${i18n.translate(
+                )}]\n/preset load preset_identifier:[${i18n.translate(
                     guildID,
                     "command.preset.help.usage.presetIdentifier"
                 )}]\``,

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -923,7 +923,7 @@ export async function generateOptionsMessage(
         .filter((option) => optionStrings[option as GameOption])
         .filter((option) => !PriorityGameOption.includes(option as GameOption));
 
-    // Remove priority options; emplace ,spotify/,answer at the start of options
+    // Remove priority options; emplace /spotify / /answer at the start of options
     if (isSpotify) {
         priorityOptions = "";
         fieldOptions.unshift(GameOption.ANSWER_TYPE);

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -801,7 +801,7 @@ export default class GameSession extends Session {
         );
 
         if (this.gameType === GameType.TEAMS) {
-            // Players join teams manually with ,join
+            // Players join teams manually with /join
             return;
         }
 

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -100,7 +100,7 @@ export default abstract class Session {
         [userID: string]: Map<string, BookmarkedSong>;
     };
 
-    /** Timer function used to for ,timer command */
+    /** Timer function used to for /timer command */
     private guessTimeoutFunc: NodeJS.Timer;
 
     constructor(

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -35,7 +35,7 @@ export default class SongSelector {
         countBeforeLimit: number;
     } | null;
 
-    /** List of songs played with ,shuffle unique enabled */
+    /** List of songs played with /shuffle unique enabled */
     public uniqueSongsPlayed: Set<string>;
 
     /** The last gender played when gender is set to alternating, can be null (in not alternating mode), GENDER.MALE, or GENDER.FEMALE */
@@ -139,7 +139,7 @@ export default class SongSelector {
      * Selects a random song based on the GameOptions, avoiding recently played songs
      * @param filteredSongs - The filtered songs to select from
      * @param ignoredSongs - The union of last played songs and unique songs to not select from
-     * @param alternatingGender - The gender to limit selecting from if ,gender alternating
+     * @param alternatingGender - The gender to limit selecting from if /gender alternating
      * @param shuffleType - The shuffle type
      * @returns the QueriedSong
      */

--- a/src/test/ci/begin.test.ts
+++ b/src/test/ci/begin.test.ts
@@ -56,7 +56,7 @@ describe("begin command", () => {
 
             sandbox.restore();
 
-            it("should return false (classic games are not started using ,begin)", () => {
+            it("should return false (classic games are not started using /begin)", () => {
                 assert.strictEqual(
                     PlayCommand.canStartTeamsGame(
                         gameSession,


### PR DESCRIPTION
`,play` and `,preset` were the only user-facing commands still showing commas