### PR TITLE
Sort correctGuessers from getter, fix streak bug

### DIFF
--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -171,17 +171,25 @@ export default class GameRound extends Round {
         this.guesses = {};
     }
 
-    getCorrectGuessers(): Array<KmqMember> {
-        return Object.entries(this.guesses).flatMap((playerGuessResults) => {
-            const playerId = playerGuessResults[0];
-            const guessResults = playerGuessResults[1];
-            const correctGuess = guessResults.find((x) => x.correct);
-            if (correctGuess) {
-                return [new KmqMember(playerId, correctGuess.pointsAwarded)];
-            }
+    getCorrectGuessers(isHidden: boolean): Array<KmqMember> {
+        return Object.entries(this.guesses)
+            .flatMap((playerGuessResults) => {
+                const playerId = playerGuessResults[0];
+                const guessResults = playerGuessResults[1];
+                const correctGuess = guessResults.find((x) => x.correct);
+                if (correctGuess) {
+                    return [
+                        new KmqMember(playerId, correctGuess.pointsAwarded),
+                    ];
+                }
 
-            return [];
-        });
+                return [];
+            })
+            .sort(
+                (a, b) =>
+                    this.getTimeToGuessMs(a.id, isHidden) -
+                    this.getTimeToGuessMs(b.id, isHidden),
+            );
     }
 
     getIncorrectGuessers(): Set<string> {

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -258,7 +258,7 @@ export default class GameSession extends Session {
             return;
         }
 
-        const correctGuessers = round.getCorrectGuessers();
+        const correctGuessers = round.getCorrectGuessers(this.isHiddenMode());
         const isCorrectGuess = correctGuessers.length > 0;
 
         await this.stopHiddenUpdateTimer();
@@ -572,7 +572,7 @@ export default class GameSession extends Session {
             this.guildPreference.typosAllowed(),
         );
 
-        const correctGuessers = round.getCorrectGuessers();
+        const correctGuessers = round.getCorrectGuessers(this.isHiddenMode());
         const incorrectGuessers = round.getIncorrectGuessers();
         if (this.isHiddenMode()) {
             // Determine whether to wait for more guesses
@@ -1125,7 +1125,7 @@ export default class GameSession extends Session {
 
         if (
             !round
-                .getCorrectGuessers()
+                .getCorrectGuessers(this.isHiddenMode())
                 .map((x) => x.id)
                 .includes(userID) &&
             !incorrectGuessers.has(userID)
@@ -1472,13 +1472,7 @@ export default class GameSession extends Session {
         const lastGuesserStreak = this.lastGuesser?.streak ?? 0;
         const isHidden = this.isHiddenMode();
 
-        const correctGuessers = round
-            .getCorrectGuessers()
-            .sort(
-                (a, b) =>
-                    round.getTimeToGuessMs(a.id, isHidden) -
-                    round.getTimeToGuessMs(b.id, isHidden),
-            );
+        const correctGuessers = round.getCorrectGuessers(isHidden);
 
         const playerRoundResults = await Promise.all(
             correctGuessers.map(async (correctGuesser, idx) => {
@@ -1488,10 +1482,7 @@ export default class GameSession extends Session {
                     round,
                     getNumParticipants(this.voiceChannelID),
                     lastGuesserStreak,
-                    round.getTimeToGuessMs(
-                        correctGuesser.id,
-                        this.isHiddenMode(),
-                    ),
+                    round.getTimeToGuessMs(correctGuesser.id, isHidden),
                     guessPosition,
                     await userBonusIsActive(correctGuesser.id),
                     correctGuesser.id,
@@ -1587,7 +1578,7 @@ export default class GameSession extends Session {
 
         const remainingPlayers = this.scoreboard
             .getRemainingPlayers(
-                round.getCorrectGuessers().map((x) => x.id),
+                round.getCorrectGuessers(this.isHiddenMode()).map((x) => x.id),
                 round.getIncorrectGuessers(),
             )
             .map((player) => player.username)

--- a/src/test/unit_tests/ci/game_round.test.ts
+++ b/src/test/unit_tests/ci/game_round.test.ts
@@ -871,9 +871,12 @@ describe("game round", () => {
                 ],
             });
 
-            assert.strictEqual(gameRound.getCorrectGuessers().length, 1);
+            assert.strictEqual(gameRound.getCorrectGuessers(false).length, 1);
             assert.strictEqual(gameRound.getIncorrectGuessers().size, 0);
-            assert.strictEqual(gameRound.getCorrectGuessers()[0]!.id, playerID);
+            assert.strictEqual(
+                gameRound.getCorrectGuessers(false)[0]!.id,
+                playerID,
+            );
         });
 
         it("should allow users to overwrite their guesses", async () => {
@@ -902,7 +905,7 @@ describe("game round", () => {
                     },
                 ],
             });
-            assert.strictEqual(gameRound.getCorrectGuessers().length, 0);
+            assert.strictEqual(gameRound.getCorrectGuessers(false).length, 0);
             assert.strictEqual(gameRound.getIncorrectGuessers().size, 1);
             await delay(10);
 
@@ -935,9 +938,12 @@ describe("game round", () => {
                     },
                 ],
             });
-            assert.strictEqual(gameRound.getCorrectGuessers().length, 1);
+            assert.strictEqual(gameRound.getCorrectGuessers(false).length, 1);
             assert.strictEqual(gameRound.getIncorrectGuessers().size, 0);
-            assert.strictEqual(gameRound.getCorrectGuessers()[0]!.id, playerID);
+            assert.strictEqual(
+                gameRound.getCorrectGuessers(false)[0]!.id,
+                playerID,
+            );
         });
     });
 });


### PR DESCRIPTION
Previous PR removed a `.sort()` on guess time prior to getting the first guesser, which was used to calculate streaks.