### PR TITLE
Fix bug where songs with brackets in middle of name parsed incorrectly (v2)

### DIFF
--- a/sql/procedures/create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/create_kmq_data_tables_procedure.sql
@@ -37,7 +37,7 @@ BEGIN
 	INSERT INTO available_songs_temp
 	SELECT
 		TRIM(kpop_videos.app_kpop.name) AS song_name_en,
-		(CASE kpop_videos.app_kpop.name LIKE '%(%' AND RIGHT(kpop_videos.app_kpop.name, 1) = ')' WHEN 1 THEN TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) ELSE kpop_videos.app_kpop.name END) AS clean_song_name_en,
+		TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) AS clean_song_name_en,
 		REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
 		TRIM(kpop_videos.app_kpop.kname) AS song_name_ko,
 		TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.kname, '(', 1)) AS clean_song_name_ko,
@@ -75,7 +75,7 @@ BEGIN
 	FROM (
 		SELECT
 			TRIM(kpop_videos.app_kpop.name) AS song_name_en,
-			(CASE kpop_videos.app_kpop.name LIKE '%(%' AND RIGHT(kpop_videos.app_kpop.name, 1) = ')' WHEN 1 THEN TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) ELSE kpop_videos.app_kpop.name END) AS clean_song_name_en,
+			TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1)) AS clean_song_name_en,
 			REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') AS clean_song_name_alpha_numeric,
 			TRIM(kpop_videos.app_kpop.kname) AS song_name_ko,
 			TRIM(SUBSTRING_INDEX(kpop_videos.app_kpop.kname, '(', 1)) AS clean_song_name_ko,

--- a/sql/procedures/post_seed_data_cleaning_procedure.sql
+++ b/sql/procedures/post_seed_data_cleaning_procedure.sql
@@ -1,6 +1,6 @@
 DELIMITER //
-DROP PROCEDURE IF EXISTS DeduplicateGroupNames //
-CREATE PROCEDURE DeduplicateGroupNames()
+DROP PROCEDURE IF EXISTS PostSeedDataCleaning //
+CREATE PROCEDURE PostSeedDataCleaning()
 BEGIN
 	/* de-duplicate conflicting names */
 	ALTER TABLE kpop_videos.app_kpop_group ADD COLUMN IF NOT EXISTS original_name VARCHAR(255);
@@ -10,6 +10,12 @@ BEGIN
 	RIGHT JOIN
 	(SELECT LOWER(name) as name, count(*) as c FROM kpop_videos.app_kpop_group GROUP BY LOWER(name) HAVING count(*) > 1 AND name NOT LIKE "%(%)%" ) as b USING (name)
 	SET a.name = concat(a.name, " (", a.fname, ")");
+
+	/* remove bracketed components from song names */
+	ALTER TABLE kpop_videos.app_kpop ADD COLUMN IF NOT EXISTS original_name VARCHAR(255);
+	UPDATE kpop_videos.app_kpop SET original_name = name;
 	
+	UPDATE kpop_videos.app_kpop 
+	SET name = (CASE name LIKE '%(%' AND RIGHT(name, 1) = ')' WHEN 1 THEN TRIM(SUBSTRING_INDEX(name, '(', 1)) ELSE name END);
 END //
 DELIMITER ;

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -181,11 +181,9 @@ export async function generateKmqDataTables(
  * Re-creates the KMQ data tables
  * @param db - The database context
  */
-export async function deduplicateGroupNames(
-    db: DatabaseContext,
-): Promise<void> {
-    logger.info("Deduplicating group names...");
-    await sql`CALL DeduplicateGroupNames();`.execute(db.kmq);
+export async function postSeedDataCleaning(db: DatabaseContext): Promise<void> {
+    logger.info("Performing post seed data cleaning...");
+    await sql`CALL PostSeedDataCleaning();`.execute(db.kmq);
 }
 
 /**
@@ -393,15 +391,15 @@ async function validateSqlDump(
         );
 
         if (!bootstrap) {
-            logger.info("Validating deduplication of group names");
+            logger.info("Validating post-seed data cleaning");
             const originalDedupGroupNamesSqlPath = path.join(
                 __dirname,
-                "../../sql/procedures/deduplicate_app_kpop_group_names.sql",
+                "../../sql/procedures/post_seed_data_cleaning_procedure.sql",
             );
 
             const validationDedupGroupNamesSqlPath = path.join(
                 __dirname,
-                "../../sql/deduplicate_app_kpop_group_names.validation.sql",
+                "../../sql/post_seed_data_cleaning_procedure.validation.sql",
             );
 
             await exec(
@@ -413,7 +411,7 @@ async function validateSqlDump(
             );
 
             await sql
-                .raw("CALL DeduplicateGroupNames();")
+                .raw("CALL PostSeedDataCleaning();")
                 .execute(db.kpopVideosValidation);
 
             logger.info("Validating creation of data tables");
@@ -619,7 +617,7 @@ async function updateKpopDatabase(
 
     if (!options.skipReseed) {
         await seedDb(db, bootstrap);
-        await deduplicateGroupNames(db);
+        await postSeedDataCleaning(db);
     } else {
         logger.info("Skipping reseed");
     }

--- a/src/test/test_setup.ts
+++ b/src/test/test_setup.ts
@@ -53,28 +53,28 @@ before(async function () {
         db.agnostic,
     );
 
-    // create dedup group name procedure
-    const originalDedupGroupNamesSqlPath = path.join(
+    // create post seed data cleaning procedure
+    const originalPostSeedDataCleaningSqlPath = path.join(
         __dirname,
-        "../../sql/procedures/deduplicate_app_kpop_group_names.sql",
+        "../../sql/procedures/post_seed_data_cleaning_procedure.sql",
     );
 
-    const testDedupGroupNamesSqlPath = path.join(
+    const testPostSeedDataCleaningSqlPath = path.join(
         __dirname,
-        "../../sql/deduplicate_app_kpop_group_names.validation.sql",
+        "../../sql/post_seed_data_cleaning_procedure.validation.sql",
     );
 
     cp.execSync(
-        `sed 's/kpop_videos/kpop_videos_test/g;s/kmq/kmq_test/g' ${originalDedupGroupNamesSqlPath} > ${testDedupGroupNamesSqlPath}`,
+        `sed 's/kpop_videos/kpop_videos_test/g;s/kmq/kmq_test/g' ${originalPostSeedDataCleaningSqlPath} > ${testPostSeedDataCleaningSqlPath}`,
     );
 
     cp.execSync(
-        `mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} -h ${process.env.DB_HOST} --port ${process.env.DB_PORT} kmq_test < ${testDedupGroupNamesSqlPath}`,
+        `mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} -h ${process.env.DB_HOST} --port ${process.env.DB_PORT} kmq_test < ${testPostSeedDataCleaningSqlPath}`,
         { stdio: "inherit" },
     );
 
     cp.execSync(
-        `mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} -h ${process.env.DB_HOST} --port ${process.env.DB_PORT} kmq_test -e "CALL DeduplicateGroupNames()"`,
+        `mysql -u ${process.env.DB_USER} -p${process.env.DB_PASS} -h ${process.env.DB_HOST} --port ${process.env.DB_PORT} kmq_test -e "CALL PostSeedDataCleaning()"`,
     );
 
     // create kmq data generation procedure


### PR DESCRIPTION
Original fix did not fix other related columns (`clean_song_name_alpha_numeric, clean_song_name_ko`). Instead, perform the cleaning on the source (`kpop_videos`) directly. 