### PR TITLE
Install node-gyp in Dockerfile

### DIFF
--- a/docker/kmq/Dockerfile
+++ b/docker/kmq/Dockerfile
@@ -20,6 +20,7 @@ RUN wget "https://azcopyvnext.azureedge.net/release20230331/azcopy_linux_${TARGE
 
 WORKDIR /app
 COPY yarn.lock package.json ./
+RUN yarn global add node-gyp@9.4.0
 RUN yarn install --frozen-lockfile
 
 COPY start.sh tsconfig.json ./


### PR DESCRIPTION
Docker build fails in newer versions of the node:18 image. required `node-gyp` binary was removed from npm bundle
https://github.com/npm/cli/pull/6554#issuecomment-1726429283