### PR TITLE
Remove and renew connection listeners on ensureVoiceConnection

### DIFF
--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -705,8 +705,6 @@ export default abstract class Session {
             }. clip mode = ${isClipMode}. clip action = ${clipAction}.`,
         );
 
-        // remove old 'end' listeners, which are unique for setup for each individual round
-        this.connection.removeAllListeners("end");
         this.connection.stopPlaying();
 
         try {
@@ -1234,20 +1232,25 @@ export default abstract class Session {
      * @param client - The bot instance
      */
     private async ensureVoiceConnection(client: KmqClient): Promise<void> {
-        if (this.connection && this.connection.ready) return;
-        const connection = await client.joinVoiceChannel(this.voiceChannelID, {
-            opusOnly: true,
-            selfDeaf: true,
-        });
+        // re-attempt to join vc if new connection, or connection is not ready
+        if (!this.connection || !this.connection.ready) {
+            const connection = await client.joinVoiceChannel(
+                this.voiceChannelID,
+                {
+                    opusOnly: true,
+                    selfDeaf: true,
+                },
+            );
 
-        if (!this.connection) {
-            connection.on("error", (err) => {
-                logger.warn(
-                    `Error receiving from voice connection WS. ${extractErrorString(err)}`,
-                );
-            });
+            this.connection = connection;
         }
 
-        this.connection = connection;
+        // clear existing listeners, and attach generic error handler
+        this.connection.removeAllListeners();
+        this.connection.on("error", (err) => {
+            logger.warn(
+                `Error receiving from voice connection WS. ${extractErrorString(err)}`,
+            );
+        });
     }
 }

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -1240,11 +1240,13 @@ export default abstract class Session {
             selfDeaf: true,
         });
 
-        connection.on("error", (err) => {
-            logger.warn(
-                `Error receiving from voice connection WS. ${extractErrorString(err)}`,
-            );
-        });
+        if (!this.connection) {
+            connection.on("error", (err) => {
+                logger.warn(
+                    `Error receiving from voice connection WS. ${extractErrorString(err)}`,
+                );
+            });
+        }
 
         this.connection = connection;
     }


### PR DESCRIPTION
Forgot that we had a `this.connection.once("error")` and we were no longer removing `error` events in #2120, causing a leak. Instead, revert to removing all listeners but re-attaching the generic error one that we need

```
2024-04-27T22:27:47.430Z [ERROR] - Cluster 0 | (node:52) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [VoiceConnection]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:591:17)
    at VoiceConnection.addListener (node:events:609:10)
    at VoiceConnection.once (node:events:653:8)
    at GameSession.playSong (/app/build/structures/session.js:545:25)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async GameSession.startRound (/app/build/structures/session.js:167:40)
    at async GameSession.startRound (/app/build/structures/game_session.js:153:23)
    at async GameSession.endRound (/app/build/structures/game_session.js:264:9)
    at async GameSession.guessSong (/app/build/structures/game_session.js:375:13)
    at async KmqClient.messageCreateHandler (/app/build/events/client/messageCreate.js:196:13)
    ```