### PR TITLE
Revert Docker image to Ubuntu

### DIFF
--- a/docker/kmq/Dockerfile
+++ b/docker/kmq/Dockerfile
@@ -31,10 +31,13 @@ COPY templates/ templates/
 COPY src/ src/
 RUN npx tsc
 
+# remove dev dependencies
+RUN yarn install --production --ignore-scripts --prefer-offline
 # ================================================================= #
 FROM node:18-slim
 RUN apt-get update && apt-get install -y default-mysql-client \
     ffmpeg \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app /app
@@ -45,5 +48,5 @@ STOPSIGNAL SIGINT
 ARG NODE_ENV
 ENV NODE_ENV=$NODE_ENV
 HEALTHCHECK --interval=5s --timeout=3s --start-period=30s \
-  CMD [ "$(cat status)" == "ready" ] && curl -f 127.0.0.1:5858/ping || exit 1
+  CMD [ "$(cat status)" = "ready" ] && curl -f 127.0.0.1:5858/ping || exit 1
 ENTRYPOINT ["./start.sh", "docker"]

--- a/docker/kmq/Dockerfile
+++ b/docker/kmq/Dockerfile
@@ -1,15 +1,24 @@
-FROM node:18-alpine AS build
+FROM node:18 AS build
+ARG TARGETARCH
 
-RUN apk add --no-cache git \
+RUN apt-get update && apt-get install -y git \
     python3 \
     make \
     g++ \
     autoconf \
     automake \
-    libtool
+    libtool \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /binaries
+RUN wget "https://azcopyvnext.azureedge.net/release20230331/azcopy_linux_${TARGETARCH}_10.18.0.tar.gz" \
+    && tar xzfv azcopy_linux_${TARGETARCH}_10.18.0.tar.gz \
+    && cp -fv azcopy_linux_${TARGETARCH}_10.18.0/azcopy /binaries \
+    && chmod +x /binaries/azcopy \
+    && rm azcopy_linux_${TARGETARCH}_10.18.0.tar.gz \
+    && rm -rfv azcopy_linux_${TARGETARCH}_10.18.0
 
 WORKDIR /app
-
 COPY yarn.lock package.json ./
 RUN yarn install --frozen-lockfile
 
@@ -23,23 +32,13 @@ COPY src/ src/
 RUN npx tsc
 
 # ================================================================= #
-FROM node:18-alpine
-ARG TARGETARCH
-RUN apk add --no-cache mysql-client \
-    bash \
-    curl
-
-COPY --from=mwader/static-ffmpeg:6.0 /ffmpeg /usr/local/bin/
-COPY --from=mwader/static-ffmpeg:6.0 /ffprobe /usr/local/bin/
-
-RUN wget "https://azcopyvnext.azureedge.net/release20230331/azcopy_linux_${TARGETARCH}_10.18.0.tar.gz" \
-    && tar xzfv azcopy_linux_${TARGETARCH}_10.18.0.tar.gz \
-    && cp -fv azcopy_linux_${TARGETARCH}_10.18.0/azcopy /usr/bin \
-    && chmod +x /usr/bin/azcopy \
-    && rm -rfv azcopy_linux_${TARGETARCH}_10.18.0.tar.gz \
-    && rm -rfv azcopy_linux_${TARGETARCH}_10.18.0/azcopy
+FROM node:18-slim
+RUN apt-get update && apt-get install -y default-mysql-client \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app /app
+COPY --from=build /binaries/azcopy /usr/bin/azcopy
 WORKDIR /app
 
 STOPSIGNAL SIGINT


### PR DESCRIPTION
Weird bug with the static ffmpeg binary we were using causes streams to play from the beginning regardless of the seek parameters passed. ffmpeg available in the alpine package manager isn't compiled with the flags required for `/special`. Only solution is to either manually compile ffmpeg with the appropriate flags, or revert to Ubuntu image and use the known working version. 