### PR TITLE
Cast uuids to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "zlib-sync": "^0.1.7"
     },
     "devDependencies": {
-        "@types/uuid": "^8.3.4",
+        "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.38.1",
         "eslint": "^8.24.0",

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -218,7 +218,7 @@ export default class GameSession extends Session {
                 });
             }
 
-            round.interactionCorrectAnswerUUID = uuid.v4();
+            round.interactionCorrectAnswerUUID = uuid.v4() as string;
             buttons.push({
                 type: 2,
                 style: 1,

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -918,7 +918,7 @@ export default abstract class Session {
 
         if (round instanceof ListeningRound) {
             const buttons: Array<Eris.InteractionButton> = [];
-            round.interactionSkipUUID = uuid.v4();
+            round.interactionSkipUUID = uuid.v4() as string;
             buttons.push({
                 type: 2,
                 style: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,10 +400,10 @@
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
   integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+"@types/uuid@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
+  integrity sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==
 
 "@typescript-eslint/eslint-plugin@^5.38.1":
   version "5.38.1"


### PR DESCRIPTION
Unsure why but canary transpile was failing due to 
```
1|kmq-2  | Compiling typescript...
1|kmq-2  | src/structures/game_session.ts(226,17): error TS2322: Type 'string | null' is not assignable to type 'string'.
1|kmq-2  |   Type 'null' is not assignable to type 'string'.
1|kmq-2  | src/structures/session.ts(926,17): error TS2322: Type 'string | null' is not assignable to type 'string'.
1|kmq-2  |   Type 'null' is not assignable to type 'string'.
```

Despite the typings for uuid.v4() not including `| null`. Still not sure where it comes from