### PR TITLE
Parallelize spotify matching database lookup

### DIFF
--- a/src/commands/game_options/spotify.ts
+++ b/src/commands/game_options/spotify.ts
@@ -237,7 +237,10 @@ export default class SpotifyCommand implements BaseCommand {
             logger.info(
                 `${getDebugLogHeader(messageContext)} | Matched ${
                     matchedPlaylist.metadata.matchedSongsLength
-                }/${matchedPlaylist.metadata.playlistLength} Spotify songs`
+                }/${matchedPlaylist.metadata.playlistLength} (${(
+                    (100.0 * matchedPlaylist.metadata.matchedSongsLength) /
+                    matchedPlaylist.metadata.playlistLength
+                ).toFixed(2)}%) Spotify songs`
             );
 
             if (matchedPlaylist.matchedSongs.length === 0) {

--- a/src/database_context.ts
+++ b/src/database_context.ts
@@ -44,8 +44,8 @@ export class DatabaseContext {
                 generateKnexContext("kpop_videos_test", 0, 1)
             );
         } else {
-            this.kmq = knex(generateKnexContext("kmq", 0, 5));
-            this.kpopVideos = knex(generateKnexContext("kpop_videos", 0, 1));
+            this.kmq = knex(generateKnexContext("kmq", 0, 20));
+            this.kpopVideos = knex(generateKnexContext("kpop_videos", 0, 5));
         }
 
         this.agnostic = knex(generateKnexContext(null, 0, 1));


### PR DESCRIPTION
Parallelizing database queries in chunks. Experimented with varying chunk sizes for playlist size of 4214

1 chunk (base case) = 100s - 106s
2 chunk = 61s - 64s
3 chunk = 59s - 61s
4 chunk = 57s - 58s

Diminishing returns after 4 chunk
