### PR TITLE
Remove unnecessarily docker pull in announce-restart

### DIFF
--- a/src/scripts/announce-restart.sh
+++ b/src/scripts/announce-restart.sh
@@ -65,9 +65,6 @@ server_shutdown() {
         echo "Renaming container..."
         docker rename "$APP_NAME" "$old_app_name"
 
-        echo "Pulling new docker image: $docker_image..."
-        docker pull "$docker_image"
-
         echo "Provisioning standby container with new image..."
         APP_NAME=$APP_NAME IMAGE_NAME=$docker_image IS_STANDBY=true npm run docker-run-internal
 


### PR DESCRIPTION
`docker run` will automatically pull the image if it doesn't exist locally. But in our E2E workflow, we are trying to re-use the image that already exists locally. Doing a `docker pull` will download the older images on GH registry that we no longer use.