### PR TITLE
Use this.guildID in updateGuessedMembersMessage

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -991,9 +991,10 @@ export default class GameSession extends Session {
         }
 
         round.interactionMessageNeedsUpdate = false;
-        if (round.interactionMessage) {
+        const interactionMessage = round.interactionMessage;
+        if (interactionMessage) {
             try {
-                await round.interactionMessage.edit({
+                await interactionMessage.edit({
                     embeds: [
                         {
                             ...this.generateRemainingPlayersMessage(round),
@@ -1003,7 +1004,7 @@ export default class GameSession extends Session {
                 });
             } catch (e) {
                 logger.warn(
-                    `Error editing updateGuessedMembersMessage interaction. gid = ${round.interactionMessage.guildID}. e = ${e}}`,
+                    `Error editing updateGuessedMembersMessage interaction. gid = ${this.guildID}. e = ${e}}`,
                 );
             }
         }


### PR DESCRIPTION
```
2024-03-27T18:33:26.461Z [ERROR] - unhandledRejection | Cluster Unhandled Rejection | Name: TypeError. Reason: Cannot read properties of null (reading 'guildID'). Trace: TypeError: Cannot read properties of null (reading 'guildID')
    at GameSession.updateGuessedMembersMessage (/app/build/structures/game_session.js:584:118)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Timeout._onTimeout (/app/build/structures/game_session.js:1010:13)}
```

Assuming this is some race condition where `round.interactionMessage` gets set to null elsewhere 