### PR TITLE
Remove extra gender option key

### DIFF
--- a/src/commands/game_options/gender.ts
+++ b/src/commands/game_options/gender.ts
@@ -131,7 +131,7 @@ export default class GenderCommand implements BaseCommand {
 
                     type: Eris.Constants.ApplicationCommandOptionTypes
                         .SUB_COMMAND,
-                    options: [...Array(4).keys()].map((x) => ({
+                    options: [...Array(3).keys()].map((x) => ({
                         name: `gender_${x + 1}`,
                         description: i18n.translate(
                             LocaleType.EN,


### PR DESCRIPTION
* We only accept a maximum of three gender options (male, female, coed)
* Alternating is not used in conjunction with the above three options