### PR TITLE
Assign RUN_ID on KMQ startup

### DIFF
--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -41,5 +41,6 @@ declare namespace NodeJS {
         END_TO_END_TEST_BOT_TOKEN: string | undefined;
         END_TO_END_TEST_BOT_CHANNEL: string | undefined;
         END_TO_END_TEST_BOT_VOICE_CHANNEL: string | undefined;
+        RUN_ID: string | undefined;
     }
 }

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -59,6 +59,16 @@ export default class KmqWebServer {
             },
         });
 
+        httpServer.get("/run_id", {}, async (request, reply) => {
+            if (request.ip !== "127.0.0.1") {
+                logger.error("Fetch RUN_ID attempted by non-allowed IP");
+                await reply.code(401).send();
+                return;
+            }
+
+            await reply.code(200).send(process.env.RUN_ID);
+        });
+
         httpServer.post("/announce-restart", {}, async (request, reply) => {
             if (request.ip !== "127.0.0.1") {
                 logger.error("Announce restart attempted by non-allowed IP");

--- a/src/kmq_worker.ts
+++ b/src/kmq_worker.ts
@@ -359,6 +359,8 @@ export default class BotWorker extends BaseClusterWorker {
             this.ready = true;
         }
 
+        logger.info(`Run ID is ${process.env.RUN_ID}`);
+
         logger.info(
             `${this.logHeader()} | Logged in as '${State.client.user.username}'! in '${
                 process.env.NODE_ENV

--- a/src/test/end-to-end-tests/test-runner-bot.ts
+++ b/src/test/end-to-end-tests/test-runner-bot.ts
@@ -27,6 +27,7 @@ function debug(msg: string): void {
     }
 }
 
+// eslint-disable-next-line consistent-return
 async function getKmqRunId(): Promise<string> {
     try {
         return (

--- a/src/test/end-to-end-tests/test-runner-bot.ts
+++ b/src/test/end-to-end-tests/test-runner-bot.ts
@@ -13,6 +13,7 @@ import type TestSuite from "./test_suites/test_suite";
 
 import { KmqResponseType } from "./test_suites/test_suite";
 import { program } from "commander";
+import Axios from "axios";
 import HEALTH_CHECK_TEST_SUITE from "./test_suites/healthcheck_test";
 import PLAY_TEST_SUITE from "./test_suites/gameplay_test";
 
@@ -23,6 +24,19 @@ function log(msg: string): void {
 function debug(msg: string): void {
     if (options.debug) {
         console.log(`DEBUG: ${new Date().toISOString()} | ${msg}`);
+    }
+}
+
+async function getKmqRunId(): Promise<string> {
+    try {
+        return (
+            await Axios.get(
+                `http://127.0.0.1:${process.env.WEB_SERVER_PORT}/run_id`,
+            )
+        ).data;
+    } catch (e) {
+        console.error(`Error fetching RUN_ID, is KMQ running? e = ${e}`);
+        process.exit(1);
     }
 }
 
@@ -64,7 +78,7 @@ let CURRENT_STAGE: {
     ready: boolean;
 } | null = null;
 
-let RUN_ID = crypto.randomBytes(8).toString("hex");
+let RUN_ID: string;
 let voiceConnection: Eris.VoiceConnection | undefined;
 
 function convertGameOptionsMessage(
@@ -472,6 +486,7 @@ async function ensureVoiceConnection(): Promise<void> {
         process.exit(1);
     }
 
+    RUN_ID = await getKmqRunId();
     if (options.source) {
         RUN_ID += `-${options.source}`;
     }

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,8 @@ rebuild () {
     npx tsc
 }
 
+RUN_ID=$(cat /proc/sys/kernel/random/uuid)
+
 if [ "${MINIMAL_RUN}" != "true" ]; then
     echo "Bootstrapping..."
     npx ts-node --swc src/seed/bootstrap.ts
@@ -14,7 +16,7 @@ fi
 # run with ts-node + swc, no transpile needed
 if [ "${NODE_ENV}" == "development_ts_node" ]; then
     cd src/
-    exec npx ts-node --swc kmq.ts
+    exec env RUN_ID=$RUN_ID npx ts-node --swc kmq.ts
 fi
 
 # transpile project
@@ -38,9 +40,9 @@ echo "Starting bot in ${NODE_ENV}..."
 
 cd build/
 if [ "${NODE_ENV}" == "dry-run" ] || [ "${NODE_ENV}" == "ci" ]; then
-    exec node --trace-warnings "${PWD}/kmq.js"
+    exec env RUN_ID=$RUN_ID node --trace-warnings "${PWD}/kmq.js"
     elif [ "${NODE_ENV}" == "development" ]; then
-    exec node --trace-warnings --inspect=9229 "${PWD}/kmq.js"
+    exec env RUN_ID=$RUN_ID node --trace-warnings --inspect=9229 "${PWD}/kmq.js"
     elif [ "${NODE_ENV}" == "production" ]; then
-    exec node --trace-warnings "${PWD}/kmq.js"
+    exec env RUN_ID=$RUN_ID node --trace-warnings "${PWD}/kmq.js"
 fi


### PR DESCRIPTION
Generate RUN_ID from KMQ side to prevent issue where multiple KMQ instances re-using same RUN_ID