### PR TITLE
Cache app command IDs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -240,6 +240,7 @@ export const DataFiles = {
         __dirname,
         "../data/feature_switch_config.json",
     ),
+    CACHED_APP_CMD_IDS: path.join(__dirname, "../data/cached_app_cmd_ids.json"),
 };
 
 // ephermeral to the docker container, not mounted from host

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -2,6 +2,7 @@
 import * as uuid from "uuid";
 import {
     BOOKMARK_COMMAND_NAME,
+    DataFiles,
     EMBED_ERROR_COLOR,
     EMBED_SUCCESS_BONUS_COLOR,
     EMBED_SUCCESS_COLOR,
@@ -54,6 +55,7 @@ import State from "../state";
 import _ from "lodash";
 import axios from "axios";
 import dbContext from "../database_context";
+import fs from "fs";
 import i18n from "./localization_manager";
 import type { EmbedGenerator, GuildTextableMessage } from "../types";
 import type { GuildTextableChannel } from "eris";
@@ -2206,6 +2208,10 @@ export const updateAppCommands = async (
         commandToID[command.name] = command.id;
     }
 
+    await fs.promises.writeFile(
+        DataFiles.CACHED_APP_CMD_IDS,
+        JSON.stringify(commandToID),
+    );
     return commandToID;
 };
 

--- a/src/kmq_worker.ts
+++ b/src/kmq_worker.ts
@@ -1,9 +1,10 @@
 /* eslint-disable node/no-sync */
 import { BaseClusterWorker } from "eris-fleet";
+import { DataFiles } from "./constants";
 import { IPCLogger } from "./logger";
 import { RedditClient } from "./helpers/reddit_client";
 import { config } from "dotenv";
-import { durationSeconds } from "./helpers/utils";
+import { durationSeconds, pathExists } from "./helpers/utils";
 import {
     registerIntervals,
     reloadArtists,
@@ -316,6 +317,26 @@ export default class BotWorker extends BaseClusterWorker {
                 );
 
                 await reloadCaches();
+            }
+
+            if (await pathExists(DataFiles.CACHED_APP_CMD_IDS)) {
+                logger.info(
+                    `${this.logHeader()} | Loading cached app command IDs`,
+                );
+
+                try {
+                    State.commandToID = JSON.parse(
+                        (
+                            await fs.promises.readFile(
+                                DataFiles.CACHED_APP_CMD_IDS,
+                            )
+                        ).toString(),
+                    );
+                } catch (e) {
+                    logger.error(
+                        `${this.logHeader()} | Failed loading cached app command IDs: ${e}`,
+                    );
+                }
             }
 
             logger.info(`${this.logHeader()} | Reloading app commands`);


### PR DESCRIPTION
https://discord.com/developers/docs/interactions/application-commands#updating-and-deleting-a-command
Application commands do not change their IDs, and command updates to the same type/scope are treated as upserts. 

Cache and load from cache upon startup incase of command update timing out. 