### PR TITLE
Remove GuessResult and use round guessers directly

### DIFF
--- a/src/commands/game_commands/forceskip.ts
+++ b/src/commands/game_commands/forceskip.ts
@@ -147,9 +147,7 @@ export default class ForceSkipCommand implements BaseCommand {
             interaction,
         );
 
-        await session.endRound(messageContext, {
-            correct: false,
-        });
+        await session.endRound(false, messageContext);
 
         await session.startRound(messageContext);
         await session.lastActiveNow();

--- a/src/commands/game_commands/skip.ts
+++ b/src/commands/game_commands/skip.ts
@@ -134,7 +134,7 @@ export async function skipSong(
     }
 
     session.round.skipAchieved = true;
-    await session.endRound(messageContext, { correct: false });
+    await session.endRound(false, messageContext);
     await session.startRound(messageContext);
 }
 

--- a/src/interfaces/guess_result.ts
+++ b/src/interfaces/guess_result.ts
@@ -1,7 +1,0 @@
-import type KmqMember from "../structures/kmq_member";
-
-export default interface GuessResult {
-    correct: boolean;
-    error?: boolean;
-    correctGuessers?: Array<KmqMember>;
-}

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -1455,27 +1455,12 @@ export default class GameSession extends Session {
         // update scoreboard
         const lastGuesserStreak = this.lastGuesser?.streak ?? 0;
         const isHidden = this.isHiddenMode();
-        const isCorrect = round.correctGuessers.length > 0;
-        if (isCorrect) {
-            round.correctGuessers.sort(
-                (a, b) =>
-                    getTimeToGuessMs(a, round, isHidden) -
-                    getTimeToGuessMs(b, round, isHidden),
-            );
-        }
 
-        if (this.isHiddenMode()) {
-            if (!isCorrect && round.correctGuessers.length > 0) {
-                // At least one person guessed correctly but someone didn't submit a /guess,
-                // which led to the timer ending and guessResult.correct being false
-
-                round.correctGuessers.sort(
-                    (a, b) =>
-                        getTimeToGuessMs(a, round, isHidden) -
-                        getTimeToGuessMs(b, round, isHidden),
-                );
-            }
-        }
+        round.correctGuessers.sort(
+            (a, b) =>
+                getTimeToGuessMs(a, round, isHidden) -
+                getTimeToGuessMs(b, round, isHidden),
+        );
 
         const playerRoundResults = await Promise.all(
             round.correctGuessers.map(async (correctGuesser, idx) => {

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -279,7 +279,7 @@ export default class GameSession extends Session {
                     userID: correctGuessers[0].id,
                     streak: 1,
                 };
-            } else if (this.lastGuesser) {
+            } else {
                 this.lastGuesser.streak++;
             }
 

--- a/src/structures/listening_session.ts
+++ b/src/structures/listening_session.ts
@@ -13,7 +13,6 @@ import ListeningRound from "./listening_round";
 import Session from "./session";
 import i18n from "../helpers/localization_manager";
 import type Eris from "eris";
-import type GuessResult from "../interfaces/guess_result";
 import type GuildPreference from "./guild_preference";
 import type MessageContext from "./message_context";
 import type QueriedSong from "../interfaces/queried_song";
@@ -122,11 +121,11 @@ export default class ListeningSession extends Session {
     }
 
     async endRound(
+        isError: boolean,
         messageContext?: MessageContext,
-        guessResult?: GuessResult,
     ): Promise<void> {
         await this.round?.interactionMarkButtons();
-        await super.endRound(messageContext, guessResult);
+        await super.endRound(isError, messageContext);
     }
 
     async endSession(reason: string): Promise<void> {

--- a/src/test/ci/game_session.test.ts
+++ b/src/test/ci/game_session.test.ts
@@ -132,12 +132,7 @@ describe("game session", () => {
                     Date.now(),
                 );
 
-                assert.ok(
-                    endRoundStub.calledWith(messageContext, {
-                        correct: true,
-                        correctGuessers: gameSession.round.correctGuessers,
-                    }),
-                );
+                assert.ok(endRoundStub.calledWith(false, messageContext));
 
                 // end session
                 const sendEndGameMessageStub = sandbox.stub(


### PR DESCRIPTION
We were using `GuessResult` for
```
{
                correct: true,
                correctGuessers: round.correctGuessers,
                error?
            }
```
We have access to `round.correctGuessers` later in the codepath already, and `correct` is just whether `round.correctGuessers` has a value. 