### PR TITLE
Generate expected_available_songs as source of truth

### DIFF
--- a/sql/procedures/create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/create_kmq_data_tables_procedure.sql
@@ -2,123 +2,43 @@ DELIMITER //
 DROP PROCEDURE IF EXISTS CreateKmqDataTables //
 CREATE PROCEDURE CreateKmqDataTables()
 BEGIN
-	/* replace songs with better audio counterpart */
-	ALTER TABLE kpop_videos.app_kpop ADD COLUMN IF NOT EXISTS original_vlink VARCHAR(255);
-	DROP TEMPORARY TABLE IF EXISTS temp_tbl;
-	CREATE TEMPORARY TABLE temp_tbl
-	SELECT a.id as original_id, a.original_name as original_name, a.vlink as original_link, b.vlink as better_audio_link
-	FROM kpop_videos.app_kpop as a
-	LEFT JOIN kpop_videos.app_kpop as b ON a.id_better_audio = b.id
-	WHERE b.vlink is not null
-	AND a.vtype IN ('main', 'audio');
-
-	DELETE kpop_videos.app_kpop FROM kpop_videos.app_kpop
-	JOIN temp_tbl tt on kpop_videos.app_kpop.vlink = tt.better_audio_link
-	WHERE kpop_videos.app_kpop.vlink = tt.better_audio_link;
-
-	UPDATE kpop_videos.app_kpop JOIN temp_tbl tt on kpop_videos.app_kpop.id = tt.original_id
-	SET kpop_videos.app_kpop.vlink = tt.better_audio_link, kpop_videos.app_kpop.original_vlink = tt.original_link;
-
 	/* update available_songs table */
 	DROP TABLE IF EXISTS available_songs_temp;
-	CREATE TABLE available_songs_temp (
-		song_name_en VARCHAR(255) NOT NULL,
-		clean_song_name_alpha_numeric VARCHAR(255) NOT NULL,
-		song_name_ko VARCHAR(255) NOT NULL,
-		song_aliases VARCHAR(255) NOT NULL,
-		link VARCHAR(255) NOT NULL,
-		original_link VARCHAR(255),
-		artist_name_en VARCHAR(255) NOT NULL,
-		original_artist_name_en VARCHAR(255) NOT NULL,
-		artist_name_ko VARCHAR(255),
-		artist_aliases VARCHAR(255) NOT NULL,
-		previous_name_en VARCHAR(255),
-		previous_name_ko VARCHAR(255),
-		members ENUM('female','male','coed') NOT NULL,
-		views BIGINT NOT NULL,
-		publishedon DATE NOT NULL,
-		id_artist INT(11) NOT NULL,
-		issolo ENUM('y', 'n') NOT NULL,
-		id_parent_artist INT(11) NOT NULL,
-		vtype ENUM('main', 'audio') NOT NULL,
-		tags VARCHAR(25)
-	) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
+	CREATE TABLE available_songs_temp LIKE expected_available_songs;
 	CREATE TABLE IF NOT EXISTS available_songs LIKE available_songs_temp;
 
-	/* music videos */
 	INSERT INTO available_songs_temp
 	SELECT
-		kpop_videos.app_kpop.name AS song_name_en,
-		(CASE WHEN kpop_videos.app_kpop.name REGEXP '^[^a-zA-Z0-9]+$' THEN kpop_videos.app_kpop.name ELSE REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') END) AS clean_song_name_alpha_numeric,
-		kpop_videos.app_kpop.kname AS song_name_ko,
-		kpop_videos.app_kpop.alias AS song_aliases,
-		vlink AS link,
-		kpop_videos.app_kpop.original_vlink AS original_link,
-		kpop_videos.app_kpop_group.name AS artist_name_en,
-		kpop_videos.app_kpop_group.original_name AS original_artist_name_en,
-		kpop_videos.app_kpop_group.kname AS artist_name_ko,
-		REPLACE(kpop_videos.app_kpop_group.alias, '; ', ';') AS artist_aliases,
-		kpop_videos.app_kpop_group.previous_name AS previous_name_en,
-		kpop_videos.app_kpop_group.previous_kname AS previous_name_ko,
-		kpop_videos.app_kpop_group.members AS members,
-		kpop_videos.app_kpop.views AS views,
-		releasedate as publishedon,
-		kpop_videos.app_kpop_group.id as id_artist,
+		song_name_en,
+		clean_song_name_alpha_numeric,
+		song_name_ko,
+		song_aliases,
+		link,
+		original_link,
+		artist_name_en,
+		original_artist_name_en,
+		artist_name_ko,
+		artist_aliases,
+		previous_name_en,
+		previous_name_ko,
+		members,
+		views,
+		publishedon,
+		id_artist,
 		issolo,
-		id_parentgroup,
+		id_parent_artist,
 		vtype,
 		tags
-	FROM kpop_videos.app_kpop
-	JOIN kpop_videos.app_kpop_group ON kpop_videos.app_kpop.id_artist = kpop_videos.app_kpop_group.id
-	INNER JOIN kmq.cached_song_duration USING (vlink)
-	LEFT JOIN kmq.not_downloaded USING (vlink)
+	FROM expected_available_songs
+	INNER JOIN kmq.cached_song_duration ON expected_available_songs.link = kmq.cached_song_duration.vlink
+	LEFT JOIN kmq.not_downloaded ON expected_available_songs.link = kmq.not_downloaded.vlink
 	WHERE kmq.not_downloaded.vlink IS NULL
-	AND kpop_videos.app_kpop.is_audio = 'n'
-	AND vlink NOT IN (SELECT vlink FROM kmq.dead_links)
-	AND vtype = 'main'
-	AND tags NOT LIKE "%c%" -- no covers
-	AND tags NOT LIKE "%r%" -- no relay dances
-	AND tags NOT LIKE "%x%" -- no remixes
-	AND vlink IN (SELECT vlink FROM kmq.cached_song_duration);
-
-	/* audio-only videos */
-	INSERT INTO available_songs_temp
-	SELECT
-		kpop_videos.app_kpop.name AS song_name_en,
-		(CASE WHEN kpop_videos.app_kpop.name REGEXP '^[^a-zA-Z0-9]+$' THEN kpop_videos.app_kpop.name ELSE REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') END) AS clean_song_name_alpha_numeric,
-		kpop_videos.app_kpop.kname AS song_name_ko,
-		kpop_videos.app_kpop.alias AS song_aliases,
-		vlink AS link,
-		null,
-		kpop_videos.app_kpop_group.name AS artist_name_en,
-		kpop_videos.app_kpop_group.original_name AS original_artist_name_en,
-		kpop_videos.app_kpop_group.kname AS artist_name_ko,
-		REPLACE(kpop_videos.app_kpop_group.alias, '; ', ';') AS artist_aliases,
-		kpop_videos.app_kpop_group.previous_name AS previous_name_en,
-		kpop_videos.app_kpop_group.previous_kname AS previous_name_ko,
-		kpop_videos.app_kpop_group.members AS members,
-		kpop_videos.app_kpop.views AS views,
-		releasedate as publishedon,
-		kpop_videos.app_kpop_group.id AS id_artist,
-		issolo,
-		id_parentgroup,
-		'audio' AS vtype,
-		tags
-	FROM kpop_videos.app_kpop
-	JOIN kpop_videos.app_kpop_group ON kpop_videos.app_kpop.id_artist = kpop_videos.app_kpop_group.id
-	INNER JOIN kmq.cached_song_duration USING (vlink)
-	LEFT JOIN kmq.not_downloaded USING (vlink)
-	WHERE kmq.not_downloaded.vlink IS NULL
-	AND kpop_videos.app_kpop.is_audio = 'y'
-	AND vlink NOT IN (SELECT vlink FROM kmq.dead_links)
-	AND tags NOT LIKE "%c%" -- no covers
-	AND tags NOT LIKE "%r%" -- no relay dances
-	AND tags NOT LIKE "%x%"; -- no remixes
+	AND expected_available_songs.link NOT IN (SELECT vlink FROM kmq.dead_links);
 
 
 	CREATE INDEX available_songs_id_artist_index ON available_songs_temp (id_artist);
 
+	DROP TABLE IF EXISTS old;
 	RENAME TABLE available_songs TO old, available_songs_temp TO available_songs;
 	DROP TABLE old;
 

--- a/sql/procedures/generate_expected_available_songs_procedure.sql
+++ b/sql/procedures/generate_expected_available_songs_procedure.sql
@@ -1,0 +1,77 @@
+DELIMITER //
+DROP PROCEDURE IF EXISTS GenerateExpectedAvailableSongs //
+CREATE PROCEDURE GenerateExpectedAvailableSongs()
+BEGIN
+	/* replace songs with better audio counterpart */
+	ALTER TABLE kpop_videos.app_kpop ADD COLUMN IF NOT EXISTS original_vlink VARCHAR(255);
+	DROP TEMPORARY TABLE IF EXISTS temp_tbl;
+	CREATE TEMPORARY TABLE temp_tbl
+	SELECT a.id as original_id, a.original_name as original_name, a.vlink as original_link, b.vlink as better_audio_link
+	FROM kpop_videos.app_kpop as a
+	LEFT JOIN kpop_videos.app_kpop as b ON a.id_better_audio = b.id
+	WHERE b.vlink is not null
+	AND a.vtype IN ('main', 'audio');
+
+	DELETE kpop_videos.app_kpop FROM kpop_videos.app_kpop
+	JOIN temp_tbl tt on kpop_videos.app_kpop.vlink = tt.better_audio_link
+	WHERE kpop_videos.app_kpop.vlink = tt.better_audio_link;
+
+	UPDATE kpop_videos.app_kpop JOIN temp_tbl tt on kpop_videos.app_kpop.id = tt.original_id
+	SET kpop_videos.app_kpop.vlink = tt.better_audio_link, kpop_videos.app_kpop.original_vlink = tt.original_link;
+
+	/* Generate table of expected available songs */
+	DROP TABLE IF EXISTS expected_available_songs;
+	CREATE TABLE expected_available_songs (
+		song_name_en VARCHAR(255) NOT NULL,
+		clean_song_name_alpha_numeric VARCHAR(255) NOT NULL,
+		song_name_ko VARCHAR(255) NOT NULL,
+		song_aliases VARCHAR(255) NOT NULL,
+		link VARCHAR(255) NOT NULL,
+		original_link VARCHAR(255),
+		artist_name_en VARCHAR(255) NOT NULL,
+		original_artist_name_en VARCHAR(255) NOT NULL,
+		artist_name_ko VARCHAR(255),
+		artist_aliases VARCHAR(255) NOT NULL,
+		previous_name_en VARCHAR(255),
+		previous_name_ko VARCHAR(255),
+		members ENUM('female','male','coed') NOT NULL,
+		views BIGINT NOT NULL,
+		publishedon DATE NOT NULL,
+		id_artist INT(11) NOT NULL,
+		issolo ENUM('y', 'n') NOT NULL,
+		id_parent_artist INT(11) NOT NULL,
+		vtype ENUM('main', 'audio') NOT NULL,
+		tags VARCHAR(25)
+	) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+	INSERT INTO expected_available_songs
+	SELECT
+		kpop_videos.app_kpop.name AS song_name_en,
+		(CASE WHEN kpop_videos.app_kpop.name REGEXP '^[^a-zA-Z0-9]+$' THEN kpop_videos.app_kpop.name ELSE REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') END) AS clean_song_name_alpha_numeric,
+		kpop_videos.app_kpop.kname AS song_name_ko,
+		kpop_videos.app_kpop.alias AS song_aliases,
+		vlink AS link,
+		kpop_videos.app_kpop.original_vlink AS original_link,
+		kpop_videos.app_kpop_group.name AS artist_name_en,
+		kpop_videos.app_kpop_group.original_name AS original_artist_name_en,
+		kpop_videos.app_kpop_group.kname AS artist_name_ko,
+		REPLACE(kpop_videos.app_kpop_group.alias, '; ', ';') AS artist_aliases,
+		kpop_videos.app_kpop_group.previous_name AS previous_name_en,
+		kpop_videos.app_kpop_group.previous_kname AS previous_name_ko,
+		kpop_videos.app_kpop_group.members AS members,
+		kpop_videos.app_kpop.views AS views,
+		releasedate as publishedon,
+		kpop_videos.app_kpop_group.id as id_artist,
+		issolo,
+		id_parentgroup,
+		IF(kpop_videos.app_kpop.is_audio = 'n', 'main', 'audio'),
+		tags
+	FROM kpop_videos.app_kpop
+	JOIN kpop_videos.app_kpop_group ON kpop_videos.app_kpop.id_artist = kpop_videos.app_kpop_group.id
+	AND vtype = 'main'
+	AND tags NOT LIKE "%c%" -- no covers
+	AND tags NOT LIKE "%r%" -- no relay dances
+	AND tags NOT LIKE "%x%"; -- no remixes
+
+END //
+DELIMITER ;

--- a/src/typings/kmq_db.d.ts
+++ b/src/typings/kmq_db.d.ts
@@ -81,6 +81,29 @@ export interface DeadLinks {
     vlink: string;
 }
 
+export interface ExpectedAvailableSongs {
+    artist_aliases: string;
+    artist_name_en: string;
+    artist_name_ko: Generated<string | null>;
+    clean_song_name_alpha_numeric: string;
+    id_artist: number;
+    id_parent_artist: number;
+    issolo: "n" | "y";
+    link: string;
+    members: "coed" | "female" | "male";
+    original_artist_name_en: string;
+    original_link: Generated<string | null>;
+    previous_name_en: Generated<string | null>;
+    previous_name_ko: Generated<string | null>;
+    publishedon: Date;
+    song_aliases: string;
+    song_name_en: string;
+    song_name_ko: string;
+    tags: Generated<string | null>;
+    views: number;
+    vtype: "audio" | "main";
+}
+
 export interface GameMessages {
     category: string;
     id: Generated<number>;
@@ -245,6 +268,7 @@ export interface KmqDB {
     competition_moderators: CompetitionModerators;
     daily_stats: DailyStats;
     dead_links: DeadLinks;
+    expected_available_songs: ExpectedAvailableSongs;
     game_messages: GameMessages;
     game_option_presets: GameOptionPresets;
     game_option_presets_json: GameOptionPresetsJson;


### PR DESCRIPTION
Previously both `getSongsFromDb()` (getting songs to download during seed) and `CreateKmqDataTables()` (checking which songs are downloaded to persist to available_songs) replicated the same query. Created intermediate table `expected_available_songs`  