### PR TITLE
Rename album discussion flair to album

### DIFF
--- a/src/helpers/reddit_client.ts
+++ b/src/helpers/reddit_client.ts
@@ -115,6 +115,10 @@ export class RedditClient {
                     flair = flair.slice(1, flair.length - 1);
                 }
 
+                if (flair === "album discussion") {
+                    flair = "album";
+                }
+
                 return {
                     title: x.title,
                     link: `https://reddit.com${x.permalink}`,


### PR DESCRIPTION
Example response pre-change: `We've got teasers, an MV, and even an album discussion to keep us entertained. Stay tuned for more ITZY goodness!`