### PR TITLE
reloadSong should read from playlistID from GuildPreference

### DIFF
--- a/src/commands/game_options/playlist.ts
+++ b/src/commands/game_options/playlist.ts
@@ -447,7 +447,7 @@ export default class PlaylistCommand implements BaseCommand {
             );
 
             // reset playlist if invalid
-            await guildPreference.setKmqPlaylistID(null);
+            await guildPreference.reset(GameOption.PLAYLIST_ID);
             return;
         }
 

--- a/src/commands/game_options/playlist.ts
+++ b/src/commands/game_options/playlist.ts
@@ -414,8 +414,8 @@ export default class PlaylistCommand implements BaseCommand {
             return;
         }
 
+        await guildPreference.setKmqPlaylistID(kmqPlaylistIdentifier);
         const matchedPlaylist = (await guildPreference.songSelector.reloadSongs(
-            kmqPlaylistIdentifier,
             true,
             messageContext,
             interaction,
@@ -446,10 +446,10 @@ export default class PlaylistCommand implements BaseCommand {
                 interaction,
             );
 
+            // reset playlist if invalid
+            await guildPreference.setKmqPlaylistID(null);
             return;
         }
-
-        await guildPreference.setKmqPlaylistID(kmqPlaylistIdentifier);
 
         await LimitCommand.updateOption(
             messageContext,

--- a/src/events/client/messageCreate.ts
+++ b/src/events/client/messageCreate.ts
@@ -140,7 +140,10 @@ export default async function messageCreateHandler(
             return;
         }
 
-        if (!State.rateLimiter.check(message.author.id)) {
+        if (
+            message.author.id !== process.env.END_TO_END_TEST_BOT_CLIENT &&
+            !State.rateLimiter.check(message.author.id)
+        ) {
             logger.error(
                 `User ${
                     message.author.id

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -57,9 +57,7 @@ export async function getAvailableSongCount(
 
         // only reload if song selector has never loaded yet, otherwise used cached count
         if (songSelector.getSongs().songs.size === 0) {
-            await songSelector.reloadSongs(
-                guildPreference.getKmqPlaylistID() ?? undefined,
-            );
+            await songSelector.reloadSongs();
         }
 
         const songSelectorResults = songSelector.getSongs();

--- a/src/structures/guild_preference.ts
+++ b/src/structures/guild_preference.ts
@@ -1040,9 +1040,7 @@ export default class GuildPreference {
                 `gid: ${this.guildID} | Impactful game options modified, songs reloaded`,
             );
 
-            await this.songSelector.reloadSongs(
-                this.getKmqPlaylistID() ?? undefined,
-            );
+            await this.songSelector.reloadSongs();
         }
 
         if (this.answerTypeChangeCallback) {

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -178,7 +178,6 @@ export default abstract class Session {
         if (this.guildPreference.songSelector.getSongs().songs.size === 0) {
             try {
                 await this.guildPreference.songSelector.reloadSongs(
-                    this.guildPreference.getKmqPlaylistID() ?? undefined,
                     !this.sessionInitialized,
                 );
             } catch (err) {

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -253,17 +253,16 @@ export default class SongSelector {
     }
 
     async reloadSongs(
-        kmqPlaylistIdentifier?: string,
         forceRefreshMetadata?: boolean,
         messageContext?: MessageContext,
         interaction?: Eris.CommandInteraction,
     ): Promise<MatchedPlaylist | null> {
+        const kmqPlaylistIdentifier = this.guildPreference.getKmqPlaylistID();
         if (
             !kmqPlaylistIdentifier ||
             this.guildPreference.gameOptions.forcePlaySongID
         ) {
             this.selectedSongs = await this.querySelectedSongs();
-
             return null;
         }
 


### PR DESCRIPTION
We were relying on passing in kmqPlaylistID into `reloadSongs`, which most invocations were doing already, except for in `/lookup`. Since `/lookup` wasn't passing a `kmqPlaylistID`, reload went into the non-playlist reload path. 