### PR TITLE
Fix getDebugChannel for multicluster deployments

### DIFF
--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1663,10 +1663,7 @@ export function checkBotIsAlone(guildID: string): boolean {
 
 /** @returns the debug TextChannel */
 export function getDebugChannel(): Promise<Eris.TextChannel | null> {
-    if (!process.env.DEBUG_SERVER_ID || !process.env.DEBUG_TEXT_CHANNEL_ID)
-        return Promise.resolve(null);
-    const debugGuild = State.client.guilds.get(process.env.DEBUG_SERVER_ID);
-    if (!debugGuild) return Promise.resolve(null);
+    if (!process.env.DEBUG_TEXT_CHANNEL_ID) return Promise.resolve(null);
     return fetchChannel(process.env.DEBUG_TEXT_CHANNEL_ID);
 }
 


### PR DESCRIPTION
`State.client.guilds` only contains guild cache for the guilds on that the specific shards that the curerent cluster is holding. The `if (!debugGuild) return` would fail if running `,debug` on any cluster other than the one holding the debug server. 

`fetchChannel` already searches for the channel in other clusters via ipc