### PR TITLE
Unref post-upgrade test runner execution

### DIFF
--- a/src/scripts/announce-restart.ts
+++ b/src/scripts/announce-restart.ts
@@ -186,7 +186,9 @@ function serverShutdown(
                     const basicOptionsTestCmd = `docker exec ${appName} sh -c '. ./.env && npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=BASIC_OPTIONS --debug --stage-delay=5'`;
                     const gameplayTestCmd = `docker exec ${appName} sh -c '. ./.env && npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=PLAY --debug --stage-delay=5'`;
                     if (!skipTests) {
-                        cp.exec(`${basicOptionsTestCmd} && ${gameplayTestCmd}`);
+                        cp.exec(
+                            `${basicOptionsTestCmd} && ${gameplayTestCmd}`,
+                        ).unref();
                     }
                 },
                 restartMinutes * 1000 * 60,


### PR DESCRIPTION
         * By default, the parent will wait for the detached child to exit. To prevent the
         * parent from waiting for a given `subprocess` to exit, use the`subprocess.unref()` method. Doing so will cause the parent's event loop to not
         * include the child in its reference count, allowing the parent to exit
         * independently of the child, unless there is an established IPC channel between
         * the child and the parent.