### PR TITLE
Fix bug where quick guess bonus was always applied

### DIFF
--- a/src/commands/game_commands/exp.ts
+++ b/src/commands/game_commands/exp.ts
@@ -246,7 +246,7 @@ export function participantExpScalingModifier(numParticipants: number): number {
  * @param gameRound - The game round
  * @param numParticipants - The number of participants
  * @param streak - The current guessing streak
- * @param guessSpeed - The guess speed
+ * @param guessSpeedMs - The guess speed, in milliseconds
  * @param place - The place of the guess
  * @returns The round's total EXP modifier
  */
@@ -254,7 +254,7 @@ export function calculateRoundExpMultiplier(
     gameRound: GameRound,
     numParticipants: number,
     streak: number,
-    guessSpeed: number,
+    guessSpeedMs: number,
     place: number
 ): number {
     let expModifier = 1;
@@ -262,7 +262,7 @@ export function calculateRoundExpMultiplier(
     // incentivize for number of participants from 1x to 1.5x
     expModifier *= participantExpScalingModifier(numParticipants);
     // bonus for quick guess
-    if (guessSpeed < QUICK_GUESS_MS) {
+    if (guessSpeedMs < QUICK_GUESS_MS) {
         expModifier *= ExpBonusModifierValues[ExpBonusModifier.QUICK_GUESS];
     }
 
@@ -290,7 +290,7 @@ export function calculateRoundExpMultiplier(
  * @param gameRound - The game round
  * @param numParticipants - The number of participants
  * @param streak - The current guessing streak
- * @param guessSpeed - The guess speed
+ * @param guessSpeedMs - The guess speed, in milliseconds
  * @param place - The place of the guess
  * @param voteBonusExp - Whether bonus EXP should be applied to the modifier
  * @param playerID - the player's ID
@@ -301,7 +301,7 @@ export async function calculateTotalRoundExp(
     gameRound: GameRound,
     numParticipants: number,
     streak: number,
-    guessSpeed: number,
+    guessSpeedMs: number,
     place: number,
     voteBonusExp: boolean,
     playerID: string
@@ -316,7 +316,7 @@ export async function calculateTotalRoundExp(
         gameRound,
         numParticipants,
         streak,
-        guessSpeed,
+        guessSpeedMs,
         place
     );
 

--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -9,10 +9,7 @@ import {
     QUICK_GUESS_MS,
     ROUND_MAX_RUNNERS_UP,
 } from "../constants";
-import {
-    friendlyFormattedNumber,
-    getMention,
-} from "../helpers/utils";
+import { friendlyFormattedNumber, getMention } from "../helpers/utils";
 import ExpBonusModifier from "../enums/exp_bonus_modifier";
 import GameType from "../enums/game_type";
 import GuessModeType from "../enums/option_types/guess_mode_type";
@@ -491,9 +488,7 @@ export default class GameRound extends Round {
         const sortedGuesses = Object.entries(this.guesses).map(
             (x): [string, Array<GuessResult>] => [
                 x[0],
-                x[1].sort(
-                    (a, b) => a.timeToGuessMs - b.timeToGuessMs
-                ),
+                x[1].sort((a, b) => a.timeToGuessMs - b.timeToGuessMs),
             ]
         );
 
@@ -505,9 +500,7 @@ export default class GameRound extends Round {
 
                     return [playerID, mostRecentGuess];
                 })
-                .sort(
-                    (a, b) => a[1].timeToGuessMs - b[1].timeToGuessMs
-                )
+                .sort((a, b) => a[1].timeToGuessMs - b[1].timeToGuessMs)
                 .slice(0, ROUND_MAX_RUNNERS_UP)) {
                 const userID = entry[0];
                 const timeToGuessMs = entry[1].timeToGuessMs;
@@ -538,9 +531,7 @@ export default class GameRound extends Round {
                 correctDescription += `\n${
                     isCorrect ? CORRECT_GUESS_EMOJI : INCORRECT_GUESS_EMOJI
                 } ${getMention(userID)}: \`\`${displayedGuess}\`\`${streak}(${
-                    timeToGuessMs <= QUICK_GUESS_MS
-                        ? QUICK_GUESS_EMOJI
-                        : ""
+                    timeToGuessMs <= QUICK_GUESS_MS ? QUICK_GUESS_EMOJI : ""
                 }${timeToGuessMs / 1000}s)${expGain}`;
             }
 

--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -10,7 +10,6 @@ import {
     ROUND_MAX_RUNNERS_UP,
 } from "../constants";
 import {
-    durationSeconds,
     friendlyFormattedNumber,
     getMention,
 } from "../helpers/utils";
@@ -492,7 +491,9 @@ export default class GameRound extends Round {
         const sortedGuesses = Object.entries(this.guesses).map(
             (x): [string, Array<GuessResult>] => [
                 x[0],
-                x[1].sort((a, b) => a.timeToGuessMs - b.timeToGuessMs),
+                x[1].sort(
+                    (a, b) => a.timeToGuessMs - b.timeToGuessMs
+                ),
             ]
         );
 
@@ -504,7 +505,9 @@ export default class GameRound extends Round {
 
                     return [playerID, mostRecentGuess];
                 })
-                .sort((a, b) => a[1].timeToGuessMs - b[1].timeToGuessMs)
+                .sort(
+                    (a, b) => a[1].timeToGuessMs - b[1].timeToGuessMs
+                )
                 .slice(0, ROUND_MAX_RUNNERS_UP)) {
                 const userID = entry[0];
                 const timeToGuessMs = entry[1].timeToGuessMs;
@@ -535,7 +538,9 @@ export default class GameRound extends Round {
                 correctDescription += `\n${
                     isCorrect ? CORRECT_GUESS_EMOJI : INCORRECT_GUESS_EMOJI
                 } ${getMention(userID)}: \`\`${displayedGuess}\`\`${streak}(${
-                    timeToGuessMs <= QUICK_GUESS_MS ? QUICK_GUESS_EMOJI : ""
+                    timeToGuessMs <= QUICK_GUESS_MS
+                        ? QUICK_GUESS_EMOJI
+                        : ""
                 }${timeToGuessMs / 1000}s)${expGain}`;
             }
 

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -1492,13 +1492,13 @@ export default class GameSession extends Session {
             (guessResult.correctGuessers ?? []).map(
                 async (correctGuesser, idx) => {
                     const guessPosition = idx + 1;
-                    const timeToGuess = (
+                    const timeToGuessMs = (
                         this.gameType === GameType.HIDDEN ? Math.max : Math.min
                     )(
                         ...round
                             .getGuesses()
                             [correctGuesser.id].filter((x) => x.correct)
-                            .map((x) => x.timeToGuessSeconds)
+                            .map((x) => x.timeToGuessMs)
                     );
 
                     const expGain = await calculateTotalRoundExp(
@@ -1506,7 +1506,7 @@ export default class GameSession extends Session {
                         round,
                         getNumParticipants(this.voiceChannelID),
                         lastGuesserStreak,
-                        timeToGuess,
+                        timeToGuessMs,
                         guessPosition,
                         await userBonusIsActive(correctGuesser.id),
                         correctGuesser.id

--- a/src/test/ci/game_round.test.ts
+++ b/src/test/ci/game_round.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/dot-notation */
 import { ExpBonusModifierValues } from "../../constants";
-import { delay, durationSeconds } from "../../helpers/utils";
+import { delay } from "../../helpers/utils";
 import ExpBonusModifier from "../../enums/exp_bonus_modifier";
 import GameRound, {
     cleanArtistName,
@@ -713,10 +713,7 @@ describe("game round", () => {
             assert.deepStrictEqual(gameRound.getGuesses(), {
                 [playerID]: [
                     {
-                        timeToGuessSeconds: durationSeconds(
-                            gameRound.startedAt,
-                            createdAt
-                        ),
+                        timeToGuessMs: createdAt - gameRound.startedAt,
                         guess,
                         correct: true,
                     },
@@ -745,10 +742,8 @@ describe("game round", () => {
             assert.deepStrictEqual(gameRound.getGuesses(), {
                 [playerID]: [
                     {
-                        timeToGuessSeconds: durationSeconds(
-                            gameRound.startedAt,
-                            firstGuessCreatedAt
-                        ),
+                        timeToGuessMs:
+                            firstGuessCreatedAt - gameRound.startedAt,
                         guess: firstGuess,
                         correct: false,
                     },
@@ -772,18 +767,14 @@ describe("game round", () => {
             assert.deepStrictEqual(gameRound.getGuesses(), {
                 [playerID]: [
                     {
-                        timeToGuessSeconds: durationSeconds(
-                            gameRound.startedAt,
-                            firstGuessCreatedAt
-                        ),
+                        timeToGuessMs:
+                            firstGuessCreatedAt - gameRound.startedAt,
                         guess: firstGuess,
                         correct: false,
                     },
                     {
-                        timeToGuessSeconds: durationSeconds(
-                            gameRound.startedAt,
-                            secondGuessCreatedAt
-                        ),
+                        timeToGuessMs:
+                            secondGuessCreatedAt - gameRound.startedAt,
                         guess: secondGuess,
                         correct: true,
                     },


### PR DESCRIPTION
In 8bc9ec533671bfbbc5cc5a7b892a28d57923bd33, the switch from storing timestamps to guess times (in seconds) led to an inconsistency when comparing with the quick guess bonus cutoff constant (in milliseconds).