### PR TITLE
Create EmptyWhereIn Kysely plugin

### DIFF
--- a/src/database_context.ts
+++ b/src/database_context.ts
@@ -2,6 +2,7 @@ import { Kysely, MysqlDialect } from "kysely";
 import { config } from "dotenv";
 import { createPool } from "mysql2";
 import { resolve } from "path";
+import EmptyWhereInPlugin from "./kysely/plugins/empty-where-in-plugin/plugin";
 import EnvType from "./enums/env_type";
 import type { InfoSchemaDB } from "./typings/info_schema_db";
 import type { KmqDB } from "./typings/kmq_db";
@@ -27,6 +28,7 @@ function generateKysleyContext<T>(
                 multipleStatements: true,
             }),
         }),
+        plugins: [new EmptyWhereInPlugin()],
     });
 }
 

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -190,29 +190,27 @@ export async function getMatchingGroupNames(
             .execute()
     ).map((x) => x.id);
 
-    const matchingGroups = artistIds.length
-        ? (
-              await dbContext.kpopVideos // collab matches
-                  .selectFrom("app_kpop_agrelation")
-                  .innerJoin(
-                      "app_kpop_group",
-                      "app_kpop_agrelation.id_subgroup",
-                      "app_kpop_group.id"
-                  )
-                  .select(["id", "name"])
-                  .where("app_kpop_agrelation.id_artist", "in", artistIds)
-                  .where("app_kpop_group.is_collab", "=", "y")
-                  // artist matches
-                  .unionAll(
-                      dbContext.kpopVideos
-                          .selectFrom("app_kpop_group")
-                          .select(["id", "name"])
-                          .where("app_kpop_group.id", "in", artistIds)
-                  )
-                  .orderBy("name", "asc")
-                  .execute()
-          ).map((x) => ({ id: x.id, name: x.name }))
-        : [];
+    const matchingGroups = (
+        await dbContext.kpopVideos // collab matches
+            .selectFrom("app_kpop_agrelation")
+            .innerJoin(
+                "app_kpop_group",
+                "app_kpop_agrelation.id_subgroup",
+                "app_kpop_group.id"
+            )
+            .select(["id", "name"])
+            .where("app_kpop_agrelation.id_artist", "in", artistIds)
+            .where("app_kpop_group.is_collab", "=", "y")
+            // artist matches
+            .unionAll(
+                dbContext.kpopVideos
+                    .selectFrom("app_kpop_group")
+                    .select(["id", "name"])
+                    .where("app_kpop_group.id", "in", artistIds)
+            )
+            .orderBy("name", "asc")
+            .execute()
+    ).map((x) => ({ id: x.id, name: x.name }));
 
     const matchingGroupNames = matchingGroups.map((x) => x.name.toUpperCase());
     const unrecognizedGroups = rawGroupNames.filter(

--- a/src/kysely/plugins/empty-where-in-plugin/plugin.ts
+++ b/src/kysely/plugins/empty-where-in-plugin/plugin.ts
@@ -1,0 +1,33 @@
+/**
+ * Plugin that replaces .where("column", "in", []) with a condition that returns false
+ * Plugin that replaces .where("column", "not in", []) with a condition that returns true
+ */
+
+import { SelectQueryNode } from "kysely";
+import EmptyWhereInTransformer from "./transformer";
+import type {
+    KyselyPlugin,
+    PluginTransformQueryArgs,
+    PluginTransformResultArgs,
+    QueryResult,
+    RootOperationNode,
+    UnknownRow,
+} from "kysely";
+
+export default class EmptyWhereInPlugin implements KyselyPlugin {
+    readonly #transformer = new EmptyWhereInTransformer();
+
+    transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+        if (SelectQueryNode.is(args.node)) {
+            return this.#transformer.transformNode(args.node);
+        }
+
+        return args.node;
+    }
+
+    transformResult(
+        args: PluginTransformResultArgs
+    ): Promise<QueryResult<UnknownRow>> {
+        return Promise.resolve(args.result);
+    }
+}

--- a/src/kysely/plugins/empty-where-in-plugin/transformer.ts
+++ b/src/kysely/plugins/empty-where-in-plugin/transformer.ts
@@ -1,0 +1,38 @@
+import {
+    OperationNodeTransformer,
+    OperatorNode,
+    PrimitiveValueListNode,
+    ValueListNode,
+    ValueNode,
+} from "kysely";
+import type { BinaryOperationNode } from "kysely";
+
+export default class EmptyWhereInTransformer extends OperationNodeTransformer {
+    protected transformBinaryOperation(
+        node: BinaryOperationNode
+    ): BinaryOperationNode {
+        const isWhereInOperator =
+            OperatorNode.is(node.operator) &&
+            ["in", "not in"].includes(node.operator.operator);
+
+        const hasListOperand =
+            PrimitiveValueListNode.is(node.rightOperand) ||
+            ValueListNode.is(node.rightOperand);
+
+        if (isWhereInOperator && hasListOperand) {
+            const valueList = node.rightOperand;
+            if (valueList.values.length === 0) {
+                return {
+                    kind: "BinaryOperationNode",
+                    leftOperand: ValueNode.createImmediate("0"),
+                    operator: OperatorNode.create("="),
+                    rightOperand: ValueNode.createImmediate(
+                        node.operator.operator === "in" ? "1" : "0"
+                    ),
+                };
+            }
+        }
+
+        return super.transformBinaryOperation(node);
+    }
+}

--- a/src/scripts/download-new-songs.ts
+++ b/src/scripts/download-new-songs.ts
@@ -236,9 +236,7 @@ async function getSongsFromDb(databaseContext: DatabaseContext): Promise<any> {
         .where("is_audio", "=", "n")
         .where("tags", "not like", "%c%");
 
-    if (deadLinks.length) {
-        mvBuilder = mvBuilder.where("vlink", "not in", deadLinks);
-    }
+    mvBuilder = mvBuilder.where("vlink", "not in", deadLinks);
 
     const avBuilder = databaseContext.kpopVideos.with(
         "rankedAudioSongs",

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -295,21 +295,17 @@ export default class SongSelector {
                 .selectFrom("app_kpop_group")
                 .select("id");
 
-            if (selectedGroupIDs.length) {
-                subunitsQueryBuilder = subunitsQueryBuilder.where(
-                    "id_parentgroup",
-                    "in",
-                    selectedGroupIDs
-                );
-            }
+            subunitsQueryBuilder = subunitsQueryBuilder.where(
+                "id_parentgroup",
+                "in",
+                selectedGroupIDs
+            );
 
-            if (shadowBannedArtistIds.length) {
-                subunitsQueryBuilder = subunitsQueryBuilder.where(
-                    "id",
-                    "not in",
-                    shadowBannedArtistIds
-                );
-            }
+            subunitsQueryBuilder = subunitsQueryBuilder.where(
+                "id",
+                "not in",
+                shadowBannedArtistIds
+            );
 
             subunits = (await subunitsQueryBuilder.execute()).map(
                 (x) => x["id"]
@@ -371,15 +367,13 @@ export default class SongSelector {
 
             const mainArtistFilterExpressions: Array<Expression<SqlBool>> = [];
 
-            if (guildPreference.getExcludesGroupIDs().length) {
-                mainArtistFilterExpressions.push(
-                    cmpr(
-                        "id_artist",
-                        "not in",
-                        guildPreference.getExcludesGroupIDs()
-                    )
-                );
-            }
+            mainArtistFilterExpressions.push(
+                cmpr(
+                    "id_artist",
+                    "not in",
+                    guildPreference.getExcludesGroupIDs()
+                )
+            );
 
             if (!guildPreference.isGroupsMode()) {
                 const gender: Array<AvailableGenders> =
@@ -403,40 +397,28 @@ export default class SongSelector {
             } else if (
                 gameOptions.subunitPreference === SubunitsPreference.EXCLUDE
             ) {
-                if (selectedGroupIDs) {
-                    mainArtistFilterExpressions.push(
-                        cmpr("id_artist", "in", selectedGroupIDs)
-                    );
-                }
+                mainArtistFilterExpressions.push(
+                    cmpr("id_artist", "in", selectedGroupIDs)
+                );
             } else {
                 const mainArtistIdSearchExpressions = [];
-                if (selectedGroupIDs.length) {
-                    mainArtistIdSearchExpressions.push(
-                        ...[
-                            cmpr("id_artist", "in", selectedGroupIDs),
-                            cmpr("id_parent_artist", "in", selectedGroupIDs),
-                        ]
-                    );
-                }
+                mainArtistIdSearchExpressions.push(
+                    ...[
+                        cmpr("id_artist", "in", selectedGroupIDs),
+                        cmpr("id_parent_artist", "in", selectedGroupIDs),
+                    ]
+                );
 
-                if (collabGroupContainingSubunit.length) {
-                    mainArtistIdSearchExpressions.push(
-                        cmpr("id_artist", "in", collabGroupContainingSubunit)
-                    );
-                }
+                mainArtistIdSearchExpressions.push(
+                    cmpr("id_artist", "in", collabGroupContainingSubunit)
+                );
 
-                if (shadowBannedArtistIds.length) {
-                    mainArtistFilterExpressions.push(
-                        and([
-                            cmpr("id_artist", "not in", shadowBannedArtistIds),
-                            or(mainArtistIdSearchExpressions),
-                        ])
-                    );
-                } else {
-                    mainArtistFilterExpressions.push(
-                        or(mainArtistIdSearchExpressions)
-                    );
-                }
+                mainArtistFilterExpressions.push(
+                    and([
+                        cmpr("id_artist", "not in", shadowBannedArtistIds),
+                        or(mainArtistIdSearchExpressions),
+                    ])
+                );
             }
 
             // Kyseley does not like it when you provide an empty array or array of size 1 to OR/AND


### PR DESCRIPTION
When we used Knex, `.whereIn("column", [])` would compile into a falsey statement like `WHERE 1 = 2` because `WHERE IN ()` is not valid SQL syntax. 

Kysely will generate the invalid syntax, hence my previous attempts to add array length checks to all WHERE IN queries. This plugin should revert it back to Knex's behavior. 