### PR TITLE
Fix bug where guess time would get overwritten

### DIFF
--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -467,6 +467,7 @@ export default class GameRound extends Round {
                         const mostRecentGuessTime = Number(
                             Object.keys(x[1]).pop()
                         );
+
                         const mostRecentGuess = Object.values(x[1]).pop()!;
                         return [
                             playerID,
@@ -535,10 +536,12 @@ export default class GameRound extends Round {
             const playerIDToEarliestCorrectTimestamp: {
                 [playerID: string]: number;
             } = {};
+
             for (const [playerID, guesses] of Object.entries(this.guesses)) {
                 const earliestGuess = Object.entries(guesses).find(
                     (y) => y[1].correct
                 );
+
                 if (earliestGuess) {
                     playerIDToEarliestCorrectTimestamp[playerID] = Number(
                         earliestGuess[0]

--- a/src/test/ci/game_round.test.ts
+++ b/src/test/ci/game_round.test.ts
@@ -711,7 +711,7 @@ describe("game round", () => {
             );
 
             assert.deepStrictEqual(gameRound.getGuesses(), {
-                [playerID]: { guess, createdAt },
+                [playerID]: { [createdAt]: { guess, correct: true } },
             });
             assert.strictEqual(gameRound.correctGuessers.length, 1);
             assert.strictEqual(gameRound.incorrectGuessers.size, 0);
@@ -735,8 +735,10 @@ describe("game round", () => {
 
             assert.deepStrictEqual(gameRound.getGuesses(), {
                 [playerID]: {
-                    guess: firstGuess,
-                    createdAt: firstGuessCreatedAt,
+                    [firstGuessCreatedAt]: {
+                        guess: firstGuess,
+                        correct: false,
+                    },
                 },
             });
             assert.strictEqual(gameRound.correctGuessers.length, 0);
@@ -756,8 +758,14 @@ describe("game round", () => {
 
             assert.deepStrictEqual(gameRound.getGuesses(), {
                 [playerID]: {
-                    guess: secondGuess,
-                    createdAt: secondGuessCreatedAt,
+                    [firstGuessCreatedAt]: {
+                        guess: firstGuess,
+                        correct: false,
+                    },
+                    [secondGuessCreatedAt]: {
+                        guess: secondGuess,
+                        correct: true,
+                    },
                 },
             });
             assert.strictEqual(gameRound.correctGuessers.length, 1);

--- a/src/test/ci/game_round.test.ts
+++ b/src/test/ci/game_round.test.ts
@@ -711,7 +711,7 @@ describe("game round", () => {
             );
 
             assert.deepStrictEqual(gameRound.getGuesses(), {
-                [playerID]: { [createdAt]: { guess, correct: true } },
+                [playerID]: [{ createdAt, guess, correct: true }],
             });
             assert.strictEqual(gameRound.correctGuessers.length, 1);
             assert.strictEqual(gameRound.incorrectGuessers.size, 0);
@@ -734,12 +734,13 @@ describe("game round", () => {
             );
 
             assert.deepStrictEqual(gameRound.getGuesses(), {
-                [playerID]: {
-                    [firstGuessCreatedAt]: {
+                [playerID]: [
+                    {
+                        createdAt: firstGuessCreatedAt,
                         guess: firstGuess,
                         correct: false,
                     },
-                },
+                ],
             });
             assert.strictEqual(gameRound.correctGuessers.length, 0);
             assert.strictEqual(gameRound.incorrectGuessers.size, 1);
@@ -757,16 +758,18 @@ describe("game round", () => {
             );
 
             assert.deepStrictEqual(gameRound.getGuesses(), {
-                [playerID]: {
-                    [firstGuessCreatedAt]: {
+                [playerID]: [
+                    {
+                        createdAt: firstGuessCreatedAt,
                         guess: firstGuess,
                         correct: false,
                     },
-                    [secondGuessCreatedAt]: {
+                    {
+                        createdAt: secondGuessCreatedAt,
                         guess: secondGuess,
                         correct: true,
                     },
-                },
+                ],
             });
             assert.strictEqual(gameRound.correctGuessers.length, 1);
             assert.strictEqual(gameRound.incorrectGuessers.size, 0);


### PR DESCRIPTION
Keep track of all guesses. For hidden games, use the most recent guess. For non-hidden games, use the oldest correct guess.