### PR TITLE
Add daisuki dumps to container mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "docker-compose-dryrun": "cd docker/ && NODE_ENV=dry-run docker-compose up --exit-code-from kmq --build kmq",
         "docker-build": "cd docker/ && DOCKER_BUILDKIT=1 docker build -f kmq/Dockerfile -t ghcr.io/brainicism/kmq_discord:latest ../",
         "docker-run": "bash src/scripts/docker-run.sh",
-        "docker-run-internal": ". ./.env && docker run --restart unless-stopped -d -v ${SONG_DOWNLOAD_DIR}:${SONG_DOWNLOAD_DIR} -v ${PWD}/data:/app/data -v ${PWD}/.env:/app/.env -v ${PWD}/logs:/app/logs -v ${PWD}/sql_dumps/kmq_backup:/app/sql_dumps/kmq_backup --env NODE_ENV=production --env IS_STANDBY=${IS_STANDBY:=false} --network=host --name ${APP_NAME} ${IMAGE_NAME:=ghcr.io/brainicism/kmq_discord:latest}",
+        "docker-run-internal": ". ./.env && docker run --restart unless-stopped -d -v ${SONG_DOWNLOAD_DIR}:${SONG_DOWNLOAD_DIR} -v ${PWD}/data:/app/data -v ${PWD}/.env:/app/.env -v ${PWD}/logs:/app/logs -v ${PWD}/sql_dumps:/app/sql_dumps --env NODE_ENV=production --env IS_STANDBY=${IS_STANDBY:=false} --network=host --name ${APP_NAME} ${IMAGE_NAME:=ghcr.io/brainicism/kmq_discord:latest}",
         "backup": "ts-node --swc src/scripts/backup-kmq-database",
         "import": "ts-node --swc src/scripts/backup-kmq-database --import",
         "regenerate-test-db-dump": "NODE_ENV=test ts-node src/scripts/regenerate-test-db-dump",


### PR DESCRIPTION
`/sql_dumps/daisuki` wasn't being mounted, so we aren't keeping old dumps after container is re-created.