### PR TITLE
Fix bug preventing preset from loading

### DIFF
--- a/src/structures/guild_preference.ts
+++ b/src/structures/guild_preference.ts
@@ -414,6 +414,7 @@ export default class GuildPreference {
         }
 
         const oldOptions = this.gameOptions;
+        this.gameOptions = preset as GameOptions;
         this.validateGameOptions();
         const updatedOptions = Object.entries(this.gameOptions).filter(
             (option) =>

--- a/src/test/ci/guild_preference.test.ts
+++ b/src/test/ci/guild_preference.test.ts
@@ -79,4 +79,47 @@ describe("guild preference", () => {
             });
         });
     });
+
+    describe("presets", () => {
+        const guildPreference = GuildPreference.fromGuild("123");
+        const BEGINNING_CUTOFF_YEAR = 1999;
+        const END_CUTOFF_YEAR = 2017;
+        const TEST_PRESET_NAME = "test_preset";
+
+        const filledGameOptions = {
+            ...GuildPreference.DEFAULT_OPTIONS,
+        };
+
+        filledGameOptions.beginningYear = BEGINNING_CUTOFF_YEAR;
+        filledGameOptions.endYear = END_CUTOFF_YEAR;
+
+        beforeEach(() => {
+            guildPreference.resetToDefault();
+            guildPreference.setBeginningCutoffYear(BEGINNING_CUTOFF_YEAR);
+            guildPreference.setEndCutoffYear(END_CUTOFF_YEAR);
+            guildPreference.savePreset(TEST_PRESET_NAME, null);
+            guildPreference.resetToDefault();
+        });
+
+        describe("savePreset", () => {
+            it("should include the new preset in the list of presets", async () => {
+                const presetList = await guildPreference.listPresets();
+                assert(presetList.includes(TEST_PRESET_NAME));
+            });
+        });
+
+        describe("loadPreset", () => {
+            it("should update the current options with values defined in the preset", async () => {
+                await guildPreference.loadPreset(TEST_PRESET_NAME, "123");
+                assert.deepStrictEqual(
+                    guildPreference.gameOptions,
+                    filledGameOptions
+                );
+            });
+        });
+
+        afterEach(() => {
+            guildPreference.deletePreset(TEST_PRESET_NAME);
+        });
+    });
 });


### PR DESCRIPTION
In commits prior to 66936080f, the value passed into `validateGameOptions` was used to set `this.gameOptions`. After removing this argument, we did not initialize `this.gameOptions` with the loaded preset. Directly setting it before running the validation restores old behavior