### PR TITLE
Use RUN_ID and commandExecuted instead of reference ID

### DIFF
--- a/.github/workflows/gci-e2e.yml
+++ b/.github/workflows/gci-e2e.yml
@@ -95,9 +95,9 @@ jobs:
             - name: Check pre-upgrade KMQ healthiness
               run: while [[ "$(docker inspect --format='{{json .State.Health.Status}}' kmq-gci)" != "\"healthy\"" ]]; do sleep 1; done
             - name: Run test runner on live instance (game options test)
-              run: docker exec --env-file	./.env kmq-gci sh -c 'npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=BASIC_OPTIONS --source=gci; exit $?'
+              run: docker exec --env-file	./.env kmq-gci sh -c 'npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=BASIC_OPTIONS --debug --source=gci; exit $?'
             - name: Run test runner on live instance (gameplay test)
-              run: docker exec --env-file	./.env kmq-gci sh -c 'npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=PLAY --source=gci; exit $?'
+              run: docker exec --env-file	./.env kmq-gci sh -c 'npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=PLAY --debug --source=gci; exit $?'
             - name: Check for errors
               run: docker logs kmq-gci 2>&1 | grep -i "\[Error\]" && echo "Errors found in container logs." && exit 1 || echo "No errors found in container logs." && exit 0
             - name: Print logs

--- a/src/test/end-to-end-tests/test-runner-bot.ts
+++ b/src/test/end-to-end-tests/test-runner-bot.ts
@@ -99,9 +99,15 @@ function convertGameOptionsMessage(
 }
 
 async function sendCommand(message: string): Promise<string> {
+    if (!CURRENT_STAGE) {
+        return "";
+    }
+
+    const command = message.replace(",", process.env.BOT_PREFIX!);
+    CURRENT_STAGE.commandExecuted = command;
     return (
         await bot.createMessage(process.env.END_TO_END_TEST_BOT_CHANNEL!, {
-            content: message.replace(",", process.env.BOT_PREFIX!),
+            content: command,
             embeds: [
                 {
                     footer: {
@@ -214,7 +220,6 @@ async function mainLoop(): Promise<void> {
     }
 
     CURRENT_STAGE.ready = true;
-    CURRENT_STAGE.commandExecuted = command;
     CURRENT_STAGE.processed = false;
     log(`STAGE ${CURRENT_STAGE.stage} | Sending command: '${command}'`);
     await sendCommand(command);

--- a/src/test/end-to-end-tests/test-runner-bot.ts
+++ b/src/test/end-to-end-tests/test-runner-bot.ts
@@ -130,11 +130,16 @@ async function proceedNextStage(): Promise<void> {
             "========================================Test suite completed========================================",
         );
 
-        log(`Passed ${totalTests - failedTests.length}/${totalTests}`);
         if (failedTests.length) {
+            const message = !TEST_SUITE.cascadingFailures
+                ? `Passed ${totalTests - failedTests.length}/${totalTests}   ${failedTests.length > 0 ? `\nFailed Tests:\n ${failedTests.join("\n ")}` : ""} `
+                : `Failed Test During Step: ${failedTests.join("\n")}`;
+
+            log(message);
+
             await sendDebugAlertWebhook(
                 `Test Suite '${TEST_SUITE.name}' Failed`,
-                `Passed ${totalTests - failedTests.length}/${totalTests}   ${failedTests.length > 0 ? `\nFailed Tests:\n ${failedTests.join("\n ")}` : ""} `,
+                message,
                 EMBED_ERROR_COLOR,
                 KmqImages.DEAD,
             );


### PR DESCRIPTION
We used to use `CURRENT_STAGE.messageId = await sendCommand(command);` to check if KMQ's response matched the test runner's command. However, `await sendCommand(command)` might finish and go directly to `messageCreate` before `messageId` is assigned. 

Instead, use RUN_ID and let KMQ respond with what command it's replying to