### PR TITLE
Fix lookup interaction bug

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -439,14 +439,22 @@ export async function sendMessage(
     authorID?: string,
     interaction?: Eris.ComponentInteraction | Eris.CommandInteraction,
 ): Promise<Eris.Message | null> {
-    if (messageContent.messageReference) {
-        const message: Message<TextChannel> | undefined = await (
-            State.client.getChannel(textChannelID!) as
-                | Eris.TextChannel
-                | undefined
-        )?.getMessage(messageContent.messageReference.messageID);
+    // test bot request, reply with same run ID
+    if (!interaction && messageContent.messageReference) {
+        let message: Message<TextChannel> | undefined;
 
-        // test bot request, reply with same run ID
+        try {
+            message = await (
+                State.client.getChannel(textChannelID!) as
+                    | Eris.TextChannel
+                    | undefined
+            )?.getMessage(messageContent.messageReference.messageID);
+        } catch (e) {
+            logger.warn(
+                `Error fetching channel ${textChannelID} for test runner response`,
+            );
+        }
+
         if (
             message &&
             message.author.id === process.env.END_TO_END_TEST_BOT_CLIENT &&


### PR DESCRIPTION
Happens when `/lookup` returns more than one result, but less than two embeds worth of results, which goes into `sendMessage` path. Goes into the test-runner response code path with the interaction ID as the message reference, which isn't a valid message. 