### PR TITLE
Use async promise pool instead of Promise.all for spotify db queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "node-schedule": "^2.1.0",
         "sinon": "^14.0.0",
         "sodium-native": "^3.4.1",
+        "tiny-async-pool": "^2.1.0",
         "ts-node": "^10.9.1",
         "uuid": "^9.0.0",
         "winston": "^3.8.2",

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-await-in-loop */
 import { IPCLogger } from "../logger";
-import { chunkArray, retryJob } from "./utils";
 import { normalizeArtistNameEntry } from "./game_utils";
+import { retryJob } from "./utils";
 import Axios from "axios";
 import SongSelector from "../structures/song_selector";
 import State from "../state";
 import _ from "lodash";
+import asyncPool from "tiny-async-pool";
 import dbContext from "../database_context";
 import type { AxiosResponse } from "axios";
 import type QueriedSong from "../interfaces/queried_song";
@@ -177,38 +178,29 @@ export default class SpotifyManager {
 
         let matchedSongs: Array<QueriedSong> = [];
         const unmatchedSongs: Array<string> = [];
-        const chunkedSpotifySongs = chunkArray(spotifySongs, 4);
 
         logger.info(
             `Starting to parse playlist: ${playlistID}, number of songs: ${spotifySongs.length}`
         );
         const start = Date.now();
-        for (const [idx, spotifySongChunk] of chunkedSpotifySongs.entries()) {
-            logger.info(
-                `Processing chunk ${idx + 1}/${
-                    chunkedSpotifySongs.length
-                } of ${playlistID}.`
-            );
-            const promises = spotifySongChunk.map((x) =>
-                this.generateSongMatchingPromise(x, isPremium)
-            );
+        for await (const queryOutput of asyncPool(
+            4,
+            spotifySongs,
+            (x: SpotifyTrack) => this.generateSongMatchingPromise(x, isPremium)
+        )) {
+            if ((unmatchedSongs.length + matchedSongs.length) % 100 === 0) {
+                logger.info(
+                    `Processed ${unmatchedSongs.length + matchedSongs.length}/${
+                        spotifySongs.length
+                    } for playlist ${playlistID}`
+                );
+            }
 
-            const settledPromises = await Promise.allSettled(promises);
-            unmatchedSongs.push(
-                ...(
-                    settledPromises.filter(
-                        (x) => x.status === "rejected"
-                    ) as PromiseRejectedResult[]
-                ).map((x) => x.reason as string)
-            );
-
-            matchedSongs.push(
-                ...(
-                    settledPromises.filter(
-                        (x) => x.status === "fulfilled"
-                    ) as PromiseFulfilledResult<QueriedSong>[]
-                ).map((x) => x.value)
-            );
+            if (typeof queryOutput === "string") {
+                unmatchedSongs.push(queryOutput);
+            } else {
+                matchedSongs.push(queryOutput);
+            }
         }
 
         const end = Date.now();
@@ -239,8 +231,8 @@ export default class SpotifyManager {
     private generateSongMatchingPromise(
         song: SpotifyTrack,
         isPremium: boolean
-    ): Promise<QueriedSong> {
-        return new Promise(async (resolve, reject) => {
+    ): Promise<QueriedSong | string> {
+        return new Promise(async (resolve) => {
             const aliasIDs: Array<number> = [];
             for (const artist of song.artists) {
                 const lowercaseArtist = normalizeArtistNameEntry(artist);
@@ -321,8 +313,7 @@ export default class SpotifyManager {
             if (result) {
                 resolve(result);
             } else {
-                // eslint-disable-next-line prefer-promise-reject-errors
-                reject(`${song.name} - ${song.artists[0]}`);
+                resolve(`${song.name} - ${song.artists[0]}`);
             }
         });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3309,6 +3309,11 @@ tildify@2.0.0:
   resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
   integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
 
+tiny-async-pool@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-async-pool/-/tiny-async-pool-2.1.0.tgz#3ec126568c18a7916912fb9fbecf812337ec6b84"
+  integrity sha512-ltAHPh/9k0STRQqaoUX52NH4ZQYAJz24ZAEwf1Zm+HYg3l9OXTWeqWKyYsHu40wF/F0rxd2N2bk5sLvX2qlSvg==
+
 tiny-lru@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-10.0.1.tgz#aaf5d22207e641ed1b176ac2e616d6cc2fc9ef66"


### PR DESCRIPTION
Chunking promises and using Promise.all() causes unnecessary delay when one of the promises takes longer than the others. Switched to using async-pool to maximize concurrency.

Average ~20% decrease in total query time.
For playlist of 4214 songs, 66s -> 55s
For playlist of 2283 songs, 18.5s -> 15.5s
