### PR TITLE
Fix race condition for double startRound() during correct guess

### DIFF
--- a/src/test/end-to-end-tests/test-runner-bot.ts
+++ b/src/test/end-to-end-tests/test-runner-bot.ts
@@ -330,6 +330,10 @@ async function evaluateStage(messageResponse?: {
 
     log(`STAGE ${CURRENT_STAGE.stage} | Validating stage`);
     const stageOutputValidator = testStage.responseValidator;
+    if (testStage.prevalidationDelay) {
+        await delay(testStage.prevalidationDelay);
+    }
+
     if (
         stageOutputValidator(
             messageResponse?.title!,

--- a/src/test/end-to-end-tests/test_suites/gameplay_test.ts
+++ b/src/test/end-to-end-tests/test_suites/gameplay_test.ts
@@ -216,6 +216,7 @@ const PLAY_TEST_SUITE: TestSuite = {
                 console.log(`voiceMembers: ${voiceMembers.join(", ")}`);
                 return !voiceMembers.includes(process.env.BOT_CLIENT_ID!);
             },
+            prevalidationDelay: 3000,
             expectedResponseType: KmqResponseType.NONE,
         },
     ],

--- a/src/test/end-to-end-tests/test_suites/test_suite.ts
+++ b/src/test/end-to-end-tests/test_suites/test_suite.ts
@@ -12,6 +12,7 @@ export default interface TestSuite {
             client?: Eris.Client,
         ) => boolean;
         expectedResponseType: KmqResponseType;
+        prevalidationDelay?: number;
         preCommandDelay?: number;
     }[];
     cascadingFailures: boolean;


### PR DESCRIPTION
`this.round` points to the new round after one correct guess has been submitted. If two correct guesses are submitted simultaneously, the second invocation has a reference to the new game round, so it accidentally skips it. 

Closes #2079