### PR TITLE
Playlist with zero matches/unmatched error handling

### DIFF
--- a/src/commands/game_options/playlist.ts
+++ b/src/commands/game_options/playlist.ts
@@ -624,6 +624,29 @@ export default class PlaylistCommand implements BaseCommand {
             });
         }
 
+        if (attachments.length === 0) {
+            logger.warn(
+                `Playlist ${kmqPlaylistIdentifier} unexpectedly has 0 matched/unmatched songs. playlist = ${JSON.stringify(playlist)}`,
+            );
+
+            await sendErrorMessage(
+                messageContext,
+                {
+                    title: i18n.translate(
+                        guildID,
+                        "command.playlist.noMatches.title",
+                    ),
+                    description: i18n.translate(
+                        guildID,
+                        "command.playlist.noMatches.description",
+                    ),
+                },
+                interaction,
+            );
+
+            return;
+        }
+
         if (interaction.acknowledged) {
             await interaction.createFollowup({
                 attachments,

--- a/src/commands/game_options/playlist.ts
+++ b/src/commands/game_options/playlist.ts
@@ -626,7 +626,7 @@ export default class PlaylistCommand implements BaseCommand {
 
         if (attachments.length === 0) {
             logger.warn(
-                `Playlist ${kmqPlaylistIdentifier} unexpectedly has 0 matched/unmatched songs. playlist = ${JSON.stringify(playlist)}`,
+                `Playlist ${kmqPlaylistIdentifier} unexpectedly empty in sendMatchedSongsFile. playlist = ${JSON.stringify(playlist)}`,
             );
 
             await sendErrorMessage(
@@ -644,7 +644,6 @@ export default class PlaylistCommand implements BaseCommand {
                 interaction,
             );
 
-            await guildPreference.reset(GameOption.PLAYLIST_ID);
             return;
         }
 

--- a/src/commands/game_options/playlist.ts
+++ b/src/commands/game_options/playlist.ts
@@ -644,6 +644,7 @@ export default class PlaylistCommand implements BaseCommand {
                 interaction,
             );
 
+            await guildPreference.reset(GameOption.PLAYLIST_ID);
             return;
         }
 

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -34,6 +34,7 @@ import type Eris from "eris";
 import type GuildPreference from "./guild_preference";
 import type MessageContext from "./message_context";
 import type UniqueSongCounter from "../interfaces/unique_song_counter";
+import GameOption from "../enums/game_option_name";
 
 const logger = new IPCLogger("song_selector");
 
@@ -295,6 +296,17 @@ export default class SongSelector {
             messageContext,
             interaction!,
         );
+
+        if (
+            playlist.unmatchedSongs.length === 0 &&
+            playlist.matchedSongs.length === 0
+        ) {
+            logger.warn(
+                `Playlist ${kmqPlaylistIdentifier} unexpectedly has 0 matched/unmatched songs in reloadSongs, resetting playlist. playlist = ${JSON.stringify(playlist)}`,
+            );
+
+            await this.guildPreference.reset(GameOption.PLAYLIST_ID);
+        }
 
         this.selectedSongs = playlist as SelectedSongs;
         return playlist;

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -15,6 +15,7 @@ import {
 import { getDebugLogHeader } from "../helpers/discord_utils";
 import ArtistType from "../enums/option_types/artist_type";
 import EnvVariableManager from "../env_variable_manager";
+import GameOption from "../enums/game_option_name";
 import GameRound from "./game_round";
 import LanguageType from "../enums/option_types/language_type";
 import OstPreference from "../enums/option_types/ost_preference";
@@ -34,7 +35,6 @@ import type Eris from "eris";
 import type GuildPreference from "./guild_preference";
 import type MessageContext from "./message_context";
 import type UniqueSongCounter from "../interfaces/unique_song_counter";
-import GameOption from "../enums/game_option_name";
 
 const logger = new IPCLogger("song_selector");
 

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -12,6 +12,7 @@ import {
     setDifference,
     shufflePartitionedArray,
 } from "../helpers/utils";
+import { getDebugLogHeader } from "../helpers/discord_utils";
 import ArtistType from "../enums/option_types/artist_type";
 import EnvVariableManager from "../env_variable_manager";
 import GameRound from "./game_round";
@@ -279,6 +280,12 @@ export default class SongSelector {
             this.guildPreference.gameOptions.forcePlaySongID
         ) {
             this.selectedSongs = await this.querySelectedSongs();
+            if (messageContext) {
+                logger.error(
+                    `${getDebugLogHeader(messageContext)} | Returning null matchedPlaylist for either non-playlist ${!kmqPlaylistIdentifier} or forceplay is active ${this.guildPreference.gameOptions.forcePlaySongID}`,
+                );
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Idk how this happened in prod, but this can happen with:
1. `/playlist` with Spotify playlist with 1 song that matches
2. Remove song from playlist
3. Do something to trigger `reloadSongs` with metadata refresh, which will load 0 songs while playlist data is still persisted
4. `/spotify matches`
```
2024-04-02T15:04:43.232Z [ERROR] - interactionCreate | gid: 343260119934697483, tid: 1203535494181421118 | Error while invoking command (CHAT_INPUT CommandInteraction interaction for 'spotify') | 4f1baa48-2dd9-4791-a8e4-d47df7faaa03 |  Data: {"id":"1212643928730509381","name":"spotify","options":[{"name":"matches","options":[],"type":1}],"type":1} | Exception Name: DiscordRESTError [50006]. Reason: Cannot send an empty message. Trace: DiscordRESTError [50006]: Cannot send an empty message
    at RequestHandler.request (/app/node_modules/eris/lib/rest/RequestHandler.js:71:15)
    at KmqClient.executeWebhook (/app/node_modules/eris/lib/Client.js:2050:36)
    at CommandInteraction.createFollowup (/app/node_modules/eris/lib/structures/CommandInteraction.js:176:44)
    at PlaylistCommand.sendMatchedSongsFile (/app/build/commands/game_options/playlist.js:291:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async PlaylistCommand.processChatInputInteraction (/app/build/commands/game_options/playlist.js:314:13)
    at async KmqClient.interactionCreateHandler (/app/build/events/client/interactionCreate.js:137:21)}.
```