### PR TITLE
Add additional logic to Docker healthcheck

### DIFF
--- a/docker/kmq/Dockerfile
+++ b/docker/kmq/Dockerfile
@@ -15,12 +15,12 @@ RUN yarn install --frozen-lockfile
 
 COPY start.sh tsconfig.json ./
 COPY i18n/ i18n/
-COPY src/ src/
-COPY templates/ templates/
-RUN npx tsc
-
 COPY sql_dumps/daisuki/bootstrap.sql sql_dumps/daisuki/bootstrap.sql
 COPY sql/ sql/
+COPY templates/ templates/
+
+COPY src/ src/
+RUN npx tsc
 
 # ================================================================= #
 FROM node:18-alpine
@@ -46,5 +46,5 @@ STOPSIGNAL SIGINT
 ARG NODE_ENV
 ENV NODE_ENV=$NODE_ENV
 HEALTHCHECK --interval=5s --timeout=3s --start-period=30s \
-  CMD curl -f 127.0.0.1:5858/ping || exit 1
+  CMD [ "$(cat status)" == "ready" ] && curl -f 127.0.0.1:5858/ping || exit 1
 ENTRYPOINT ["./start.sh", "docker"]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -241,6 +241,7 @@ export const DataFiles = {
 
 // ephermeral to the docker container, not mounted from host
 export const STANDBY_COOKIE = path.join(__dirname, "../standby");
+export const STATUS_COOKIE = path.join(__dirname, "../status");
 
 export const PERMISSIONS_LINK = "https://www.youtube.com/watch?v=87GW0SmF5LI";
 export const SPOTIFY_BASE_URL = "https://open.spotify.com/playlist/";

--- a/src/kmq.ts
+++ b/src/kmq.ts
@@ -4,6 +4,7 @@ import {
     IGNORED_WARNING_SUBSTRINGS,
     KmqImages,
     STANDBY_COOKIE,
+    STATUS_COOKIE,
 } from "./constants";
 import { Fleet } from "eris-fleet";
 import { clearRestartNotification } from "./helpers/management_utils";
@@ -195,6 +196,9 @@ function registerProcessEvents(fleet: Fleet): void {
 
             logger.info("Starting web server...");
             await new KmqWebServer(dbContext).startWebServer(fleet);
+
+            // notify that the current instance is now ready
+            await fs.promises.writeFile(STATUS_COOKIE, "ready");
 
             logger.info("Registering process event handlers...");
             registerProcessEvents(fleet);

--- a/src/seed/bootstrap.ts
+++ b/src/seed/bootstrap.ts
@@ -1,5 +1,5 @@
 import { IPCLogger } from "../logger";
-import { STANDBY_COOKIE } from "../constants";
+import { STANDBY_COOKIE, STATUS_COOKIE } from "../constants";
 import { config } from "dotenv";
 import {
     databaseExists,
@@ -156,8 +156,10 @@ async function bootstrapDatabases(): Promise<void> {
 
         if (process.env.IS_STANDBY === "true") {
             logger.info("Preparing standby instance");
-            fs.promises.writeFile(STANDBY_COOKIE, "starting");
+            await fs.promises.writeFile(STANDBY_COOKIE, "starting");
         }
+
+        await fs.promises.writeFile(STATUS_COOKIE, "starting");
 
         const dataDir = path.join(__dirname, "../../data");
 


### PR DESCRIPTION
Previously, the healthcheck would only ping localhost:5858/ping, which may be running on a different instance (i.e: the primary, while the healthcheck is running on the standby). Added an additional check for status on the current instance, which only becomes ready after standby promotion, and the old primary no longer existing. 