### PR TITLE
clean_song_name_alpha_numeric should come from clean_song_name_en

### DIFF
--- a/sql/procedures/create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/create_kmq_data_tables_procedure.sql
@@ -47,7 +47,7 @@ BEGIN
 	SELECT
 		TRIM(kpop_videos.app_kpop.name) AS song_name_en,
 		TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) AS clean_song_name_en,
-		REGEXP_REPLACE(kpop_videos.app_kpop.name, '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
+		REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
 		TRIM(kpop_videos.app_kpop.kname) AS song_name_ko,
 		TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.kname, '(', 1)) AS clean_song_name_ko,
 		kpop_videos.app_kpop.alias AS song_aliases,
@@ -85,7 +85,7 @@ BEGIN
 		SELECT
 			TRIM(kpop_videos.app_kpop.name) AS song_name_en,
 			TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) AS clean_song_name_en,
-			REGEXP_REPLACE(kpop_videos.app_kpop.name, '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
+			REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
 			TRIM(kpop_videos.app_kpop.kname) AS song_name_ko,
 			TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.kname, '(', 1)) AS clean_song_name_ko,
 			kpop_videos.app_kpop.alias AS song_aliases,


### PR DESCRIPTION
`clean_song_name_alpha_numeric` was reading from `name`, which often contains additional text in brackets, e.g: `DND (Do Not Disturb)`, which resulted in `DNDDoNotDisturb` which removing non-alpha numeric characters. Remove the brackets beforehand. 