### PR TITLE
Ignore songs without english names

### DIFF
--- a/sql/procedures/generate_expected_available_songs_procedure.sql
+++ b/sql/procedures/generate_expected_available_songs_procedure.sql
@@ -73,6 +73,7 @@ BEGIN
 	FROM kpop_videos.app_kpop
 	JOIN kpop_videos.app_kpop_group ON kpop_videos.app_kpop.id_artist = kpop_videos.app_kpop_group.id
 	AND vtype = 'main'
+	AND kpop_videos.app_kpop.name REGEXP '[0-9a-zA-Z[:punct:]]'; -- only songs with english song names
 	AND tags NOT LIKE "%c%" -- no covers
 	AND tags NOT LIKE "%x%"; -- no remixes
 

--- a/sql/procedures/generate_expected_available_songs_procedure.sql
+++ b/sql/procedures/generate_expected_available_songs_procedure.sql
@@ -73,7 +73,7 @@ BEGIN
 	FROM kpop_videos.app_kpop
 	JOIN kpop_videos.app_kpop_group ON kpop_videos.app_kpop.id_artist = kpop_videos.app_kpop_group.id
 	AND vtype = 'main'
-	AND kpop_videos.app_kpop.name REGEXP '[0-9a-zA-Z[:punct:]]'; -- only songs with english song names
+	AND kpop_videos.app_kpop.name REGEXP '[0-9a-zA-Z[:punct:]]' -- only songs with english song names
 	AND tags NOT LIKE "%c%" -- no covers
 	AND tags NOT LIKE "%x%"; -- no remixes
 


### PR DESCRIPTION
Accounts for a very small minority of songs (~20), mostly in Korean. Likely auto-added by Daisuki and haven't had their entries updated with english names yet. 

Considered hiding them based on locale but was too much work to support that. These songs have historically low popularity anyway, and would only affect korean locale players. 