### PR TITLE
Spotify match prioritize exact artist match

### DIFF
--- a/src/helpers/playlist_manager.ts
+++ b/src/helpers/playlist_manager.ts
@@ -993,18 +993,17 @@ export default class PlaylistManager {
                 if (results.length === 1) {
                     result = results[0];
                 } else if (results.length > 1) {
-                    // prioritize pre-bracket name
-                    const properNameMatch = results.find(
+                    const properArtistNameMatch = results.find(
                         (x) =>
-                            x.songName
+                            x.artistName
                                 .toLowerCase()
                                 .replace(/[^0-9a-z]/gi, "") ===
-                            songNames[0]
+                            song.artists[0]
                                 .toLowerCase()
                                 .replace(/[^0-9a-z]/gi, ""),
                     );
 
-                    result = properNameMatch || results[0];
+                    result = properArtistNameMatch || results[0];
                 }
 
                 if (result) {


### PR DESCRIPTION
Spotify matching searches for `id_parentgroup`, `id_artist`, and `id_parent_artist` simultaneously incase spotify has labelled it incorrectly. This causes issues when an artist and their parent group both have a song of the same name. 
e.g: 
EXO - diamond
Baekhyun - diamond

Prioritize exact match on artist name before going for other options