### PR TITLE
Fix bug where parsing playlist prevented /options ack

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -737,7 +737,6 @@ export async function generateOptionsMessage(
 
     if (spotifyPlaylistID) {
         if (!State.cachedSpotifyPlaylists[spotifyPlaylistID]) {
-            logger.info("uncached");
             // Let the user know the playlist is being fetched by acking their interaction
             // Send the options once the playlist is fetched via followup message
             await sendInfoMessage(

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -699,6 +699,7 @@ function getFormattedLimit(
  * @param preset - Specifies whether the GameOptions were modified by a preset
  * @param allReset - Specifies whether all GameOptions were reset
  * @param footerText - The footer text
+ * @param interaction - The interaction
  *  @returns an embed of current game options
  */
 export async function generateOptionsMessage(
@@ -708,7 +709,8 @@ export async function generateOptionsMessage(
     updatedOptions: { option: GameOption; reset: boolean }[],
     preset = false,
     allReset = false,
-    footerText?: string
+    footerText?: string,
+    interaction?: Eris.CommandInteraction
 ): Promise<EmbedPayload | null> {
     if (guildPreference.gameOptions.forcePlaySongID) {
         return {
@@ -724,6 +726,46 @@ export async function generateOptionsMessage(
         session,
         messageContext.author.id
     );
+
+    // Store the VALUE of ,[option]: [VALUE] into optionStrings
+    // Null optionStrings values are set to "Not set" below
+    const optionStrings: { [option: string]: string | null } = {};
+
+    const gameOptions = guildPreference.gameOptions;
+    const spotifyPlaylistID = gameOptions.spotifyPlaylistID;
+    let thumbnailUrl: string | undefined;
+
+    if (spotifyPlaylistID) {
+        if (!State.cachedSpotifyPlaylists[spotifyPlaylistID]) {
+            logger.info("uncached");
+            // Let the user know the playlist is being fetched by acking their interaction
+            // Send the options once the playlist is fetched via followup message
+            await sendInfoMessage(
+                messageContext,
+                {
+                    title: i18n.translate(guildID, "command.spotify.parsing"),
+                },
+                false,
+                undefined,
+                [],
+                interaction
+            );
+        }
+
+        const matchedPlaylist =
+            await State.spotifyManager.getMatchedSpotifySongs(
+                spotifyPlaylistID,
+                premiumRequest
+            );
+
+        optionStrings[
+            GameOption.SPOTIFY_PLAYLIST_ID
+        ] = `[${matchedPlaylist.metadata.playlistName}](${SPOTIFY_BASE_URL}${matchedPlaylist.metadata.playlistID})`;
+
+        thumbnailUrl = matchedPlaylist.metadata.thumbnailUrl;
+    } else {
+        optionStrings[GameOption.SPOTIFY_PLAYLIST_ID] = null;
+    }
 
     const totalSongs = await getAvailableSongCount(
         guildPreference,
@@ -748,7 +790,6 @@ export async function generateOptionsMessage(
         return null;
     }
 
-    const gameOptions = guildPreference.gameOptions;
     const limit = getFormattedLimit(
         guildID,
         gameOptions,
@@ -756,9 +797,6 @@ export async function generateOptionsMessage(
         totalSongs.countBeforeLimit
     );
 
-    // Store the VALUE of ,[option]: [VALUE] into optionStrings
-    // Null optionStrings values are set to "Not set" below
-    const optionStrings: { [option: string]: string | null } = {};
     optionStrings[GameOption.LIMIT] = `${limit} / ${friendlyFormattedNumber(
         totalSongs.countBeforeLimit
     )}`;
@@ -802,24 +840,6 @@ export async function generateOptionsMessage(
     optionStrings[GameOption.INCLUDE] = guildPreference.isIncludesMode()
         ? guildPreference.getDisplayedIncludesGroupNames()
         : null;
-
-    const spotifyPlaylistID = gameOptions.spotifyPlaylistID;
-    let thumbnailUrl: string | undefined;
-    if (spotifyPlaylistID) {
-        const matchedPlaylist =
-            await State.spotifyManager.getMatchedSpotifySongs(
-                spotifyPlaylistID,
-                premiumRequest
-            );
-
-        optionStrings[
-            GameOption.SPOTIFY_PLAYLIST_ID
-        ] = `[${matchedPlaylist.metadata.playlistName}](${SPOTIFY_BASE_URL}${matchedPlaylist.metadata.playlistID})`;
-
-        thumbnailUrl = matchedPlaylist.metadata.thumbnailUrl;
-    } else {
-        optionStrings[GameOption.SPOTIFY_PLAYLIST_ID] = null;
-    }
 
     const conflictString = i18n.translate(guildID, "misc.conflict");
 
@@ -1139,7 +1159,8 @@ export async function sendOptionsMessage(
         updatedOptions,
         preset,
         allReset,
-        footerText
+        footerText,
+        interaction
     );
 
     if (!optionsEmbed) {
@@ -1148,14 +1169,20 @@ export async function sendOptionsMessage(
         );
     }
 
-    await sendInfoMessage(
-        messageContext,
-        optionsEmbed,
-        true,
-        undefined,
-        [],
-        interaction
-    );
+    if (interaction?.acknowledged) {
+        await interaction.createFollowup({
+            embeds: [generateEmbed(messageContext, optionsEmbed)],
+        });
+    } else {
+        await sendInfoMessage(
+            messageContext,
+            optionsEmbed,
+            true,
+            undefined,
+            [],
+            interaction
+        );
+    }
 }
 
 /**


### PR DESCRIPTION
* When a playlist is uncached, it has to be parsed before it's shown in /options
* For non-interaction ,options calls, this leads to users waiting multiple seconds while the playlist is parsed before /options is sent, which makes the bot look unresponsive 
    * Added a parsing message, followed by ,options
* For interactions, if it is a large playlist, the bot fails to acknowledge the interaction, and only subsequent calls of /options go through after the playlist is parsed
    * Acknowledged the interaction with a parsing message, and used a followup message for /options