### PR TITLE
Hints should be same if Korean name is same

### DIFF
--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -134,18 +134,30 @@ export default class GameRound extends Round {
         this.finished = false;
         this.hints = {
             songHint: {
-                [LocaleType.EN]: this.generateHint(song.songName),
-                [LocaleType.KO]: this.generateHint(
-                    song.hangulSongName || song.songName,
-                ),
+                [LocaleType.KO]: "",
+                [LocaleType.EN]: "",
             },
             artistHint: {
-                [LocaleType.EN]: this.generateHint(song.artistName),
-                [LocaleType.KO]: this.generateHint(
-                    song.hangulArtistName || song.artistName,
-                ),
+                [LocaleType.KO]: "",
+                [LocaleType.EN]: "",
             },
         };
+
+        this.hints.songHint[LocaleType.EN] = this.generateHint(song.songName);
+        this.hints.songHint[LocaleType.KO] =
+            song.hangulSongName && song.hangulSongName !== song.songName
+                ? this.generateHint(song.songName)
+                : this.hints.songHint[LocaleType.EN];
+
+        this.hints.artistHint[LocaleType.EN] = this.generateHint(
+            song.artistName,
+        );
+
+        this.hints.artistHint[LocaleType.KO] =
+            song.hangulArtistName && song.hangulArtistName !== song.artistName
+                ? this.generateHint(song.artistName)
+                : this.hints.artistHint[LocaleType.EN];
+
         this.interactionCorrectAnswerUUID = null;
         this.interactionIncorrectAnswerUUIDs = {};
         this.interactionMessage = null;

--- a/src/structures/queried_song.ts
+++ b/src/structures/queried_song.ts
@@ -4,7 +4,7 @@ import type { AvailableGenders } from "../enums/option_types/gender";
 
 export default class QueriedSong extends BaseArtistInfo {
     songName: string;
-    hangulSongName?: string;
+    hangulSongName: string | null;
     youtubeLink: string;
     originalLink: string | null;
     publishDate: Date;
@@ -32,7 +32,7 @@ export default class QueriedSong extends BaseArtistInfo {
         selectionWeight,
     }: {
         songName: string;
-        hangulSongName?: string;
+        hangulSongName: string | null;
         artistName: string;
         hangulArtistName: string | null;
         youtubeLink: string;
@@ -49,8 +49,9 @@ export default class QueriedSong extends BaseArtistInfo {
         super({ artistName, hangulArtistName, artistID });
         this.songName = songName;
         this.artistName = artistName;
-        this.hangulSongName = hangulSongName;
-        this.hangulArtistName = hangulArtistName;
+        this.hangulSongName = hangulSongName === "" ? null : hangulSongName;
+        this.hangulArtistName =
+            hangulArtistName === "" ? null : hangulArtistName;
         this.youtubeLink = youtubeLink;
         this.originalLink = originalLink;
         this.publishDate = publishDate;

--- a/src/test/unit_tests/ci/game_round.test.ts
+++ b/src/test/unit_tests/ci/game_round.test.ts
@@ -4,6 +4,7 @@ import { delay } from "../../../helpers/utils";
 import ExpBonusModifier from "../../../enums/exp_bonus_modifier";
 import GameRound from "../../../structures/game_round";
 import GuessModeType from "../../../enums/option_types/guess_mode_type";
+import LocaleType from "../../../enums/locale_type";
 import QueriedSong from "../../../structures/queried_song";
 import State from "../../../state";
 import assert from "assert";
@@ -944,6 +945,114 @@ describe("game round", () => {
                 gameRound.getCorrectGuessers(false)[0]!.id,
                 playerID,
             );
+        });
+    });
+
+    describe("hint generation", () => {
+        describe("songs have differing english and korean names", () => {
+            it("should generate unique hints", () => {
+                gameRound = new GameRound(
+                    new QueriedSong({
+                        songName: "long song name to prevent rng collision",
+                        hangulSongName: "충돌을 피하기 위해 긴 노래 이름",
+                        artistName: "long artist name to prevent rng collision",
+                        hangulArtistName: "충돌 방지를 위해 긴 아티스트 이름",
+                        youtubeLink: "a1b2c3",
+                        originalLink: null,
+                        publishDate: new Date(2015, 0),
+                        members: "male",
+                        artistID: 4,
+                        isSolo: "n",
+                        views: 3141592653589,
+                        tags: "",
+                        vtype: "main",
+                        selectionWeight: 1,
+                    }),
+                    5,
+                );
+
+                // hints have been generated
+                assert.notEqual(gameRound.hints.artistHint[LocaleType.EN], "");
+                assert.notEqual(gameRound.hints.artistHint[LocaleType.KO], "");
+                assert.notEqual(gameRound.hints.songHint[LocaleType.EN], "");
+                assert.notEqual(gameRound.hints.songHint[LocaleType.KO], "");
+
+                // hints of differing locales are different
+                assert.notEqual(
+                    gameRound.hints.artistHint[LocaleType.EN],
+                    gameRound.hints.artistHint[LocaleType.KO],
+                );
+
+                assert.notEqual(
+                    gameRound.hints.songHint[LocaleType.EN],
+                    gameRound.hints.songHint[LocaleType.KO],
+                );
+            });
+        });
+
+        describe("songs have the same english and korean names, or missing korean name", () => {
+            it("should generate the same hint", () => {
+                const songName = "long song name to prevent rng collision";
+                const artistName = "long artist name to prevent rng collision";
+                for (const [koSongName, koArtistName] of [
+                    [songName, artistName],
+                    [songName, ""],
+                    ["", artistName],
+                    ["", ""],
+                ]) {
+                    gameRound = new GameRound(
+                        new QueriedSong({
+                            songName,
+                            hangulSongName: koSongName!,
+                            artistName,
+                            hangulArtistName: koArtistName!,
+                            youtubeLink: "a1b2c3",
+                            originalLink: null,
+                            publishDate: new Date(2015, 0),
+                            members: "male",
+                            artistID: 4,
+                            isSolo: "n",
+                            views: 3141592653589,
+                            tags: "",
+                            vtype: "main",
+                            selectionWeight: 1,
+                        }),
+                        5,
+                    );
+
+                    // hints have been generated
+                    assert.notEqual(
+                        gameRound.hints.artistHint[LocaleType.EN],
+                        "",
+                    );
+
+                    assert.notEqual(
+                        gameRound.hints.artistHint[LocaleType.KO],
+                        "",
+                    );
+
+                    assert.notEqual(
+                        gameRound.hints.songHint[LocaleType.EN],
+                        "",
+                    );
+
+                    assert.notEqual(
+                        gameRound.hints.songHint[LocaleType.KO],
+                        "",
+                    );
+
+                    // hints of differing locales are the same
+                    assert.equal(
+                        gameRound.hints.artistHint[LocaleType.EN],
+                        gameRound.hints.artistHint[LocaleType.KO],
+                    );
+
+                    assert.equal(
+                        gameRound.hints.songHint[LocaleType.EN],
+                        gameRound.hints.songHint[LocaleType.KO],
+                    );
+                }
+            });
         });
     });
 });


### PR DESCRIPTION
Users have been abusing this mechanic by switching to Korean locale for a newly generated hint