### PR TITLE
Don't remove bracketed component if in middle of song name

### DIFF
--- a/sql/procedures/generate_expected_available_songs_procedure.sql
+++ b/sql/procedures/generate_expected_available_songs_procedure.sql
@@ -49,7 +49,13 @@ BEGIN
 	INSERT INTO expected_available_songs
 	SELECT
 		kpop_videos.app_kpop.name AS song_name_en,
-		(CASE WHEN kpop_videos.app_kpop.name REGEXP '^[^a-zA-Z0-9]+$' THEN kpop_videos.app_kpop.name ELSE REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') END) AS clean_song_name_alpha_numeric,
+		(CASE 
+			WHEN kpop_videos.app_kpop.name REGEXP '^[^a-zA-Z0-9]+$' -- no-op if song name is fully non-alphanumeric (i.e punctuation)
+			THEN kpop_videos.app_kpop.name 
+			WHEN kpop_videos.app_kpop.name REGEXP '\\([^)]*\\)$' -- ignore bracketed part if at end of the song name
+			THEN REGEXP_REPLACE(SUBSTRING_INDEX(kpop_videos.app_kpop.name, '(', 1), '[^0-9a-zA-Z]', '') 
+			ELSE REGEXP_REPLACE(kpop_videos.app_kpop.name, '[^0-9a-zA-Z]', '') -- regular cleaning
+		END) AS clean_song_name_alpha_numeric,
 		kpop_videos.app_kpop.kname AS song_name_ko,
 		kpop_videos.app_kpop.alias AS song_aliases,
 		vlink AS link,


### PR DESCRIPTION
We are removing bracketed parts of song names for entries like `Song (X Version) => Song`. But there are some songs where the bracket occurs in the middle of the name, like `Ab(c) De => Ab`  
Example song names:
```
NY(f)C
FRI(END)S
Dream (s) 1
Dream (s) 2
Dream (s) 3
```

Modify to check that bracket ends at the end of the string before removing them