### PR TITLE
Consolidate add/remove premium into one tx

### DIFF
--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -455,18 +455,19 @@ export async function isUserPremium(userID: string): Promise<boolean> {
 }
 
 /**
- * @param patrons - The users to grant premium membership
+ * @param activePatrons - The users to grant premium membership
+ * @param inactiveUserIDs - The users to revoke premium membership from
  */
-export async function addPremium(patrons: Array<Patron>): Promise<void> {
-    if (patrons.length === 0) {
-        return;
-    }
-
+export async function updatePremium(
+    activePatrons: Array<Patron>,
+    inactiveUserIDs: string[]
+): Promise<void> {
     await dbContext.kmq.transaction(async (trx) => {
+        // Grant premium
         await dbContext
             .kmq("premium_users")
             .insert(
-                patrons.map((x) => ({
+                activePatrons.map((x) => ({
                     active: x.activePatron,
                     first_subscribed: x.firstSubscribed,
                     user_id: x.discordID,
@@ -479,7 +480,7 @@ export async function addPremium(patrons: Array<Patron>): Promise<void> {
         await dbContext
             .kmq("badges_players")
             .insert(
-                patrons.map((x) => ({
+                activePatrons.map((x) => ({
                     user_id: x.discordID,
                     badge_id: PATREON_SUPPORTER_BADGE_ID,
                 }))
@@ -487,23 +488,17 @@ export async function addPremium(patrons: Array<Patron>): Promise<void> {
             .onConflict(["user_id", "badge_name"])
             .ignore()
             .transacting(trx);
-    });
-}
 
-/**
- * @param userIDs - The users to revoke premium membership from
- */
-export async function removePremium(userIDs: string[]): Promise<void> {
-    await dbContext.kmq.transaction(async (trx) => {
+        // Revoke premium
         await dbContext
             .kmq("premium_users")
-            .whereIn("user_id", userIDs)
+            .whereIn("user_id", inactiveUserIDs)
             .update({ active: false })
             .transacting(trx);
 
         await dbContext
             .kmq("badges_players")
-            .whereIn("user_id", userIDs)
+            .whereIn("user_id", inactiveUserIDs)
             .andWhere("badge_id", "=", PATREON_SUPPORTER_BADGE_ID)
             .del()
             .transacting(trx);

--- a/src/helpers/patreon_manager.ts
+++ b/src/helpers/patreon_manager.ts
@@ -1,5 +1,5 @@
 import { IPCLogger } from "../logger";
-import { addPremium, removePremium } from "./game_utils";
+import { updatePremium } from "./game_utils";
 import Axios from "axios";
 import dbContext from "../database_context";
 import type Patron from "../interfaces/patron";
@@ -120,7 +120,8 @@ export default async function updatePremiumUsers(): Promise<void> {
         .filter((x) => x.activePatron)
         .map((x) => x.discordID);
 
-    await removePremium(
+    await updatePremium(
+        patrons,
         (
             await dbContext
                 .kmq("premium_users")
@@ -129,5 +130,4 @@ export default async function updatePremiumUsers(): Promise<void> {
                 .whereNot("source", "=", "loyalty")
         ).map((x) => x.user_id)
     );
-    await addPremium(patrons);
 }

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ rebuild () {
 }
 
 echo "Killing running instances..."
-ps x | grep node | grep "${PWD}/" | egrep "kmq\.js|cluster_manager\.js|kmq\.ts" | awk '{print $1}' | xargs kill &> /dev/null || echo "No running instances to kill"
+ps x | grep node | grep "${PWD}/" | grep -E "kmq\.js|cluster_manager\.js|kmq\.ts" | awk '{print $1}' | xargs kill &> /dev/null || echo "No running instances to kill"
 
 echo "Bootstrapping..."
 npx ts-node  --swc src/seed/bootstrap.ts


### PR DESCRIPTION
Previous:
```
      knex:query select `user_id` from `premium_users` where `user_id` not in (?, ?, ?) and not `source` = ? undefined +60s
      knex:tx trx44: Starting top level transaction +60s
      knex:query BEGIN; trx44 +1ms
      knex:query update `premium_users` set `active` = ? where `user_id` in (?, ?, ?) trx44 +0ms
      knex:query delete from `badges_players` where `user_id` in (?, ?, ?) and `badge_id` = ? trx44 +0ms
      knex:query COMMIT; trx44 +0ms
      knex:tx trx44: releasing connection +16ms
      knex:tx trx45: Starting top level transaction +0ms
      knex:query BEGIN; trx45 +15ms
      knex:query insert into `premium_users` (`active`, `first_subscribed`, `user_id`) values (?, ?, ?), (?, ?, ?), (?, ?, ?), (?, ?, ?), (?, ?, ?) on duplicate key update `active` = values(`active`), `first_subscribed` = values(`first_subscribed`), `user_id` = values(`user_id`) trx45 +1ms
      knex:query insert ignore into `badges_players` (`badge_id`, `user_id`) values (?, ?), (?, ?), (?, ?), (?, ?), (?, ?) trx45 +0ms
      knex:query COMMIT; trx45 +0ms
      knex:tx trx45: releasing connection +2ms
```
    
Updated:
```
      knex:query select `user_id` from `premium_users` where `user_id` not in (?, ?, ?) and not `source` = ? undefined +38s
      knex:tx trx8: Starting top level transaction +0ms
      knex:query BEGIN; trx8 +1ms
      knex:query insert into `premium_users` (`active`, `first_subscribed`, `user_id`) values (?, ?, ?), (?, ?, ?), (?, ?, ?), (?, ?, ?), (?, ?, ?) on duplicate key update `active` = values(`active`), `first_subscribed` = values(`first_subscribed`), `user_id` = values(`user_id`) trx8 +1ms
      knex:query insert ignore into `badges_players` (`badge_id`, `user_id`) values (?, ?), (?, ?), (?, ?), (?, ?), (?, ?) trx8 +1ms
      knex:query update `premium_users` set `active` = ? where `user_id` in (?, ?, ?) trx8 +0ms
      knex:query delete from `badges_players` where `user_id` in (?, ?, ?) and `badge_id` = ? trx8 +1ms
      knex:query COMMIT; trx8 +0ms
      knex:tx trx8: releasing connection +18ms
```

Also replaces `egrep` with `grep -E` (deprecated)