### PR TITLE
Handle error for test-runner RUN_ID reply

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -440,27 +440,33 @@ export async function sendMessage(
     interaction?: Eris.ComponentInteraction | Eris.CommandInteraction,
 ): Promise<Eris.Message | null> {
     if (messageContent.messageReference) {
-        const message: Message<TextChannel> | undefined = await (
-            State.client.getChannel(textChannelID!) as
-                | Eris.TextChannel
-                | undefined
-        )?.getMessage(messageContent.messageReference.messageID);
+        try {
+            const message: Message<TextChannel> | undefined = await (
+                State.client.getChannel(textChannelID!) as
+                    | Eris.TextChannel
+                    | undefined
+            )?.getMessage(messageContent.messageReference.messageID);
 
-        // test bot request, reply with same run ID
-        if (
-            message &&
-            message.author.id === process.env.END_TO_END_TEST_BOT_CLIENT &&
-            message.embeds[0]
-        ) {
-            const runId = message.embeds[0].footer?.text!;
-            const messageFooter = messageContent.embeds![0]!.footer;
-            if (messageFooter) {
-                messageFooter.text += `\n ${runId}`;
-            } else {
-                messageContent.embeds![0]!.footer = {
-                    text: runId,
-                };
+            // test bot request, reply with same run ID
+            if (
+                message &&
+                message.author.id === process.env.END_TO_END_TEST_BOT_CLIENT &&
+                message.embeds[0]
+            ) {
+                const runId = message.embeds[0].footer?.text!;
+                const messageFooter = messageContent.embeds![0]!.footer;
+                if (messageFooter) {
+                    messageFooter.text += `\n ${runId}`;
+                } else {
+                    messageContent.embeds![0]!.footer = {
+                        text: runId,
+                    };
+                }
             }
+        } catch (e) {
+            logger.warn(
+                `Failed to get message reference for ${messageContent.messageReference.messageID} for test runner, probably not important. e = ${e}`,
+            );
         }
     }
 

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -439,37 +439,6 @@ export async function sendMessage(
     authorID?: string,
     interaction?: Eris.ComponentInteraction | Eris.CommandInteraction,
 ): Promise<Eris.Message | null> {
-    if (messageContent.messageReference) {
-        try {
-            const message: Message<TextChannel> | undefined = await (
-                State.client.getChannel(textChannelID!) as
-                    | Eris.TextChannel
-                    | undefined
-            )?.getMessage(messageContent.messageReference.messageID);
-
-            // test bot request, reply with same run ID
-            if (
-                message &&
-                message.author.id === process.env.END_TO_END_TEST_BOT_CLIENT &&
-                message.embeds[0]
-            ) {
-                const runId = message.embeds[0].footer?.text!;
-                const messageFooter = messageContent.embeds![0]!.footer;
-                if (messageFooter) {
-                    messageFooter.text += `\n ${runId}`;
-                } else {
-                    messageContent.embeds![0]!.footer = {
-                        text: runId,
-                    };
-                }
-            }
-        } catch (e) {
-            logger.warn(
-                `Failed to get message reference for ${messageContent.messageReference.messageID} for test runner, probably not important. e = ${e}`,
-            );
-        }
-    }
-
     if (interaction) {
         if (!withinInteractionInterval(interaction)) {
             return null;

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -53,7 +53,7 @@ import dbContext from "../database_context";
 import fs from "fs";
 import i18n from "./localization_manager";
 import type { EmbedGenerator, GuildTextableMessage } from "../types";
-import type { GuildTextableChannel, Message, TextChannel } from "eris";
+import type { GuildTextableChannel } from "eris";
 import type AutocompleteEntry from "../interfaces/autocomplete_entry";
 import type BookmarkedSong from "../interfaces/bookmarked_song";
 import type EmbedPayload from "../interfaces/embed_payload";

--- a/src/test/end-to-end-tests/test-runner-bot.ts
+++ b/src/test/end-to-end-tests/test-runner-bot.ts
@@ -309,10 +309,6 @@ bot.on("messageCreate", async (msg) => {
         return;
     }
 
-    if (!embeds[0]?.footer?.text.includes(RUN_ID)) {
-        return;
-    }
-
     if (CURRENT_STAGE === null) {
         console.error("messageCreate called before test began.");
         process.exit(1);
@@ -336,7 +332,9 @@ bot.on("messageCreate", async (msg) => {
         combinedDescription += `${field.value}\n`;
     }
 
-    combinedDescription += `\n${footer!.text}`;
+    if (footer) {
+        combinedDescription += `\n${footer.text}`;
+    }
 
     console.log({ title, description, fields, footer });
 


### PR DESCRIPTION
Redundant because the test-runner only reads messages that KMQ 'replied' to