### PR TITLE
Add tiebreaker on Spotify matchers if multiple results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 main.db
 .env
+status
 src/config/debug_settings.json
 logs/
 build/

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -409,6 +409,8 @@ export default class SpotifyManager {
                         ? (process.env.PREMIUM_AUDIO_SONGS_PER_ARTIST as string)
                         : (process.env.AUDIO_SONGS_PER_ARTIST as string)
                 )
+                .orderByRaw("CHAR_LENGTH(tags) ASC")
+                .orderBy("views", "DESC")
                 .first();
 
             const result = (await query) as QueriedSong;


### PR DESCRIPTION
Prefer non-alternate language matches
Secondary order on number of views