### PR TITLE
Longer docker health check after start period

### DIFF
--- a/docker/kmq/Dockerfile
+++ b/docker/kmq/Dockerfile
@@ -52,6 +52,6 @@ WORKDIR /app
 STOPSIGNAL SIGINT
 ARG NODE_ENV
 ENV NODE_ENV=$NODE_ENV
-HEALTHCHECK --interval=5s --timeout=3s --start-period=30s \
+HEALTHCHECK --start-interval=5s --interval=60s --timeout=3s --start-period=30s \
   CMD [ "$(cat status)" = "ready" ] && curl -f 127.0.0.1:5858/ping || exit 1
 ENTRYPOINT ["./start.sh", "docker"]


### PR DESCRIPTION
Keep health as every 5 seconds during start-up, but once per minute once container is healthy.