### PR TITLE
Remove internal cronjob for database seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "6.4.1",
     "main": "src/kmq.js",
     "scripts": {
-        "seed": "ts-node --swc src/seed/seed_db",
+        "seed": ". ./.env && ts-node --swc src/seed/seed_db",
         "bootstrap": "ts-node --swc src/seed/bootstrap.ts",
         "start": "./start.sh native",
         "dry-run": "NODE_ENV=dry-run npm run start",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -225,7 +225,6 @@ export const SELECTION_WEIGHT_VALUES_EASY = [
 export const EPHEMERAL_MESSAGE_FLAG = 64;
 
 export const DataFiles = {
-    SKIP_SEED_COOKIE: path.join(__dirname, "../data/skip_seed"),
     PRIMARY_COOKIE: path.join(__dirname, "../data/primary"),
     NEWS: path.join(__dirname, "../data/news.md"),
     FROZEN_TABLE_SCHEMA: path.join(

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -446,13 +446,6 @@ export async function isPrimaryInstance(): Promise<boolean> {
 }
 
 /**
- * @returns whether this instance should skip seed
- */
-export async function shouldSkipSeed(): Promise<boolean> {
-    return pathExists(DataFiles.SKIP_SEED_COOKIE);
-}
-
-/**
  * @param url - the URL
  * @returns whether the URL is valid
  */

--- a/src/kmq.ts
+++ b/src/kmq.ts
@@ -1,7 +1,6 @@
 import * as cp from "child_process";
 import * as util from "util";
 import {
-    EMBED_ERROR_COLOR,
     EMBED_SUCCESS_COLOR,
     IGNORED_WARNING_SUBSTRINGS,
     KmqImages,
@@ -13,10 +12,8 @@ import { getInternalLogger } from "./logger";
 import {
     isPrimaryInstance,
     measureExecutionTime,
-    shouldSkipSeed,
     standardDateFormat,
 } from "./helpers/utils";
-import { seedAndDownloadNewSongs } from "./seed/seed_db";
 import { sendDebugAlertWebhook } from "./helpers/discord_utils";
 import { userVoted } from "./helpers/bot_listing_manager";
 import EnvType from "./enums/env_type";

--- a/src/kmq.ts
+++ b/src/kmq.ts
@@ -152,31 +152,6 @@ function registerGlobalIntervals(fleet: Fleet): void {
             });
         }
     });
-
-    // as defined in DAISUKI_SEED_CRON_JOB
-    schedule.scheduleJob(
-        process.env.DAISUKI_SEED_CRON_JOB ?? "15 3,15 * * *",
-        async () => {
-            if (process.env.NODE_ENV !== EnvType.PROD) return;
-            if (!(await isPrimaryInstance()) || (await shouldSkipSeed())) {
-                logger.info("Skipping scheduled Daisuki database seed");
-                return;
-            }
-
-            logger.info("Performing regularly scheduled Daisuki database seed");
-
-            try {
-                await seedAndDownloadNewSongs(dbContext);
-            } catch (e) {
-                await sendDebugAlertWebhook(
-                    "Download and seed failure",
-                    e.toString(),
-                    EMBED_ERROR_COLOR,
-                    KmqImages.NOT_IMPRESSED
-                );
-            }
-        }
-    );
 }
 
 function registerProcessEvents(fleet: Fleet): void {

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -11,6 +11,7 @@ import { config } from "dotenv";
 import { getNewConnection } from "../database_context";
 import { parseJsonFile, pathExists } from "../helpers/utils";
 import { program } from "commander";
+import { sendDebugAlertWebhook } from "../helpers/discord_utils";
 import Axios from "axios";
 import EnvType from "../enums/env_type";
 import _ from "lodash";
@@ -20,7 +21,6 @@ import path from "path";
 import util from "util";
 import type { DatabaseContext } from "../database_context";
 import type { Knex } from "knex";
-import { sendDebugAlertWebhook } from "../helpers/discord_utils";
 
 const exec = util.promisify(cp.exec);
 
@@ -642,4 +642,4 @@ async function seedAndDownloadNewSongs(db: DatabaseContext): Promise<void> {
     }
 })();
 
-export { seedAndDownloadNewSongs, updateKpopDatabase };
+export { updateKpopDatabase };


### PR DESCRIPTION
Will replace with system cronjob running `npm run seed`. Allows changing to the database seed cadence without restarting the KMQ instance. Also allows for updated seed code without restart. 