### PR TITLE
Support visitor id cookie

### DIFF
--- a/.github/workflows/gci-e2e.yml
+++ b/.github/workflows/gci-e2e.yml
@@ -108,7 +108,7 @@ jobs:
                   REPO_NAME: ${{ github.event.repository.name }}
                   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
             - name: Acquire youtube session tokens
-              run: mkdir data && bash src/scripts/session-generator.sh data/yt_session.json
+              run: mkdir data && bash src/scripts/session-generator.sh data/
             - name: Dry-run bootstrap
               run: |
                   . ./.env

--- a/docker/kmq/Dockerfile
+++ b/docker/kmq/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y default-mysql-client \
 COPY --from=build /app /app
 WORKDIR /app
 
+RUN mkdir data
 STOPSIGNAL SIGINT
 ARG NODE_ENV
 ENV NODE_ENV=$NODE_ENV

--- a/docker/kmq/Dockerfile
+++ b/docker/kmq/Dockerfile
@@ -43,7 +43,6 @@ RUN apt-get update && apt-get install -y default-mysql-client \
 COPY --from=build /app /app
 WORKDIR /app
 
-RUN mkdir data
 STOPSIGNAL SIGINT
 ARG NODE_ENV
 ENV NODE_ENV=$NODE_ENV

--- a/src/kmq_configuration.ts
+++ b/src/kmq_configuration.ts
@@ -79,4 +79,8 @@ export default class KmqConfiguration {
     ytdlpUpdatesEnabled(): boolean {
         return this.config["ytdlpUpdatesEnabled"] ?? false;
     }
+
+    ytdlpDownloadWithCookie(): boolean {
+        return this.config["ytdlpDownloadWithCookie"] ?? false;
+    }
 }

--- a/src/kmq_configuration.ts
+++ b/src/kmq_configuration.ts
@@ -81,6 +81,6 @@ export default class KmqConfiguration {
     }
 
     ytdlpDownloadWithCookie(): boolean {
-        return this.config["ytdlpDownloadWithCookie"] ?? false;
+        return this.config["ytdlpDownloadWithCookie"] ?? true;
     }
 }

--- a/src/scripts/download-new-songs.ts
+++ b/src/scripts/download-new-songs.ts
@@ -185,7 +185,7 @@ async function downloadYouTubeAudio(
     try {
         let ytdlpCommand: string;
         if (KmqConfiguration.Instance.ytdlpDownloadWithCookie()) {
-            ytdlpCommand = `${ytDlpLocation} -f bestaudio -o "${outputFile}" ---extractor-args  "youtube:player-client=web,default;po_token=${ytSessionTokens.po_token}" --cookies ${sessionCookiePath} '${id}';`;
+            ytdlpCommand = `${ytDlpLocation} -f bestaudio -o "${outputFile}" --extractor-args  "youtube:player-client=web,default;po_token=${ytSessionTokens.po_token}" --cookies ${sessionCookiePath} '${id}';`;
         } else {
             ytdlpCommand = `${ytDlpLocation} -f bestaudio -o "${outputFile}" --extractor-arg "youtube:player_client=web;po_token=${ytSessionTokens.po_token};visitor_data=${ytSessionTokens.visitor_data};player_skip=webpage,configs" '${id}';`;
         }

--- a/src/scripts/download-new-songs.ts
+++ b/src/scripts/download-new-songs.ts
@@ -190,7 +190,6 @@ async function downloadYouTubeAudio(
             ytdlpCommand = `${ytDlpLocation} -f bestaudio -o "${outputFile}" --extractor-arg "youtube:player_client=web;po_token=${ytSessionTokens.po_token};visitor_data=${ytSessionTokens.visitor_data};player_skip=webpage,configs" '${id}';`;
         }
 
-        logger.info(ytdlpCommand);
         await exec(ytdlpCommand);
     } catch (err) {
         const errorMessage =

--- a/src/scripts/download-new-songs.ts
+++ b/src/scripts/download-new-songs.ts
@@ -159,6 +159,11 @@ async function downloadYouTubeAudio(
         "../../data/yt_session.json",
     );
 
+    const sessionCookiePath = path.join(
+        __dirname,
+        "../../data/yt_session.cookie",
+    );
+
     if (!(await pathExists(sessionTokensPath))) {
         logger.warn("Youtube session token doesn't exist... aborting");
         throw new Error("Youtube session token doesn't exist");
@@ -178,9 +183,15 @@ async function downloadYouTubeAudio(
     }
 
     try {
-        await exec(
-            `${ytDlpLocation} -f bestaudio -o "${outputFile}" --extractor-arg "youtube:player_client=web;po_token=${ytSessionTokens.po_token};visitor_data=${ytSessionTokens.visitor_data};player_skip=webpage,configs" '${id}';`,
-        );
+        let ytdlpCommand: string;
+        if (KmqConfiguration.Instance.ytdlpDownloadWithCookie()) {
+            ytdlpCommand = `${ytDlpLocation} -f bestaudio -o "${outputFile}" ---extractor-args  "youtube:player-client=web,default;po_token=${ytSessionTokens.po_token}" --cookies ${sessionCookiePath} '${id}';`;
+        } else {
+            ytdlpCommand = `${ytDlpLocation} -f bestaudio -o "${outputFile}" --extractor-arg "youtube:player_client=web;po_token=${ytSessionTokens.po_token};visitor_data=${ytSessionTokens.visitor_data};player_skip=webpage,configs" '${id}';`;
+        }
+
+        logger.info(ytdlpCommand);
+        await exec(ytdlpCommand);
     } catch (err) {
         const errorMessage =
             (err as Error).message

--- a/src/scripts/session-generator.sh
+++ b/src/scripts/session-generator.sh
@@ -8,11 +8,15 @@ session_data=$(docker run quay.io/invidious/youtube-trusted-session-generator)
 visitor_data=$(echo "$session_data" | grep -oP 'visitor_data: \K.*')
 po_token=$(echo "$session_data" | grep -oP 'po_token: \K.*')
 generated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+visitor_id=$(echo "${visitor_data:0:18}" | base64 --decode | tr -d '[:space:]')
+
 json_output=$(jq -n \
                   --arg visitor_data "$visitor_data" \
                   --arg po_token "$po_token" \
                   --arg generated_at "$generated_at" \
-                  '{visitor_data: $visitor_data, po_token: $po_token, generated_at: $generated_at}')
+                  --arg visitor_id "$visitor_id" \
+                  '{visitor_data: $visitor_data, po_token: $po_token, generated_at: $generated_at, visitor_id: $visitor_id}')
+
 
 output_file="$1"
 echo "$json_output" > "$output_file"

--- a/src/scripts/session-generator.sh
+++ b/src/scripts/session-generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <output_file>"
+    echo "Usage: $0 <session_data>"
     exit 1
 fi
 
@@ -17,11 +17,11 @@ json_output=$(jq -n \
                   --arg visitor_id "$visitor_id" \
                   '{visitor_data: $visitor_data, po_token: $po_token, generated_at: $generated_at, visitor_id: $visitor_id}')
 
+session_data="$1"
+echo "$json_output" > "$session_data"
 
-echo "$json_output" > "$output_file"
-
-expiration_time=$(date -d "+1 months" +"%s")
+cookie_file="${session_data%.json}.cookie"
+expiration_time=$(date -d "+6 months" +"%s")
 echo "# Netscape HTTP Cookie File" > "$cookie_file"
 echo -e ".youtube.com\tTRUE\t/\tTRUE\t$expiration_time\tVISITOR_INFO1_LIVE\t$visitor_id" >> "$cookie_file"
 
-output_file="$1"

--- a/src/scripts/session-generator.sh
+++ b/src/scripts/session-generator.sh
@@ -17,6 +17,11 @@ json_output=$(jq -n \
                   --arg visitor_id "$visitor_id" \
                   '{visitor_data: $visitor_data, po_token: $po_token, generated_at: $generated_at, visitor_id: $visitor_id}')
 
+# Create a cookie file with the specified format
+cookie_file="${output_file%.json}.cookie"
+expiration_time=$(date -d "+6 months" +"%s")
+echo "# Netscape HTTP Cookie File" > "$cookie_file"
+echo -e ".youtube.com\tTRUE\t/\tTRUE\t$expiration_time\tVISITOR_INFO1_LIVE\t$visitor_id" >> "$cookie_file"
 
 output_file="$1"
 echo "$json_output" > "$output_file"

--- a/src/scripts/session-generator.sh
+++ b/src/scripts/session-generator.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <session_data>"
+    echo "Usage: $0 <directory>"
     exit 1
 fi
 
+# Get the directory argument
+output_dir="$1"
+
+# Ensure the directory exists
+if [ ! -d "$output_dir" ]; then
+    echo "Directory $output_dir does not exist."
+    exit 1
+fi
+
+echo "Running session generator"
 session_data=$(docker run quay.io/invidious/youtube-trusted-session-generator)
+
+echo "Extracting session data from stdout"
 visitor_data=$(echo "$session_data" | grep -oP 'visitor_data: \K.*')
 po_token=$(echo "$session_data" | grep -oP 'po_token: \K.*')
 generated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -17,11 +29,13 @@ json_output=$(jq -n \
                   --arg visitor_id "$visitor_id" \
                   '{visitor_data: $visitor_data, po_token: $po_token, generated_at: $generated_at, visitor_id: $visitor_id}')
 
-session_data="$1"
-echo "$json_output" > "$session_data"
+session_data_file="$output_dir/yt_session.json"
+echo "$json_output" > "$session_data_file"
+echo "Session data saved to $session_data_file"
 
-cookie_file="${session_data%.json}.cookie"
+cookie_file="$output_dir/yt_session.cookie"
 expiration_time=$(date -d "+6 months" +"%s")
 echo "# Netscape HTTP Cookie File" > "$cookie_file"
 echo -e ".youtube.com\tTRUE\t/\tTRUE\t$expiration_time\tVISITOR_INFO1_LIVE\t$visitor_id" >> "$cookie_file"
 
+echo "Cookie file saved to $cookie_file"

--- a/src/scripts/session-generator.sh
+++ b/src/scripts/session-generator.sh
@@ -17,11 +17,11 @@ json_output=$(jq -n \
                   --arg visitor_id "$visitor_id" \
                   '{visitor_data: $visitor_data, po_token: $po_token, generated_at: $generated_at, visitor_id: $visitor_id}')
 
-# Create a cookie file with the specified format
-cookie_file="${output_file%.json}.cookie"
-expiration_time=$(date -d "+6 months" +"%s")
+
+echo "$json_output" > "$output_file"
+
+expiration_time=$(date -d "+1 months" +"%s")
 echo "# Netscape HTTP Cookie File" > "$cookie_file"
 echo -e ".youtube.com\tTRUE\t/\tTRUE\t$expiration_time\tVISITOR_INFO1_LIVE\t$visitor_id" >> "$cookie_file"
 
 output_file="$1"
-echo "$json_output" > "$output_file"


### PR DESCRIPTION
Using cookie is recommended over passing visitor data to extractor because passing visitor data means `It requires skipping webpage requests so the VISITOR_INFO1_LIVE cookie does not interfere, which will mean more requests, and less stable extraction.`  and `yes, as you are technically using fallbacks. so e.g if that iframe request gets 429nd, the nsig/sig transforming will fail`

https://github.com/yt-dlp/yt-dlp-wiki/blob/761b7d71bdad5f7a91326beb4757471d41b4821b/Extractors.md