### PR TITLE
Remove redundant error listener removal

### DIFF
--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -870,12 +870,6 @@ export default abstract class Session {
         });
 
         this.connection.once("error", async (err) => {
-            if (this.connection) {
-                // replace listener with no-op to catch any exceptions thrown after this event
-                this.connection.removeAllListeners("error");
-                this.connection.on("error", () => {});
-            }
-
             if (clipAction === ClipAction.END_ROUND) {
                 // Don't restart the round if the end round clip failed to play
                 return;


### PR DESCRIPTION
`.once()` already removes the listener after the first event is triggered. Removing all listeners was also removing the listener set in `ensureVoiceConnection()` to log warnings during abnormal WS errors, causing uncaught exceptions.  