### PR TITLE
Fetch test-runner messages from cache

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -54,7 +54,7 @@ import dbContext from "../database_context";
 import fs from "fs";
 import i18n from "./localization_manager";
 import type { EmbedGenerator, GuildTextableMessage } from "../types";
-import type { GuildTextableChannel, Message, TextChannel } from "eris";
+import type { GuildTextableChannel } from "eris";
 import type AutocompleteEntry from "../interfaces/autocomplete_entry";
 import type BookmarkedSong from "../interfaces/bookmarked_song";
 import type EmbedPayload from "../interfaces/embed_payload";

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -476,19 +476,13 @@ export async function sendMessage(
 ): Promise<Eris.Message | null> {
     // test bot request, reply with same run ID
     if (!interaction && messageContent.messageReference) {
-        let message: Message<TextChannel> | undefined;
+        const testRunnerChannel = State.client.getChannel(textChannelID!) as
+            | Eris.TextChannel
+            | undefined;
 
-        try {
-            message = await (
-                State.client.getChannel(textChannelID!) as
-                    | Eris.TextChannel
-                    | undefined
-            )?.getMessage(messageContent.messageReference.messageID);
-        } catch (e) {
-            logger.warn(
-                `Error fetching channel ${textChannelID} for test runner response`,
-            );
-        }
+        const message = testRunnerChannel?.messages.get(
+            messageContent.messageReference.messageID,
+        );
 
         if (
             message &&

--- a/src/kmq_worker.ts
+++ b/src/kmq_worker.ts
@@ -50,6 +50,7 @@ import voiceChannelJoinHandler from "./events/client/voiceChannelJoin";
 import voiceChannelLeaveHandler from "./events/client/voiceChannelLeave";
 import voiceChannelSwitchHandler from "./events/client/voiceChannelSwitch";
 import warnHandler from "./events/client/warn";
+import type * as Eris from "eris";
 import type { Setup } from "eris-fleet/dist/clusters/BaseClusterWorker";
 import type KmqClient from "./kmq_client";
 
@@ -389,6 +390,15 @@ export default class BotWorker extends BaseClusterWorker {
         ) {
             logger.info(`${this.logHeader()} | Dry run finished successfully.`);
             State.ipc.totalShutdown();
+        }
+
+        // test runner needs to fetch messages from cache
+        const testRunnerChannel = State.client.getChannel(
+            process.env.END_TO_END_TEST_BOT_CHANNEL!,
+        ) as Eris.TextChannel | undefined;
+
+        if (testRunnerChannel) {
+            testRunnerChannel.messages.limit = 10;
         }
     }
 }


### PR DESCRIPTION
channel.getMessage() performs a REST call to fetch message from API.