### PR TITLE
Update sendMessageExceptionHandler timeout strings

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1844,6 +1844,13 @@ function interactionRejectionHandler(
                 )} | Interaction acknowledge (unknown interaction)`,
             );
             return;
+        } else if (err.code === 40060) {
+            logger.warn(
+                `${getDebugLogHeader(
+                    interaction,
+                )} | Interaction already acknowledged`,
+            );
+            return;
         }
 
         logger.error(

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -423,7 +423,11 @@ async function sendMessageExceptionHandler(
             }
         }
     } else if (e instanceof Error) {
-        if (e.message.includes("Request timed out")) {
+        if (
+            ["Request timed out", "connect ETIMEDOUT"].some((errString) =>
+                e.message.includes(errString),
+            )
+        ) {
             logger.warn(
                 `Error sending message. Request timed out. textChannelID = ${channelID}. Name: ${e.name}. Reason: ${e.message}. Stack: ${e.stack}`,
             );


### PR DESCRIPTION
2024-04-05T19:10:16.198Z [ERROR] - discord_utils | Error sending message. Unknown generic error. textChannelID = 1196846707883913317. Name: Error. Reason: connect ETIMEDOUT 162.159.136.232:443. Stack: Error: connect ETIMEDOUT
