### PR TITLE
Sequential and alpha-ordered game option inserts

### DIFF
--- a/src/structures/guild_preference.ts
+++ b/src/structures/guild_preference.ts
@@ -233,7 +233,6 @@ export default class GuildPreference {
     async validateGameOptions(): Promise<void> {
         const validatedGameOptions = { ...this.gameOptions };
         let newDefaultOptionsAdded = 0;
-        let extraneousKeysRemoved = 0;
         // apply default game option for empty
         for (const defaultOption in GuildPreference.DEFAULT_OPTIONS) {
             if (!(defaultOption in validatedGameOptions)) {
@@ -247,25 +246,11 @@ export default class GuildPreference {
             }
         }
 
-        // extraneous keys
-        // TODO: this doesn't actually remove the entries in the database
-        for (const option in validatedGameOptions) {
-            if (!(option in GuildPreference.DEFAULT_OPTIONS)) {
-                extraneousKeysRemoved++;
-                delete validatedGameOptions[
-                    option as keyof typeof validatedGameOptions
-                ];
-            }
-        }
-
         this.gameOptions = validatedGameOptions;
 
-        if (
-            (newDefaultOptionsAdded || extraneousKeysRemoved) &&
-            process.env.NODE_ENV !== EnvType.TEST
-        ) {
+        if (newDefaultOptionsAdded && process.env.NODE_ENV !== EnvType.TEST) {
             logger.info(
-                `gid: ${this.guildID} | validateGameOptions: options modified during validation (+${newDefaultOptionsAdded} | -${extraneousKeysRemoved})`,
+                `gid: ${this.guildID} | validateGameOptions: options modified during validation (+${newDefaultOptionsAdded})`,
             );
             await this.updateGuildPreferences();
         }

--- a/src/test/ci/guild_preference.test.ts
+++ b/src/test/ci/guild_preference.test.ts
@@ -55,28 +55,6 @@ describe("guild preference", () => {
                     );
                 });
             });
-
-            describe("it has extraneous game options", () => {
-                it("should return a guild preference without the extraneous values", () => {
-                    const gameOptionsWithExtraValues: {
-                        [optionName: string]: any;
-                    } = {
-                        ...GuildPreference.DEFAULT_OPTIONS,
-                    };
-
-                    const nonExistentOption = "option_that_doesnt_exist";
-                    gameOptionsWithExtraValues[nonExistentOption] = 58;
-                    const guildPreference = GuildPreference.fromGuild(
-                        "123",
-                        gameOptionsWithExtraValues,
-                    );
-
-                    assert.strictEqual(
-                        nonExistentOption in guildPreference.gameOptions,
-                        false,
-                    );
-                });
-            });
         });
     });
 
@@ -111,6 +89,8 @@ describe("guild preference", () => {
         describe("loadPreset", () => {
             it("should update the current options with values defined in the preset", async () => {
                 await guildPreference.loadPreset(TEST_PRESET_NAME, "123");
+                // ignore UUID
+                delete (guildPreference.gameOptions as any)["uuid"];
                 assert.deepStrictEqual(
                     guildPreference.gameOptions,
                     filledGameOptions,


### PR DESCRIPTION
Deadlocks occurring due to gaplocking: http://thushw.blogspot.com/2010/11/mysql-deadlocks-with-concurrent-inserts.html?m=1

Easiest way to avoid is ordering the inserts alphabetically by columns in the constraint, in this case, `option_name`