### PR TITLE
Prevent stale /spotify metadata

### DIFF
--- a/src/commands/game_options/spotify.ts
+++ b/src/commands/game_options/spotify.ts
@@ -22,10 +22,9 @@ import LocaleType from "../../enums/locale_type";
 import MessageContext from "../../structures/message_context";
 import Session from "../../structures/session";
 import SongSelector from "../../structures/song_selector";
-import State from "../../state";
 import i18n from "../../helpers/localization_manager";
 import type { DefaultSlashCommand } from "../interfaces/base_command";
-import type { MatchedPlaylist } from "../../helpers/spotify_manager";
+import type { MatchedPlaylist } from "../../interfaces/matched_playlist";
 import type BaseCommand from "../interfaces/base_command";
 import type CommandArgs from "../../interfaces/command_args";
 import type HelpDocumentation from "../../interfaces/help";
@@ -198,18 +197,18 @@ export default class SpotifyCommand implements BaseCommand {
             guildID
         );
 
-        const gameSession = State.gameSessions[guildID];
+        const session = Session.getSession(guildID);
         if (reset) {
-            await guildPreference.reset(GameOption.SPOTIFY_PLAYLIST_METADATA);
+            await guildPreference.reset(GameOption.SPOTIFY_PLAYLIST_ID);
             logger.info(
                 `${getDebugLogHeader(messageContext)} | Spotify playlist reset.`
             );
 
             await sendOptionsMessage(
-                Session.getSession(guildID),
+                session,
                 messageContext,
                 guildPreference,
-                [{ option: GameOption.SPOTIFY_PLAYLIST_METADATA, reset }],
+                [{ option: GameOption.SPOTIFY_PLAYLIST_ID, reset }],
                 false,
                 undefined,
                 undefined,
@@ -233,7 +232,7 @@ export default class SpotifyCommand implements BaseCommand {
             }
 
             const premiumRequest = await isPremiumRequest(
-                gameSession,
+                session,
                 messageContext.author.id
             );
 
@@ -256,8 +255,8 @@ export default class SpotifyCommand implements BaseCommand {
             }
 
             let matchedPlaylist: MatchedPlaylist;
-            if (gameSession) {
-                matchedPlaylist = (await gameSession.songSelector.reloadSongs(
+            if (session) {
+                matchedPlaylist = (await session.songSelector.reloadSongs(
                     guildPreference,
                     premiumRequest,
                     playlistID
@@ -294,9 +293,7 @@ export default class SpotifyCommand implements BaseCommand {
                 return;
             }
 
-            await guildPreference.setSpotifyPlaylistMetadata(
-                matchedPlaylist.metadata
-            );
+            await guildPreference.setSpotifyPlaylistID(playlistID);
 
             await LimitCommand.updateOption(
                 messageContext,
@@ -363,10 +360,10 @@ export default class SpotifyCommand implements BaseCommand {
         }
 
         await sendOptionsMessage(
-            Session.getSession(guildID),
+            session,
             messageContext,
             guildPreference,
-            [{ option: GameOption.SPOTIFY_PLAYLIST_METADATA, reset }],
+            [{ option: GameOption.SPOTIFY_PLAYLIST_ID, reset }],
             false,
             undefined,
             undefined,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -183,7 +183,7 @@ export const enum GameOptionInternal {
     SUBUNIT_PREFERENCE = "subunitPreference",
     OST_PREFERENCE = "ostPreference",
     FORCE_PLAY_SONG = "forcePlaySongID",
-    SPOTIFY_PLAYLIST_METADATA = "spotifyPlaylistMetadata",
+    SPOTIFY_PLAYLIST_ID = "spotifyPlaylistID",
 }
 
 export const GameOptionInternalToGameOption: { [option: string]: string } = {
@@ -210,8 +210,7 @@ export const GameOptionInternalToGameOption: { [option: string]: string } = {
     [GameOptionInternal.SUBUNIT_PREFERENCE]: GameOption.SUBUNIT_PREFERENCE,
     [GameOptionInternal.OST_PREFERENCE]: GameOption.OST_PREFERENCE,
     [GameOptionInternal.FORCE_PLAY_SONG]: GameOption.FORCE_PLAY_SONG,
-    [GameOptionInternal.SPOTIFY_PLAYLIST_METADATA]:
-        GameOption.SPOTIFY_PLAYLIST_METADATA,
+    [GameOptionInternal.SPOTIFY_PLAYLIST_ID]: GameOption.SPOTIFY_PLAYLIST_ID,
 };
 
 export const ROUND_MAX_RUNNERS_UP = 30;

--- a/src/enums/game_option_name.ts
+++ b/src/enums/game_option_name.ts
@@ -20,7 +20,7 @@ enum GameOption {
     EXCLUDE = "Exclude",
     INCLUDE = "Include",
     FORCE_PLAY_SONG = "Force Play Song",
-    SPOTIFY_PLAYLIST_METADATA = "Spotify Playlist",
+    SPOTIFY_PLAYLIST_ID = "Spotify Playlist",
 }
 
 export default GameOption;

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -782,10 +782,6 @@ export async function generateOptionsMessage(
     optionStrings[GameOption.SEEK_TYPE] = gameOptions.seekType;
     optionStrings[GameOption.GUESS_MODE_TYPE] = gameOptions.guessModeType;
     optionStrings[GameOption.SPECIAL_TYPE] = gameOptions.specialType;
-    optionStrings[GameOption.SPOTIFY_PLAYLIST_METADATA] =
-        gameOptions.spotifyPlaylistMetadata
-            ? `[${gameOptions.spotifyPlaylistMetadata.playlistName}](${SPOTIFY_BASE_URL}${gameOptions.spotifyPlaylistMetadata.playlistID})`
-            : null;
 
     optionStrings[GameOption.TIMER] = guildPreference.isGuessTimeoutSet()
         ? i18n.translate(guildID, "command.options.timer", {
@@ -806,6 +802,24 @@ export async function generateOptionsMessage(
     optionStrings[GameOption.INCLUDE] = guildPreference.isIncludesMode()
         ? guildPreference.getDisplayedIncludesGroupNames()
         : null;
+
+    const spotifyPlaylistID = gameOptions.spotifyPlaylistID;
+    let thumbnailUrl: string | undefined;
+    if (spotifyPlaylistID) {
+        const matchedPlaylist =
+            await State.spotifyManager.getMatchedSpotifySongs(
+                spotifyPlaylistID,
+                premiumRequest
+            );
+
+        optionStrings[
+            GameOption.SPOTIFY_PLAYLIST_ID
+        ] = `[${matchedPlaylist.metadata.playlistName}](${SPOTIFY_BASE_URL}${matchedPlaylist.metadata.playlistID})`;
+
+        thumbnailUrl = matchedPlaylist.metadata.thumbnailUrl;
+    } else {
+        optionStrings[GameOption.SPOTIFY_PLAYLIST_ID] = null;
+    }
 
     const conflictString = i18n.translate(guildID, "misc.conflict");
 
@@ -978,7 +992,7 @@ export async function generateOptionsMessage(
     if (isSpotify) {
         priorityOptions = "";
         fieldOptions.unshift(GameOption.ANSWER_TYPE);
-        fieldOptions.unshift(GameOption.SPOTIFY_PLAYLIST_METADATA);
+        fieldOptions.unshift(GameOption.SPOTIFY_PLAYLIST_ID);
     }
 
     const ZERO_WIDTH_SPACE = "​";
@@ -1092,6 +1106,7 @@ export async function generateOptionsMessage(
         description,
         fields,
         footerText,
+        thumbnailUrl,
     };
 }
 

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -411,7 +411,7 @@ async function reloadLocales(): Promise<void> {
 }
 
 function clearCachedPlaylists(): void {
-    State.cachedPlaylists = {};
+    State.cachedSpotifyPlaylists = {};
 }
 
 /**

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -232,17 +232,12 @@ export default class SpotifyManager {
             thumbnailUrl: spotifyMetadata.thumbnailUrl as string,
         };
 
-        if (
-            !cachedPlaylist ||
-            cachedPlaylist.snapshotID !== spotifyMetadata.snapshotID
-        ) {
-            State.cachedSpotifyPlaylists[playlistID] = {
-                snapshotID: spotifyMetadata.snapshotID,
-                metadata,
-                matchedSongs,
-                truncated,
-            };
-        }
+        State.cachedSpotifyPlaylists[playlistID] = {
+            snapshotID: spotifyMetadata.snapshotID,
+            metadata,
+            matchedSongs,
+            truncated,
+        };
 
         return {
             matchedSongs,

--- a/src/helpers/spotify_manager.ts
+++ b/src/helpers/spotify_manager.ts
@@ -232,12 +232,17 @@ export default class SpotifyManager {
             thumbnailUrl: spotifyMetadata.thumbnailUrl as string,
         };
 
-        State.cachedSpotifyPlaylists[playlistID] = {
-            snapshotID: spotifyMetadata.snapshotID,
-            metadata,
-            matchedSongs,
-            truncated,
-        };
+        if (
+            !cachedPlaylist ||
+            cachedPlaylist.snapshotID !== spotifyMetadata.snapshotID
+        ) {
+            State.cachedSpotifyPlaylists[playlistID] = {
+                snapshotID: spotifyMetadata.snapshotID,
+                metadata,
+                matchedSongs,
+                truncated,
+            };
+        }
 
         return {
             matchedSongs,

--- a/src/interfaces/game_options.ts
+++ b/src/interfaces/game_options.ts
@@ -1,5 +1,4 @@
 import type { GenderModeOptions } from "../enums/option_types/gender";
-import type { PlaylistMetadata } from "src/helpers/spotify_manager";
 import type AnswerType from "../enums/option_types/answer_type";
 import type ArtistType from "../enums/option_types/artist_type";
 import type GuessModeType from "../enums/option_types/guess_mode_type";
@@ -37,5 +36,5 @@ export default interface GameOptions {
     subunitPreference: SubunitsPreference;
     ostPreference: OstPreference;
     forcePlaySongID: string | null;
-    spotifyPlaylistMetadata: PlaylistMetadata | null;
+    spotifyPlaylistID: string | null;
 }

--- a/src/interfaces/matched_playlist.ts
+++ b/src/interfaces/matched_playlist.ts
@@ -1,0 +1,8 @@
+import type { PlaylistMetadata } from "./playlist_metadata";
+import type QueriedSong from "./queried_song";
+
+export interface MatchedPlaylist {
+    matchedSongs: Array<QueriedSong>;
+    metadata: PlaylistMetadata;
+    truncated: boolean;
+}

--- a/src/interfaces/playlist_metadata.ts
+++ b/src/interfaces/playlist_metadata.ts
@@ -1,0 +1,7 @@
+export interface PlaylistMetadata {
+    playlistID: string;
+    playlistName: string;
+    playlistLength: number;
+    matchedSongsLength: number;
+    thumbnailUrl?: string;
+}

--- a/src/scripts/spotify-playlist-metadata-to-id.ts
+++ b/src/scripts/spotify-playlist-metadata-to-id.ts
@@ -1,0 +1,92 @@
+import dbContext from "../database_context";
+import type { PlaylistMetadata } from "../interfaces/playlist_metadata";
+
+(async () => {
+    if (require.main === module) {
+        {
+            const metadataList = await dbContext.kmq
+                .selectFrom("game_options")
+                .selectAll()
+                .where("option_name", "=", "spotifyPlaylistMetadata")
+                .where("option_value", "<>", "null")
+                .execute();
+
+            const playlistIDs: Array<{
+                guild_id: string;
+                option_name: string;
+                option_value: string;
+                client_id: string;
+            }> = [];
+
+            for (const metadata of metadataList) {
+                if (metadata.option_value) {
+                    const optionValue: PlaylistMetadata = JSON.parse(
+                        metadata.option_value
+                    );
+
+                    const playlistID = optionValue.playlistID;
+                    playlistIDs.push({
+                        guild_id: metadata.guild_id,
+                        option_name: "spotifyPlaylistID",
+                        option_value: playlistID,
+                        client_id: metadata.client_id,
+                    });
+                }
+            }
+
+            await dbContext.kmq
+                .insertInto("game_options")
+                .values(playlistIDs)
+                .execute();
+
+            await dbContext.kmq
+                .deleteFrom("game_options")
+                .where("option_name", "=", "spotifyPlaylistMetadata")
+                .execute();
+        }
+
+        {
+            const metadataList = await dbContext.kmq
+                .selectFrom("game_option_presets")
+                .selectAll()
+                .where("option_name", "=", "spotifyPlaylistMetadata")
+                .where("option_value", "<>", "null")
+                .execute();
+
+            const playlistIDs: Array<{
+                guild_id: string;
+                preset_name: string;
+                option_name: string;
+                option_value: string;
+            }> = [];
+
+            for (const metadata of metadataList) {
+                if (metadata.option_value) {
+                    const optionValue: PlaylistMetadata = JSON.parse(
+                        metadata.option_value
+                    );
+
+                    const playlistID = optionValue.playlistID;
+                    playlistIDs.push({
+                        guild_id: metadata.guild_id,
+                        preset_name: metadata.preset_name,
+                        option_name: "spotifyPlaylistID",
+                        option_value: playlistID,
+                    });
+                }
+            }
+
+            await dbContext.kmq
+                .insertInto("game_option_presets")
+                .values(playlistIDs)
+                .execute();
+
+            await dbContext.kmq
+                .deleteFrom("game_option_presets")
+                .where("option_name", "=", "spotifyPlaylistMetadata")
+                .execute();
+        }
+
+        process.exit(0);
+    }
+})();

--- a/src/scripts/spotify-playlist-metadata-to-id.ts
+++ b/src/scripts/spotify-playlist-metadata-to-id.ts
@@ -28,7 +28,7 @@ import type { PlaylistMetadata } from "../interfaces/playlist_metadata";
                     playlistIDs.push({
                         guild_id: metadata.guild_id,
                         option_name: "spotifyPlaylistID",
-                        option_value: playlistID,
+                        option_value: JSON.stringify(playlistID),
                         client_id: metadata.client_id,
                     });
                 }
@@ -71,7 +71,7 @@ import type { PlaylistMetadata } from "../interfaces/playlist_metadata";
                         guild_id: metadata.guild_id,
                         preset_name: metadata.preset_name,
                         option_name: "spotifyPlaylistID",
-                        option_value: playlistID,
+                        option_value: JSON.stringify(playlistID),
                     });
                 }
             }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,14 +1,15 @@
 import { DEFAULT_LOCALE } from "./constants";
 import RateLimiter from "./rate_limiter";
 import type { IPC } from "eris-fleet";
+import type { PlaylistMetadata } from "./interfaces/playlist_metadata";
 import type GameSession from "./structures/game_session";
 import type KmqClient from "./kmq_client";
 import type ListeningSession from "./structures/listening_session";
 import type LocaleType from "./enums/locale_type";
 import type MatchedArtist from "./interfaces/matched_artist";
+import type QueriedSong from "./interfaces/queried_song";
 import type RestartNotification from "./interfaces/restart_notification";
 import type SpotifyManager from "./helpers/spotify_manager";
-import type SpotifyTrack from "./interfaces/spotify_track";
 
 export default class State {
     static version: string;
@@ -49,8 +50,13 @@ export default class State {
 
     static restartNotification: RestartNotification | null;
     static spotifyManager: SpotifyManager;
-    static cachedPlaylists: {
-        [spotifySnapshotID: string]: Array<SpotifyTrack>;
+    static cachedSpotifyPlaylists: {
+        [playlistID: string]: {
+            snapshotID: string;
+            metadata: PlaylistMetadata;
+            matchedSongs: Array<QueriedSong>;
+            truncated: boolean;
+        };
     } = {};
 
     static commandToID: { [commandName: string]: string } = {};

--- a/src/structures/guild_preference.ts
+++ b/src/structures/guild_preference.ts
@@ -28,7 +28,6 @@ import _ from "lodash";
 import dbContext from "../database_context";
 import type { GenderModeOptions } from "../enums/option_types/gender";
 import type { MutexInterface } from "async-mutex";
-import type { PlaylistMetadata } from "src/helpers/spotify_manager";
 import type ArtistType from "../enums/option_types/artist_type";
 import type GameOptions from "../interfaces/game_options";
 import type GuessModeType from "../enums/option_types/guess_mode_type";
@@ -60,7 +59,6 @@ type GameOptionValue =
     | MultiGuessType
     | SubunitsPreference
     | OstPreference
-    | PlaylistMetadata
     | string
     | null;
 
@@ -161,9 +159,9 @@ export default class GuildPreference {
             default: [null],
             setter: this.setForcePlaySong,
         },
-        [GameOption.SPOTIFY_PLAYLIST_METADATA]: {
+        [GameOption.SPOTIFY_PLAYLIST_ID]: {
             default: [null],
-            setter: this.setSpotifyPlaylistMetadata,
+            setter: this.setSpotifyPlaylistID,
         },
     };
 
@@ -191,7 +189,7 @@ export default class GuildPreference {
         subunitPreference: DEFAULT_SUBUNIT_PREFERENCE,
         ostPreference: DEFAULT_OST_PREFERENCE,
         forcePlaySongID: null,
-        spotifyPlaylistMetadata: null,
+        spotifyPlaylistID: null,
     };
 
     /** The GuildPreference's respective GameOptions */
@@ -892,30 +890,28 @@ export default class GuildPreference {
 
     /**
      * Sets the Spotify playlist option value
-     * @param playlistMetadata - Spotify playlist ID, length, name
+     * @param playlistID - Spotify playlist ID
      */
-    async setSpotifyPlaylistMetadata(
-        playlistMetadata: PlaylistMetadata | null
-    ): Promise<void> {
-        this.gameOptions.spotifyPlaylistMetadata = playlistMetadata;
+    async setSpotifyPlaylistID(playlistID: string | null): Promise<void> {
+        this.gameOptions.spotifyPlaylistID = playlistID;
         await this.updateGuildPreferences([
             {
-                name: GameOptionInternal.SPOTIFY_PLAYLIST_METADATA,
-                value: playlistMetadata,
+                name: GameOptionInternal.SPOTIFY_PLAYLIST_ID,
+                value: playlistID,
             },
         ]);
     }
 
     /** @returns the ID of the playlist to retrieve songs from */
-    getSpotifyPlaylistMetadata(): PlaylistMetadata | null {
-        return this.gameOptions.spotifyPlaylistMetadata;
+    getSpotifyPlaylistID(): string | null {
+        return this.gameOptions.spotifyPlaylistID;
     }
 
     /**
      * @returns whether the spotify playing option is set
      */
     isSpotifyPlaylist(): boolean {
-        return this.gameOptions.spotifyPlaylistMetadata !== null;
+        return this.gameOptions.spotifyPlaylistID !== null;
     }
 
     /**

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -136,7 +136,7 @@ export default abstract class Session {
             await this.songSelector.reloadSongs(
                 this.guildPreference,
                 this.isPremium,
-                this.guildPreference.getSpotifyPlaylistMetadata()?.playlistID
+                this.guildPreference.getSpotifyPlaylistID() ?? undefined
             );
         };
     }
@@ -193,8 +193,7 @@ export default abstract class Session {
                 await this.songSelector.reloadSongs(
                     this.guildPreference,
                     this.isPremium,
-                    this.guildPreference.getSpotifyPlaylistMetadata()
-                        ?.playlistID
+                    this.guildPreference.getSpotifyPlaylistID() ?? undefined
                 );
             } catch (err) {
                 await sendErrorMessage(messageContext, {
@@ -640,7 +639,7 @@ export default abstract class Session {
         await this.songSelector.reloadSongs(
             this.guildPreference,
             isPremium,
-            this.guildPreference.getSpotifyPlaylistMetadata()?.playlistID
+            this.guildPreference.getSpotifyPlaylistID() ?? undefined
         );
 
         if (!isPremium) {

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -20,7 +20,7 @@ import type {
     GenderModeOptions,
 } from "../enums/option_types/gender";
 import type { Expression, SqlBool } from "kysely";
-import type { MatchedPlaylist } from "../helpers/spotify_manager";
+import type { MatchedPlaylist } from "../interfaces/matched_playlist";
 import type GuildPreference from "./guild_preference";
 import type QueriedSong from "../interfaces/queried_song";
 import type UniqueSongCounter from "../interfaces/unique_song_counter";

--- a/src/test/ci/command_prechecks.test.ts
+++ b/src/test/ci/command_prechecks.test.ts
@@ -588,12 +588,7 @@ describe("command prechecks", () => {
 
         describe("spotify playlist set", () => {
             it("should return false", async () => {
-                await guildPreference.setSpotifyPlaylistMetadata({
-                    playlistID: "id",
-                    playlistName: "playlist",
-                    playlistLength: 4,
-                    matchedSongsLength: 2,
-                });
+                await guildPreference.setSpotifyPlaylistID("id");
 
                 assert.strictEqual(
                     await CommandPrechecks.notSpotifyPrecheck({
@@ -607,7 +602,7 @@ describe("command prechecks", () => {
 
         describe("spotify playlist not set", () => {
             it("should return true", async () => {
-                await guildPreference.setSpotifyPlaylistMetadata(null);
+                await guildPreference.setSpotifyPlaylistID(null);
 
                 assert.strictEqual(
                     await CommandPrechecks.notSpotifyPrecheck({

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export const GameOptionCommand: { [option: string]: string } = {
     [GameOption.DURATION]: "duration",
     [GameOption.EXCLUDE]: "exclude",
     [GameOption.INCLUDE]: "include",
-    [GameOption.SPOTIFY_PLAYLIST_METADATA]: "spotify",
+    [GameOption.SPOTIFY_PLAYLIST_ID]: "spotify",
 };
 
 export const PriorityGameOption: Array<GameOption> = [
@@ -37,7 +37,7 @@ export const PriorityGameOption: Array<GameOption> = [
     GameOption.GENDER,
     GameOption.ANSWER_TYPE,
     GameOption.CUTOFF,
-    GameOption.SPOTIFY_PLAYLIST_METADATA,
+    GameOption.SPOTIFY_PLAYLIST_ID,
 ];
 
 export const ConflictingGameOptions: { [option: string]: Array<GameOption> } = {


### PR DESCRIPTION
* Store only playlistID in game options and game option presets (script needs to be run)
* Cache queried songs and metadata (flushed daily, invalidated on snapshotID change)
* Show spotify thumbnail in /options
* Move MatchedPlaylist, PlaylistMetadata into interface files