### PR TITLE
Application command update improvements

### DIFF
--- a/src/commands/admin/appcommands.ts
+++ b/src/commands/admin/appcommands.ts
@@ -1,9 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { IPCLogger } from "../../logger";
-import {
-    sendInfoMessage,
-    updateAppCommands,
-} from "../../helpers/discord_utils";
+import { sendInfoMessage } from "../../helpers/discord_utils";
 import AppCommandsAction from "../../enums/app_command_action";
 import CommandPrechecks from "../../command_prechecks";
 import EnvType from "../../enums/env_type";
@@ -43,13 +40,14 @@ export default class AppCommandsCommand implements BaseCommand {
             logger.info(
                 `Creating ${commandModificationScope} application commands...`,
             );
+            await State.ipc.allClustersCommand("reload_app_commands", true);
         } else {
             logger.info(
                 `Deleting ${commandModificationScope} application commands`,
             );
+            await State.ipc.allClustersCommand("delete_app_commands", true);
         }
 
-        State.commandToID = await updateAppCommands(appCommandType);
         await sendInfoMessage(MessageContext.fromMessage(message), {
             title: "Commands Updated",
         });

--- a/src/events/client/messageCreate.ts
+++ b/src/events/client/messageCreate.ts
@@ -197,15 +197,25 @@ export default async function messageCreateHandler(
             } catch (err) {
                 const debugId = uuid.v4();
 
-                logger.error(
-                    `${getDebugLogHeader(
-                        messageContext,
-                    )} | Error while invoking command (${
-                        parsedMessage.action
-                    }) | ${debugId} | Data: "${parsedMessage.argument}" | Exception Name: ${err.name}. Reason: ${
-                        err.message
-                    }. Trace: ${err.stack}}`,
-                );
+                if (err instanceof Error) {
+                    logger.error(
+                        `${getDebugLogHeader(
+                            messageContext,
+                        )} | Error while invoking command (${
+                            parsedMessage.action
+                        }) | ${debugId} | Data: "${parsedMessage.argument}" | Exception Name: ${err.name}. Reason: ${
+                            err.message
+                        }. Trace: ${err.stack}}`,
+                    );
+                } else {
+                    logger.error(
+                        `${getDebugLogHeader(
+                            messageContext,
+                        )} | Error while invoking command (${
+                            parsedMessage.action
+                        }) | ${debugId} | Data: "${parsedMessage.argument}" | err = ${err}`,
+                    );
+                }
 
                 await sendErrorMessage(messageContext, {
                     title: i18n.translate(

--- a/src/kmq.ts
+++ b/src/kmq.ts
@@ -77,9 +77,9 @@ const options: Options = {
         },
         restMode: true,
         messageLimit: 0,
-        requestTimeout: 30000,
+        requestTimeout: 15000,
     },
-    fetchTimeout: 5000,
+    fetchTimeout: 20000,
     customClient: KmqClient,
     guildsPerShard: process.env.GUILDS_PER_SHARD
         ? parseInt(process.env.GUILDS_PER_SHARD as string, 10)


### PR DESCRIPTION
- `,appcommand reload` now reloads all clusters
- More logging for `bulkEditCommands` 
- Automatically fetch from cached on bulkEditCommand failure