### PR TITLE
Don't abort test-runner early on messageCreate

### DIFF
--- a/src/test/end-to-end-tests/test-runner-bot.ts
+++ b/src/test/end-to-end-tests/test-runner-bot.ts
@@ -310,8 +310,7 @@ bot.on("messageCreate", async (msg) => {
     }
 
     if (CURRENT_STAGE === null) {
-        console.error("messageCreate called before test began.");
-        process.exit(1);
+        return;
     }
 
     // response was for a different nessage, already processed a message for the current stage, or the stage hasnt executed yet


### PR DESCRIPTION
This was from before the test runner always tried to react to the latest message sent in the chat. Now it only replies to message replies from KMQ. 