### PR TITLE
Update ytdl-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "uuid": "^9.0.0",
         "winston": "^3.8.2",
         "winston-daily-rotate-file": "^4.7.1",
-        "ytdl-core": "^4.11.2",
+        "ytdl-core": "github:fent/node-ytdl-core#pull/1187/head",
         "zlib-sync": "^0.1.7"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,10 +3609,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-ytdl-core@^4.11.2:
-  version "4.11.2"
-  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-4.11.2.tgz#c2341916b9757171741a2fa118b6ffbb4ffd92f7"
-  integrity sha512-D939t9b4ZzP3v0zDvehR2q+KgG97UTgrTKju3pOPGQcXtl4W6W5z0EpznzcJFu+OOpl7S7Ge8hv8zU65QnxYug==
+"ytdl-core@github:fent/node-ytdl-core#pull/1187/head":
+  version "0.0.0-development"
+  resolved "https://codeload.github.com/fent/node-ytdl-core/tar.gz/9a81a7c6a7cec287de3f6dd041a9248dc6ede8b9"
   dependencies:
     m3u8stream "^0.8.6"
     miniget "^4.2.2"


### PR DESCRIPTION
Update to PR branch https://github.com/fent/node-ytdl-core/pull/1187 to mitigate youtube throttling issue