### PR TITLE
Improve spotify song matching

### DIFF
--- a/src/commands/game_commands/lookup.ts
+++ b/src/commands/game_commands/lookup.ts
@@ -7,7 +7,6 @@ import {
     friendlyFormattedNumber,
     isValidURL,
 } from "../../helpers/utils";
-import { cleanSongName } from "../../structures/game_round";
 import {
     getDebugLogHeader,
     getInteractionValue,
@@ -22,8 +21,10 @@ import {
     getLocalizedArtistName,
     getLocalizedSongName,
     isPremiumRequest,
+    normalizeArtistNameEntry,
 } from "../../helpers/game_utils";
 import { getVideoID, validateID } from "ytdl-core";
+import { normalizePunctuationInName } from "../../structures/game_round";
 import { sendValidationErrorMessage } from "../../helpers/validate";
 import Eris from "eris";
 import GuildPreference from "../../structures/guild_preference";
@@ -606,7 +607,7 @@ export default class LookupCommand implements BaseCommand {
             let artistID: number | undefined;
             if (artistName) {
                 const matchingArtist =
-                    State.artistToEntry[artistName.toLowerCase()];
+                    State.artistToEntry[normalizeArtistNameEntry(artistName)];
 
                 if (matchingArtist) {
                     artistID = matchingArtist.id;
@@ -636,7 +637,7 @@ export default class LookupCommand implements BaseCommand {
 
         const focusedVal = interactionData.interactionOptions[focusedKey];
 
-        const lowercaseUserInput = focusedVal.toLowerCase();
+        const lowercaseUserInput = normalizeArtistNameEntry(focusedVal);
         const showHangul =
             containsHangul(lowercaseUserInput) ||
             State.getGuildLocale(interaction.guildID as string) ===
@@ -648,7 +649,9 @@ export default class LookupCommand implements BaseCommand {
 
             let artistID: number | undefined;
             if (artistName) {
-                artistID = State.artistToEntry[artistName.toLowerCase()]?.id;
+                artistID =
+                    State.artistToEntry[normalizeArtistNameEntry(artistName)]
+                        ?.id;
             }
 
             if (lowercaseUserInput.length < 2) {
@@ -695,7 +698,8 @@ export default class LookupCommand implements BaseCommand {
                 matchingArtists = searchArtists(lowercaseUserInput, []);
             } else {
                 // only return artists that have a song that matches the entered one
-                const cleanEnteredSongName = cleanSongName(enteredSongName);
+                const cleanEnteredSongName =
+                    normalizePunctuationInName(enteredSongName);
 
                 const matchingSongs = Object.values(
                     State.songLinkToEntry

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -33,6 +33,7 @@ import {
     getLocalizedArtistName,
     getLocalizedSongName,
     isPremiumRequest,
+    normalizeArtistNameEntry,
     userBonusIsActive,
 } from "./game_utils";
 import EmbedPaginator from "eris-pagination";
@@ -1878,7 +1879,7 @@ export async function processGroupAutocompleteInteraction(
     }
 
     const focusedVal = interactionData.interactionOptions[focusedKey];
-    const lowercaseUserInput = focusedVal.toLowerCase();
+    const lowercaseUserInput = normalizeArtistNameEntry(focusedVal);
 
     const previouslyEnteredArtists = getMatchedArtists(
         Object.entries(interactionData.interactionOptions)

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -609,7 +609,5 @@ export function isPowerHour(): boolean {
  * @returns the normalized artist name for state entry
  */
 export function normalizeArtistNameEntry(artistName: string): string {
-    return normalizePunctuationInName(
-        artistName.toLowerCase().replaceAll(" ", "")
-    );
+    return normalizePunctuationInName(artistName.toLowerCase());
 }

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -3,7 +3,10 @@ import {
     PATREON_SUPPORTER_BADGE_ID,
     SHADOW_BANNED_ARTIST_IDS,
 } from "../constants";
-import { cleanArtistName, cleanSongName } from "../structures/game_round";
+import {
+    cleanArtistName,
+    normalizePunctuationInName,
+} from "../structures/game_round";
 import { containsHangul, md5Hash } from "./utils";
 import AnswerType from "../enums/option_types/answer_type";
 import GuessModeType from "../enums/option_types/guess_mode_type";
@@ -362,12 +365,12 @@ export async function getMultipleChoiceOptions(
         const uniqueResult = new Map();
         const removedResults: Array<string> = [];
         for (const song of result) {
-            if (uniqueResult.has(cleanSongName(song))) {
+            if (uniqueResult.has(normalizePunctuationInName(song))) {
                 removedResults.push(song);
                 continue;
             }
 
-            uniqueResult.set(cleanSongName(song), song);
+            uniqueResult.set(normalizePunctuationInName(song), song);
         }
 
         result = [...uniqueResult.values()];
@@ -598,5 +601,15 @@ export function isPowerHour(): boolean {
     const currentHour = date.getHours();
     return powerHours.some(
         (powerHour) => currentHour >= powerHour && currentHour <= powerHour + 1
+    );
+}
+
+/**
+ * @param artistName - the artist name
+ * @returns the normalized artist name for state entry
+ */
+export function normalizeArtistNameEntry(artistName: string): string {
+    return normalizePunctuationInName(
+        artistName.toLowerCase().replaceAll(" ", "")
     );
 }

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -6,6 +6,7 @@ import {
     cleanupInactiveGameSessions,
     getMatchingGroupNames,
     isPowerHour,
+    normalizeArtistNameEntry,
 } from "./game_utils";
 import { reloadFactCache } from "../fact_generator";
 import { sendInfoMessage, sendPowerHourNotification } from "./discord_utils";
@@ -13,7 +14,7 @@ import KmqConfiguration from "../kmq_configuration";
 import MessageContext from "../structures/message_context";
 import i18n from "./localization_manager";
 
-import { cleanSongName } from "../structures/game_round";
+import { normalizePunctuationInName } from "../structures/game_round";
 import State from "../state";
 import _ from "lodash";
 import dbContext from "../database_context";
@@ -302,12 +303,16 @@ async function reloadArtists(): Promise<void> {
             id: mapping["id_artist"],
         };
 
-        State.artistToEntry[mapping["artist_name_en"].toLowerCase()] =
-            artistEntry;
+        State.artistToEntry[
+            normalizeArtistNameEntry(mapping["artist_name_en"])
+        ] = artistEntry;
+
         State.artistToEntry[mapping["artist_name_ko"]] = artistEntry;
+
         for (const alias in aliases) {
             if (alias.length > 0) {
-                State.artistToEntry[alias.toLowerCase()] = artistEntry;
+                State.artistToEntry[normalizeArtistNameEntry(alias)] =
+                    artistEntry;
             }
         }
     }
@@ -343,8 +348,12 @@ async function reloadSongs(): Promise<void> {
             hangulName: mapping["song_name_ko"],
             artistID: mapping["id_artist"],
             songLink: mapping["link"],
-            cleanName: cleanSongName(mapping["clean_song_name_en"]),
-            hangulCleanName: cleanSongName(mapping["clean_song_name_ko"]),
+            cleanName: normalizePunctuationInName(
+                mapping["clean_song_name_en"]
+            ),
+            hangulCleanName: normalizePunctuationInName(
+                mapping["clean_song_name_ko"]
+            ),
         };
 
         State.songLinkToEntry[songEntry.songLink] = songEntry;

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -206,9 +206,10 @@ export default class SpotifyManager {
 
             // handle songs with brackets in name, consider all components separately
             const songNameBracketComponents = song.name.split("(");
-            const songNames = [songNameBracketComponents[0], song.name];
+            const songNames = [songNameBracketComponents[0]];
             if (songNameBracketComponents.length > 1) {
                 songNames.push(songNameBracketComponents[1].replace(")", ""));
+                songNames.push(song.name);
             }
 
             const query = dbContext

--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -39,7 +39,7 @@ interface GuessCorrectness {
  * @param name - the song name
  * @returns The cleaned song name
  */
-export function cleanSongName(name: string): string {
+export function normalizePunctuationInName(name: string): string {
     let cleanName = name.toLowerCase();
     for (const characterReplacement of CHARACTER_REPLACEMENTS) {
         cleanName = cleanName.replace(
@@ -495,9 +495,9 @@ export default class GameRound extends Round {
      * @returns whether or not the guess was correct
      */
     private checkSongGuess(message: string): GuessCorrectness {
-        const guess = cleanSongName(message);
+        const guess = normalizePunctuationInName(message);
         const cleanedSongAliases = this.acceptedSongAnswers.map((x) =>
-            cleanSongName(x)
+            normalizePunctuationInName(x)
         );
 
         return {

--- a/src/test/ci/game_round.test.ts
+++ b/src/test/ci/game_round.test.ts
@@ -3,7 +3,7 @@ import { ExpBonusModifierValues } from "../../constants";
 import ExpBonusModifier from "../../enums/exp_bonus_modifier";
 import GameRound, {
     cleanArtistName,
-    cleanSongName,
+    normalizePunctuationInName,
 } from "../../structures/game_round";
 import Gender from "../../enums/option_types/gender";
 import GuessModeType from "../../enums/option_types/guess_mode_type";
@@ -189,7 +189,10 @@ describe("game round", () => {
     describe("clean song/artist name", () => {
         describe("has uppercase characters", () => {
             it("converts to full lower case", () => {
-                assert.strictEqual(cleanSongName("BLahBLah"), "blahblah");
+                assert.strictEqual(
+                    normalizePunctuationInName("BLahBLah"),
+                    "blahblah"
+                );
                 assert.strictEqual(cleanArtistName("ClaHClaH"), "clahclah");
             });
         });
@@ -197,7 +200,7 @@ describe("game round", () => {
         describe("has trailing or leading spaces", () => {
             it("removes the whitespace", () => {
                 assert.strictEqual(
-                    cleanSongName("       blahblah          "),
+                    normalizePunctuationInName("       blahblah          "),
                     "blahblah"
                 );
 
@@ -210,14 +213,21 @@ describe("game round", () => {
 
         describe("has unwanted punctuation or symbols", () => {
             it("removes the specified list of removed punctuation", () => {
-                assert.strictEqual(cleanSongName("!bl:ah blah?"), "blahblah");
+                assert.strictEqual(
+                    normalizePunctuationInName("!bl:ah blah?"),
+                    "blahblah"
+                );
                 assert.strictEqual(cleanArtistName("!cl:ah clah?"), "clahclah");
             });
         });
 
         describe("has punctuation to replace", () => {
             it("replaces the punctuation with the correct replacement", () => {
-                assert.strictEqual(cleanSongName("blah & blah"), "blahandblah");
+                assert.strictEqual(
+                    normalizePunctuationInName("blah & blah"),
+                    "blahandblah"
+                );
+
                 assert.strictEqual(
                     cleanArtistName("clah & clah"),
                     "clahandclah"


### PR DESCRIPTION
- Better matching for song names with brackets. e.g "Egoist (Olivia Hye)". Attempts to match each component separately, as well as all together
- Match artists in all lowercase AND punctuation removed
- Match song names with all non-alphanumeric characters removed
- Match against id_parent_artist