### PR TITLE
Hardcode docker image name in e2e gci

### DIFF
--- a/.github/workflows/gci-e2e.yml
+++ b/.github/workflows/gci-e2e.yml
@@ -66,9 +66,9 @@ jobs:
                   context: .
                   file: docker/kmq/Dockerfile
                   push: false
-                  tags: ${{ steps.meta.outputs.tags }}
+                  tags: ghcr.io/brainicism/kmq_discord:gci
             - name: Dry-run bootstrap KMQ
-              run: . ./.env && docker run -v ${SONG_DOWNLOAD_DIR}:${SONG_DOWNLOAD_DIR} -v ${PWD}/data:/app/data -v ${PWD}/.env:/app/.env -v ${PWD}/logs:/app/logs --env NODE_ENV=dry-run --network=host --name kmq ${{ steps.meta.outputs.tags }}
+              run: . ./.env && docker run -v ${SONG_DOWNLOAD_DIR}:${SONG_DOWNLOAD_DIR} -v ${PWD}/data:/app/data -v ${PWD}/.env:/app/.env -v ${PWD}/logs:/app/logs --env NODE_ENV=dry-run --network=host --name kmq ghcr.io/brainicism/kmq_discord:gci
             - name: Validate available_songs
               run: |
                   [[ $(mysql kmq -s -N -h 127.0.0.1 -u $DB_USER_CI -p$DB_PASS_CI -e 'select count(1) from available_songs') -eq 3 ]]


### PR DESCRIPTION
`${{ steps.meta.outputs.tags }}` returns two values `[ghcr.io/brainicism/kmq_discord:nightly, ghcr.io/brainicism/kmq_discord:master]` and confuses the second value as a command to invoke. 

![image](https://user-images.githubusercontent.com/13823855/227798208-a2d343f5-8421-48dd-9f7f-35b124b42c72.png)
![image](https://user-images.githubusercontent.com/13823855/227798215-0490fd6d-8fa0-49f3-b3ee-0ca345edf47e.png)
