### PR TITLE
Spotify song match on original artist name (non de-duplicated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "6.1.0",
     "main": "src/kmq.js",
     "scripts": {
-        "seed": "ts-node src/seed/seed_db",
+        "seed": "ts-node --swc src/seed/seed_db",
         "bootstrap": "ts-node src/seed/bootstrap.ts",
         "start": "./start.sh native",
         "dry-run": "NODE_ENV=dry-run npm run start",

--- a/sql/procedures/create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/create_kmq_data_tables_procedure.sql
@@ -5,6 +5,9 @@ CREATE PROCEDURE CreateKmqDataTables(
 )
 BEGIN
 	/* de-duplicate conflicting names */
+	ALTER TABLE kpop_videos.app_kpop_group ADD COLUMN IF NOT EXISTS original_name VARCHAR(255);
+	UPDATE kpop_videos.app_kpop_group SET original_name = name;
+	
 	UPDATE kpop_videos.app_kpop_group as a
 	RIGHT JOIN
 	(SELECT LOWER(name) as name, count(*) as c FROM kpop_videos.app_kpop_group GROUP BY LOWER(name) HAVING count(*) > 1 AND name NOT LIKE "%(%)%" ) as b USING (name)
@@ -21,6 +24,7 @@ BEGIN
 		song_aliases VARCHAR(255) NOT NULL,
 		link VARCHAR(255) NOT NULL,
 		artist_name_en VARCHAR(255) NOT NULL,
+		original_artist_name_en VARCHAR(255) NOT NULL,
 		artist_name_ko VARCHAR(255),
 		artist_aliases VARCHAR(255) NOT NULL,
 		previous_name_en VARCHAR(255),
@@ -49,6 +53,7 @@ BEGIN
 		kpop_videos.app_kpop.alias AS song_aliases,
 		vlink AS link,
 		TRIM(kpop_videos.app_kpop_group.name) AS artist_name_en,
+		TRIM(kpop_videos.app_kpop_group.original_name) AS original_artist_name_en,
 		TRIM(kpop_videos.app_kpop_group.kname) AS artist_name_ko,
 		kpop_videos.app_kpop_group.alias AS artist_aliases,
 		kpop_videos.app_kpop_group.previous_name AS previous_name_en,
@@ -86,6 +91,7 @@ BEGIN
 			kpop_videos.app_kpop.alias AS song_aliases,
 			vlink AS link,
 			TRIM(kpop_videos.app_kpop_group.name) AS artist_name_en,
+			TRIM(kpop_videos.app_kpop_group.original_name) AS original_artist_name_en,
 			TRIM(kpop_videos.app_kpop_group.kname) AS artist_name_ko,
 			kpop_videos.app_kpop_group.alias AS artist_aliases,
 			kpop_videos.app_kpop_group.previous_name AS previous_name_en,

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -328,9 +328,10 @@ export default class SpotifyManager {
                     return qb;
                 })
                 .andWhere((qb) => {
-                    qb.whereRaw("available_songs.artist_name_en LIKE ?", [
-                        song.artists[0],
-                    ])
+                    qb.whereRaw(
+                        "available_songs.original_artist_name_en LIKE ?",
+                        [song.artists[0]]
+                    )
                         .orWhereIn("id_artist", aliasIDs)
                         .orWhereIn("id_parentgroup", aliasIDs)
                         .orWhereIn("id_parent_artist", aliasIDs);

--- a/start.sh
+++ b/start.sh
@@ -27,7 +27,7 @@ then
         echo "Cleaning project..."
         npm run clean
         echo "Installing dependencies..."
-        yarn install --frozen-lockfile
+        yarn install -f
     fi
     rebuild
 fi


### PR DESCRIPTION
Currently, artists with duplicate names get their full name appended in `kpop_groups`. I.e: `YENA (Choi Yena), Yena (Yang Yena), Yena (Jeong Yena)`

Change Spotify matching query to match on the original name, i.e: `Yena`