### PR TITLE
Create app_kpop_groups_safe for safe access during seed

### DIFF
--- a/sql/procedures/create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/create_kmq_data_tables_procedure.sql
@@ -55,8 +55,10 @@ BEGIN
 	WHERE id in (SELECT DISTINCT(id_artist) FROM available_songs
 	RIGHT JOIN kpop_videos.app_kpop_group_temp ON available_songs.id_artist = kpop_videos.app_kpop_group_temp.id);
 
-	RENAME TABLE kpop_videos.app_kpop_group TO old, kpop_videos.app_kpop_group_temp TO kpop_videos.app_kpop_group;
-	DROP TABLE old;
+
+	CREATE TABLE IF NOT EXISTS kpop_videos.app_kpop_group_safe LIKE kpop_videos.app_kpop_group_temp;
+	RENAME TABLE kpop_videos.app_kpop_group_safe TO kpop_videos.old, kpop_videos.app_kpop_group_temp TO kpop_videos.app_kpop_group_safe;
+	DROP TABLE kpop_videos.old;
 
 END //
 DELIMITER ;

--- a/src/commands/game_commands/lookup.ts
+++ b/src/commands/game_commands/lookup.ts
@@ -521,7 +521,7 @@ export default class LookupCommand implements BaseCommand {
                     : daisukiEntry.name;
 
             const artistNameResult = await dbContext.kpopVideos
-                .selectFrom("app_kpop_group")
+                .selectFrom("app_kpop_group_safe")
                 .select(["name", "kname"])
                 .where("id", "=", daisukiEntry.id_artist)
                 .executeTakeFirst();

--- a/src/commands/game_commands/upcomingreleases.ts
+++ b/src/commands/game_commands/upcomingreleases.ts
@@ -113,14 +113,14 @@ export default class UpcomingReleasesCommand implements BaseCommand {
             await dbContext.kpopVideos
                 .selectFrom("app_upcoming")
                 .innerJoin(
-                    "app_kpop_group",
+                    "app_kpop_group_safe",
                     "app_upcoming.id_artist",
-                    "app_kpop_group.id",
+                    "app_kpop_group_safe.id",
                 )
                 .select([
                     "app_upcoming.name",
-                    "app_kpop_group.name as artistName",
-                    "app_kpop_group.id as artistID",
+                    "app_kpop_group_safe.name as artistName",
+                    "app_kpop_group_safe.id as artistID",
                     "kname as hangulArtistName",
                     "rtype as releaseType",
                     "rdate as releaseDate",

--- a/src/fact_generator.ts
+++ b/src/fact_generator.ts
@@ -171,13 +171,13 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
-                "app_kpop_group.id",
+                "app_kpop_group_safe",
+                "app_kpop_group_safe.id",
                 "app_kpop.id_artist",
             )
             .select([
                 "app_kpop.name",
-                "app_kpop_group.name as artist",
+                "app_kpop_group_safe.name as artist",
                 "vlink as youtubeLink",
                 "publishedon",
                 "id_artist",
@@ -211,16 +211,16 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop_ms")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop_ms.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .innerJoin("app_kpop", "app_kpop_ms.id_musicvideo", "app_kpop.id")
             .select([
                 "app_kpop_ms.musicshow as music_show",
                 "app_kpop_ms.date as win_date",
                 "app_kpop_ms.musicname as winning_song",
-                "app_kpop_group.name as artist_name",
+                "app_kpop_group_safe.name as artist_name",
                 "app_kpop.vlink as link",
             ])
             .where("date", ">", twoWeeksPriorDate)
@@ -252,12 +252,12 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop_ms")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop_ms.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .groupBy("app_kpop_ms.id_artist")
-            .select(["app_kpop_group.name as artist_name"])
+            .select(["app_kpop_group_safe.name as artist_name"])
             .select((eb) => eb.fn.count<number>("id_artist").as("count"))
             .having(dbContext.kpopVideos.fn.count<number>("id_artist"), ">=", 5)
             .orderBy("count", "desc")
@@ -280,11 +280,11 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
-            .select(["app_kpop_group.name as artist_name"])
+            .select(["app_kpop_group_safe.name as artist_name"])
             .groupBy("app_kpop.id_artist")
             .select(
                 dbContext.kpopVideos.fn
@@ -312,11 +312,11 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
-            .select(["app_kpop_group.name as artist_name"])
+            .select(["app_kpop_group_safe.name as artist_name"])
             .groupBy("app_kpop.id_artist")
             .select(
                 dbContext.kpopVideos.fn
@@ -344,12 +344,12 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .select([
-                "app_kpop_group.name as artist_name",
+                "app_kpop_group_safe.name as artist_name",
                 "app_kpop.name as song_name",
                 "app_kpop.views as views",
                 "app_kpop.vlink as link",
@@ -380,12 +380,12 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .select([
-                "app_kpop_group.name as artist_name",
+                "app_kpop_group_safe.name as artist_name",
                 "app_kpop.name as song_name",
                 "app_kpop.vlink as link",
                 "app_kpop.releasedate as releasedate",
@@ -416,12 +416,12 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .select([
-                "app_kpop_group.name as artist_name",
+                "app_kpop_group_safe.name as artist_name",
                 "app_kpop.name as song_name",
                 "app_kpop.likes as likes",
                 "app_kpop.vlink as link",
@@ -453,17 +453,17 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .innerJoin(
                 "app_kpop_company",
                 "app_kpop_company.id",
-                "app_kpop_group.id_company",
+                "app_kpop_group_safe.id_company",
             )
             .select(["app_kpop_company.name as name"])
-            .groupBy("app_kpop_group.id_company")
+            .groupBy("app_kpop_group_safe.id_company")
             .select((eb) => eb.fn.sum<number>("app_kpop.views").as("views"))
             .orderBy("views", "desc")
             .limit(15)
@@ -485,15 +485,15 @@ export default class FactGenerator {
         lng: LocaleType,
     ): Promise<string[]> {
         const result = await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .innerJoin(
                 "app_kpop_company",
                 "app_kpop_company.id",
-                "app_kpop_group.id_company",
+                "app_kpop_group_safe.id_company",
             )
             .select(["app_kpop_company.name as name"])
             .where("is_collab", "=", "n")
-            .groupBy("app_kpop_group.id_company")
+            .groupBy("app_kpop_group_safe.id_company")
             .select((eb) => eb.fn.countAll<number>().as("count"))
             .orderBy("count", "desc")
             .limit(15)
@@ -515,11 +515,11 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
-            .select(["app_kpop_group.name as artist_name"])
+            .select(["app_kpop_group_safe.name as artist_name"])
             .where("vtype", "=", "main")
             .groupBy("id_artist")
             .select((eb) => eb.fn.count<number>("id_artist").as("count"))
@@ -541,12 +541,12 @@ export default class FactGenerator {
 
     static async yearWithMostDebuts(lng: LocaleType): Promise<string[]> {
         const result = await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
-            .select("app_kpop_group.formation as formation_year")
+            .selectFrom("app_kpop_group_safe")
+            .select("app_kpop_group_safe.formation as formation_year")
             .where("formation", "!=", 0)
             .groupBy("formation")
             .select((eb) =>
-                eb.fn.count<number>("app_kpop_group.id").as("count"),
+                eb.fn.count<number>("app_kpop_group_safe.id").as("count"),
             )
             .orderBy("count", "desc")
             .limit(15)
@@ -591,12 +591,12 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
-            .select(["app_kpop_group.members as gender"])
-            .groupBy("app_kpop_group.members")
+            .select(["app_kpop_group_safe.members as gender"])
+            .groupBy("app_kpop_group_safe.members")
             .select((eb) => eb.fn.sum<number>("app_kpop.views").as("views"))
             .orderBy("views", "desc")
             .limit(25)
@@ -633,16 +633,16 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
-            .select(["app_kpop_group.name as artist_name"])
+            .select(["app_kpop_group_safe.name as artist_name"])
             .groupBy("app_kpop.id_artist")
             .select((eb) =>
                 eb.fn.sum<number>("app_kpop.views").as("total_views"),
             )
-            .where("app_kpop_group.issolo", "=", "y")
+            .where("app_kpop_group_safe.issolo", "=", "y")
             .orderBy("total_views", "desc")
             .limit(25)
             .execute();
@@ -663,11 +663,11 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
-            .select(["app_kpop_group.issolo as issolo"])
+            .select(["app_kpop_group_safe.issolo as issolo"])
             .groupBy("issolo")
             .select((eb) => eb.fn.sum<number>("app_kpop.views").as("views"))
             .orderBy("views", "desc")
@@ -759,16 +759,20 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_kpop")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
-            .select(["app_kpop_group.name as artist_name"])
+            .select(["app_kpop_group_safe.name as artist_name"])
             .groupBy("app_kpop.id_artist")
             .select((eb) =>
                 eb.fn.sum<number>("app_kpop.views").as("total_views"),
             )
-            .where("app_kpop_group.name", "in", ["Blackpink", "Twice", "BTS"])
+            .where("app_kpop_group_safe.name", "in", [
+                "Blackpink",
+                "Twice",
+                "BTS",
+            ])
             .orderBy("total_views", "desc")
             .execute();
 
@@ -796,7 +800,7 @@ export default class FactGenerator {
 
     static async fanclubName(lng: LocaleType): Promise<Array<string>> {
         const result = await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .select(["name", "fanclub"])
             .where("fanclub", "!=", "")
             .orderBy(sql`RAND()`)
@@ -814,7 +818,7 @@ export default class FactGenerator {
 
     static async closeBirthdays(lng: LocaleType): Promise<Array<string>> {
         const result = await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .select(["name"])
             .select((eb) => eb.fn("MONTH", ["date_birth"]).as("birth_month"))
             .select(sql`DATE_FORMAT(date_birth, '%M %e')`.as("formatted_bday"))
@@ -1035,7 +1039,7 @@ export default class FactGenerator {
 
     static async mostGaonFirsts(lng: LocaleType): Promise<string[]> {
         const result = await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .select(["name as artist_name", "gaondigital_firsts as firsts"])
             .orderBy("firsts", "desc")
             .limit(25)
@@ -1055,7 +1059,7 @@ export default class FactGenerator {
 
     static async mostGaonAppearances(lng: LocaleType): Promise<string[]> {
         const result = await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .select(["name as artist_name", "gaondigital_times as appearances"])
             .orderBy("appearances", "desc")
             .limit(25)
@@ -1075,7 +1079,7 @@ export default class FactGenerator {
 
     static async mostAnnualAwardShowWins(lng: LocaleType): Promise<string[]> {
         const result = await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .select(["name as artist_name", "yawards_total as wins"])
             .orderBy("wins", "desc")
             .limit(25)
@@ -1190,15 +1194,15 @@ export default class FactGenerator {
         const result = await dbContext.kpopVideos
             .selectFrom("app_upcoming")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_upcoming.id_artist",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .select([
                 "app_upcoming.rdate as release_date",
                 "app_upcoming.rtype as release_type",
                 "app_upcoming.name as release_name",
-                "app_kpop_group.name as artist_name",
+                "app_kpop_group_safe.name as artist_name",
             ])
             .select(sql`DATEDIFF(rdate, NOW())`.as("diff"))
             .where(sql<boolean>`DATEDIFF(rdate, NOW()) >= 1`)

--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -182,7 +182,7 @@ export async function getSimilarGroupNames(
     locale: LocaleType,
 ): Promise<Array<string>> {
     const similarGroups = await dbContext.kpopVideos
-        .selectFrom("app_kpop_group")
+        .selectFrom("app_kpop_group_safe")
         .select(["id", "name", "kname"])
         .where("is_collab", "=", "n")
         .where("has_songs", "=", 1)
@@ -215,7 +215,7 @@ export async function getMatchingGroupNames(
 ): Promise<GroupMatchResults> {
     const artistIds = (
         await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .select(["id"])
             .where("name", "in", rawGroupNames)
             .where("is_collab", "=", "n")
@@ -227,19 +227,19 @@ export async function getMatchingGroupNames(
         await dbContext.kpopVideos // collab matches
             .selectFrom("app_kpop_agrelation")
             .innerJoin(
-                "app_kpop_group",
+                "app_kpop_group_safe",
                 "app_kpop_agrelation.id_subgroup",
-                "app_kpop_group.id",
+                "app_kpop_group_safe.id",
             )
             .select(["id", "name"])
             .where("app_kpop_agrelation.id_artist", "in", artistIds)
-            .where("app_kpop_group.is_collab", "=", "y")
+            .where("app_kpop_group_safe.is_collab", "=", "y")
             // artist matches
             .unionAll(
                 dbContext.kpopVideos
-                    .selectFrom("app_kpop_group")
+                    .selectFrom("app_kpop_group_safe")
                     .select(["id", "name"])
-                    .where("app_kpop_group.id", "in", artistIds),
+                    .where("app_kpop_group_safe.id", "in", artistIds),
             )
             .orderBy("name", "asc")
             .execute()

--- a/src/helpers/management_utils.ts
+++ b/src/helpers/management_utils.ts
@@ -227,7 +227,7 @@ export async function reloadAliases(): Promise<void> {
         previous_name_ko: string | null;
         full_artist_name: string | null;
     }[] = await dbContext.kpopVideos
-        .selectFrom("app_kpop_group")
+        .selectFrom("app_kpop_group_safe")
         .select([
             "name as artist_name_en",
             "alias as artist_aliases",
@@ -283,7 +283,7 @@ export async function reloadBonusGroups(): Promise<void> {
     const date = new Date();
     const artistNameQuery: string[] = (
         await dbContext.kpopVideos
-            .selectFrom("app_kpop_group")
+            .selectFrom("app_kpop_group_safe")
             .select(["name"])
             .where("is_collab", "=", "n")
             .where("has_songs", "=", 1)

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -171,7 +171,7 @@ export async function loadStoredProcedures(): Promise<void> {
  */
 async function updateDaisukiSchemaTypings(db: DatabaseContext): Promise<void> {
     await db.kpopVideos.schema
-        .alterTable("app_kpop_group")
+        .alterTable("app_kpop_group_safe")
         .modifyColumn("name", "varchar(255)", (cb) => cb.notNull())
         .execute();
 
@@ -575,7 +575,7 @@ async function updateKpopDatabase(
  */
 async function updateGroupList(db: DatabaseContext): Promise<void> {
     const result = await db.kpopVideos
-        .selectFrom("app_kpop_group")
+        .selectFrom("app_kpop_group_safe")
         .select(["name", "members as gender"])
         .where("is_collab", "=", "n")
         .where("has_songs", "=", 1)

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -394,7 +394,7 @@ export default class SongSelector {
         const selectedGroupIDs = this.guildPreference.getGroupIDs();
         if (gameOptions.subunitPreference === SubunitsPreference.INCLUDE) {
             let subunitsQueryBuilder = dbContext.kpopVideos
-                .selectFrom("app_kpop_group")
+                .selectFrom("app_kpop_group_safe")
                 .select("id");
 
             subunitsQueryBuilder = subunitsQueryBuilder.where(
@@ -417,13 +417,13 @@ export default class SongSelector {
                 let collabGroupBuilder = dbContext.kpopVideos // collab matches
                     .selectFrom("app_kpop_agrelation")
                     .innerJoin(
-                        "app_kpop_group",
+                        "app_kpop_group_safe",
                         "app_kpop_agrelation.id_subgroup",
-                        "app_kpop_group.id",
+                        "app_kpop_group_safe.id",
                     )
                     .select(["id", "name"])
                     .distinct()
-                    .where("app_kpop_group.is_collab", "=", "y");
+                    .where("app_kpop_group_safe.is_collab", "=", "y");
 
                 collabGroupBuilder = collabGroupBuilder.where(
                     "app_kpop_agrelation.id_artist",

--- a/src/typings/kmq_db.d.ts
+++ b/src/typings/kmq_db.d.ts
@@ -256,6 +256,7 @@ export interface KmqDB {
     "kpop_videos.app_kpop_company": AppKpopCompany;
     "kpop_videos.app_kpop_gaondigi": AppKpopGaondigi;
     "kpop_videos.app_kpop_group": AppKpopGroup;
+    "kpop_videos.app_kpop_group_safe": AppKpopGroupSafe;
     "kpop_videos.app_kpop_ms": AppKpopMs;
     "kpop_videos.app_upcoming": AppUpcoming;
     available_songs: AvailableSongs;

--- a/src/typings/kpop_videos_db.d.ts
+++ b/src/typings/kpop_videos_db.d.ts
@@ -76,6 +76,36 @@ export interface AppKpopGroup {
     formation: Generated<number | null>;
     gaondigital_firsts: Generated<number>;
     gaondigital_times: Generated<number>;
+    id: number;
+    id_company: Generated<number>;
+    id_country: Generated<number>;
+    id_debut: Generated<number | null>;
+    id_parentgroup: Generated<number>;
+    is_collab: Generated<"n" | "y">;
+    is_deceased: Generated<"n" | "y">;
+    issolo: Generated<"n" | "y">;
+    kname: Generated<string | null>;
+    members: "coed" | "female" | "male";
+    mslevel: Generated<number>;
+    name: Generated<string | null>;
+    original_name: Generated<string | null>;
+    previous_kname: Generated<string>;
+    previous_name: Generated<string>;
+    sales: Generated<number>;
+    social: Generated<string>;
+    yawards_total: Generated<number>;
+}
+
+export interface AppKpopGroupSafe {
+    alias: Generated<string>;
+    date_birth: Generated<Date | null>;
+    debut_date: Generated<Date | null>;
+    disband: Generated<string>;
+    fanclub: Generated<string | null>;
+    fname: Generated<string>;
+    formation: Generated<number | null>;
+    gaondigital_firsts: Generated<number>;
+    gaondigital_times: Generated<number>;
     has_songs: Generated<number | null>;
     id: number;
     id_company: Generated<number>;
@@ -126,6 +156,7 @@ export interface KpopVideosDB {
     app_kpop_company: AppKpopCompany;
     app_kpop_gaondigi: AppKpopGaondigi;
     app_kpop_group: AppKpopGroup;
+    app_kpop_group_safe: AppKpopGroupSafe;
     app_kpop_ms: AppKpopMs;
     app_upcoming: AppUpcoming;
 }


### PR DESCRIPTION
`app_kpop_group` gets updated during seed, and modified again during `CreateKmqDataTables` to add the `has_songs` field. This means that in-between the time that we seed the new `app_kpop_group`, until `CreateKmqDataTables()` finishes, the table is missing the `has_songs` field. Which causes errors like:

```
2024-03-23T16:21:26.167Z [ERROR] - interactionCreate | gid: 1006822328610603099, tid: 1221128968573554812 | Error while invoking command (CHAT_INPUT CommandInteraction interaction for 'groups') | cf4adccf-4e15-4689-9306-82e3162ded2c |  Data: {"id":"1213407215453732934","name":"groups","options":[{"name":"add","options":[{"name":"group_1","type":3,"value":"Seventeen"}],"type":1}],"type":1} | Exception Name: Error. Reason: Unknown column 'has_songs' in 'where clause'. Trace: Error: Unknown column 'has_songs' in 'where clause'
```

Create new `app_kpop_groups_safe ` table which is only updated atomically at the end of `CreateKmqDataTables`