### PR TITLE
Mark ShuffleType as reload-impactful game option

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -200,7 +200,6 @@ export const NON_RELOAD_IMPACTING_GAME_OPTION_INTERNALS: Array<GameOptionInterna
         GameOptionInternal.SPECIAL_TYPE,
         GameOptionInternal.GUESS_MODE_TYPE,
         GameOptionInternal.ANSWER_TYPE,
-        GameOptionInternal.SHUFFLE_TYPE,
         GameOptionInternal.GOAL,
         GameOptionInternal.GUESS_TIMEOUT,
         GameOptionInternal.DURATION,


### PR DESCRIPTION
closes #1955
(Reverse) Chronological shuffle types affect the querybuilder
```ts
         queryBuilder = queryBuilder
                .orderBy(
                    sql`SUBSTRING(publishedon, 1, ${"YYYY-MM".length})`,
                    shuffleType === ShuffleType.CHRONOLOGICAL ? "asc" : "desc",
                )
                .orderBy(sql`RAND()`);
                ```