### PR TITLE
Preprocess alphanumeric-only song names for song match

### DIFF
--- a/sql/procedures/create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/create_kmq_data_tables_procedure.sql
@@ -15,6 +15,7 @@ BEGIN
 	CREATE TABLE available_songs_temp (
 		song_name_en VARCHAR(255) NOT NULL,
 		clean_song_name_en VARCHAR(255) NOT NULL,
+		clean_song_name_alpha_numeric VARCHAR(255) NOT NULL,
 		song_name_ko VARCHAR(255) NOT NULL,
 		clean_song_name_ko VARCHAR(255) NOT NULL,
 		song_aliases VARCHAR(255) NOT NULL,
@@ -42,6 +43,7 @@ BEGIN
 	SELECT
 		TRIM(kpop_videos.app_kpop.name) AS song_name_en,
 		TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) AS clean_song_name_en,
+		REGEXP_REPLACE(kpop_videos.app_kpop.name, '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
 		TRIM(kpop_videos.app_kpop.kname) AS song_name_ko,
 		TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.kname, '(', 1)) AS clean_song_name_ko,
 		kpop_videos.app_kpop.alias AS song_aliases,
@@ -78,6 +80,7 @@ BEGIN
 		SELECT
 			TRIM(kpop_videos.app_kpop.name) AS song_name_en,
 			TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) AS clean_song_name_en,
+			REGEXP_REPLACE(kpop_videos.app_kpop.name, '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
 			TRIM(kpop_videos.app_kpop.kname) AS song_name_ko,
 			TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.kname, '(', 1)) AS clean_song_name_ko,
 			kpop_videos.app_kpop.alias AS song_aliases,

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -300,7 +300,7 @@ export default class SpotifyManager {
                     for (const songName of songNames) {
                         // compare with non-alphanumeric characters removed
                         qb = qb.orWhereRaw(
-                            "REGEXP_REPLACE(available_songs.song_name_en, '[^0-9a-zA-Z]', '') LIKE ?",
+                            "available_songs.clean_song_name_alpha_numeric LIKE ?",
                             [songName.replace(/[^0-9a-z]/gi, "")]
                         );
                     }

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -193,7 +193,7 @@ export default class SpotifyManager {
         }
 
         let matchedSongs: Array<QueriedSong> = [];
-        const unmatchedSongs: Array<string> = [];
+        let unmatchedSongCount = 0;
 
         logger.info(
             `Starting to parse playlist: ${playlistID}, number of songs: ${spotifySongs.length}`
@@ -204,16 +204,16 @@ export default class SpotifyManager {
             spotifySongs,
             (x: SpotifyTrack) => this.generateSongMatchingPromise(x, isPremium)
         )) {
-            if ((unmatchedSongs.length + matchedSongs.length) % 100 === 0) {
+            if ((unmatchedSongCount + matchedSongs.length) % 100 === 0) {
                 logger.info(
-                    `Processed ${unmatchedSongs.length + matchedSongs.length}/${
+                    `Processed ${unmatchedSongCount + matchedSongs.length}/${
                         spotifySongs.length
                     } for playlist ${playlistID}`
                 );
             }
 
             if (typeof queryOutput === "string") {
-                unmatchedSongs.push(queryOutput);
+                unmatchedSongCount++;
             } else {
                 matchedSongs.push(queryOutput);
             }

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -223,13 +223,6 @@ export default class SpotifyManager {
         logger.info(
             `Finished parsing playlist: ${playlistID} after ${end - start}ms.`
         );
-        if (unmatchedSongs.length > 0) {
-            logger.info(
-                `Unmatched Spotify songs for playlistID = ${playlistID}: ${JSON.stringify(
-                    unmatchedSongs
-                )}`
-            );
-        }
 
         matchedSongs = _.uniq(matchedSongs);
         return {


### PR DESCRIPTION
For 4214 song playlist:
Per-query time: 55.65ms -> 29.1ms (-62%)
Total matching time: 58764ms -> 30792ms (-62%)

For 2281 song playlist:
Per-query time: 31ms -> 20.9ms (-38%)
Total matching time: 17841ms -> 12067ms (-38%)