### PR TITLE
Add viewChannel as required text permission

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -72,6 +72,7 @@ const REQUIRED_TEXT_PERMISSIONS = [
     "addReactions" as const,
     "embedLinks" as const,
     "attachFiles" as const,
+    "viewChannel" as const,
 ];
 
 const REQUIRED_VOICE_PERMISSIONS = [
@@ -265,14 +266,16 @@ export async function textPermissionsCheck(
     const channel = await fetchChannel(textChannelID);
     if (!channel) return false;
     if (
-        !channel
-            .permissionsOf(process.env.BOT_CLIENT_ID as string)
-            .has("sendMessages")
+        !["sendMessages" as const, "viewChannel" as const].every((permission) =>
+            channel
+                .permissionsOf(process.env.BOT_CLIENT_ID as string)
+                .has(permission),
+        )
     ) {
         logger.warn(
             `${getDebugLogHeader(
                 messageContext,
-            )} | Missing SEND_MESSAGES permissions`,
+            )} | Missing SEND_MESSAGES or VIEW_CHANNEL permissions`,
         );
         const embed: Eris.EmbedOptions = {
             title: i18n.translate(


### PR DESCRIPTION
```
2024-03-01T13:28:06.404Z [ERROR] - interactionCreate | gid: 679165980995223582, tid: 965132486290071563 | Error while invoking command (CHAT_INPUT CommandInteraction interaction for 'lookup') | e442a45f-bb87-4496-ae0a-c081e3cb90d9 | Exception Name: DiscordRESTError [50001]. Reason: Missing Access. Trace: DiscordRESTError [50001]: Missing Access
```

This happens at `eris-pagination/lib/PaginationEmbed.js:104`, when trying to add the pagination reaction emojis to the interaction message.
```ts
            await this.message.addReaction(this.back);
            await this.message.addReaction(this.forth);
```

When the bot doesn't have `viewChannel` permissions, it cannot add a reaction. But chat input interactions can still be used from that channel. Added `viewChannel` as a required permission. 