### PR TITLE
Only deduplicate group names upon database seed

### DIFF
--- a/sql/procedures/create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/create_kmq_data_tables_procedure.sql
@@ -4,15 +4,6 @@ CREATE PROCEDURE CreateKmqDataTables(
 	IN maxRank INT
 )
 BEGIN
-	/* de-duplicate conflicting names */
-	ALTER TABLE kpop_videos.app_kpop_group ADD COLUMN IF NOT EXISTS original_name VARCHAR(255);
-	UPDATE kpop_videos.app_kpop_group SET original_name = name;
-	
-	UPDATE kpop_videos.app_kpop_group as a
-	RIGHT JOIN
-	(SELECT LOWER(name) as name, count(*) as c FROM kpop_videos.app_kpop_group GROUP BY LOWER(name) HAVING count(*) > 1 AND name NOT LIKE "%(%)%" ) as b USING (name)
-	SET a.name = concat(a.name, " (", a.fname, ")");
-	
 	/* update available_songs table */
 	DROP TABLE IF EXISTS available_songs_temp;
 	CREATE TABLE available_songs_temp (

--- a/sql/procedures/deduplicate_app_kpop_group_names.sql
+++ b/sql/procedures/deduplicate_app_kpop_group_names.sql
@@ -1,0 +1,15 @@
+DELIMITER //
+DROP PROCEDURE IF EXISTS DeduplicateGroupNames //
+CREATE PROCEDURE DeduplicateGroupNames()
+BEGIN
+	/* de-duplicate conflicting names */
+	ALTER TABLE kpop_videos.app_kpop_group ADD COLUMN IF NOT EXISTS original_name VARCHAR(255);
+	UPDATE kpop_videos.app_kpop_group SET original_name = name;
+	
+	UPDATE kpop_videos.app_kpop_group as a
+	RIGHT JOIN
+	(SELECT LOWER(name) as name, count(*) as c FROM kpop_videos.app_kpop_group GROUP BY LOWER(name) HAVING count(*) > 1 AND name NOT LIKE "%(%)%" ) as b USING (name)
+	SET a.name = concat(a.name, " (", a.fname, ")");
+	
+END //
+DELIMITER ;

--- a/src/seed/bootstrap.ts
+++ b/src/seed/bootstrap.ts
@@ -113,13 +113,12 @@ async function bootstrapDatabases(): Promise<void> {
     }
 
     await performMigrations(db);
+    await loadStoredProcedures();
 
     if (!(await kpopDataDatabaseExists(db))) {
         logger.info("Seeding K-pop data database");
         await updateKpopDatabase(db, true);
     }
-
-    await loadStoredProcedures();
 
     if (!(await songThresholdReached(db))) {
         logger.info(

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -517,6 +517,7 @@ async function updateKpopDatabase(
 
     if (!options.skipReseed) {
         await seedDb(db, bootstrap);
+        await deduplicateGroupNames(db);
     } else {
         logger.info("Skipping reseed");
     }
@@ -556,7 +557,6 @@ async function seedAndDownloadNewSongs(db: DatabaseContext): Promise<void> {
         songsDownloaded = await downloadAndConvertSongs(options.limit);
     }
 
-    await deduplicateGroupNames(db);
     await generateKmqDataTables(db);
     if (process.env.NODE_ENV === EnvType.PROD) {
         await updateGroupList(db);


### PR DESCRIPTION
Previously the deduplication was being run every time `CreateKmqDataTables()` was being called, which was on every startup. The deduplication begins by saving the current group name as `original_name`, hence it should only run once. 