### PR TITLE
Fix accepted artist name answers for artist with + in name

### DIFF
--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -267,7 +267,6 @@ export default class GameRound extends Round {
         guessModeType: GuessModeType,
         typosAllowed = false,
     ): number {
-        // if (!guess) return 0;
         let pointReward = 0;
 
         const songGuessResult = this.checkSongGuess(guess);

--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -119,10 +119,15 @@ export default class GameRound extends Round {
             this.acceptedSongAnswers.push(song.hangulSongName);
         }
 
-        const artistNames = song.artistName.split("+").map((x) => x.trim());
+        const artistNames = song.artistName.includes(" + ")
+            ? song.artistName.split("+").map((x) => x.trim())
+            : [song.artistName];
+
         if (song.hangulArtistName) {
             artistNames.push(
-                ...song.hangulArtistName.split("+").map((x) => x.trim()),
+                ...(song.hangulArtistName.includes(" + ")
+                    ? song.hangulArtistName.split("+").map((x) => x.trim())
+                    : [song.hangulArtistName]),
             );
         }
 
@@ -262,6 +267,7 @@ export default class GameRound extends Round {
         guessModeType: GuessModeType,
         typosAllowed = false,
     ): number {
+        // if (!guess) return 0;
         let pointReward = 0;
 
         const songGuessResult = this.checkSongGuess(guess);

--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -267,6 +267,7 @@ export default class GameRound extends Round {
         guessModeType: GuessModeType,
         typosAllowed = false,
     ): number {
+        if (!guess) return 0;
         let pointReward = 0;
 
         const songGuessResult = this.checkSongGuess(guess);

--- a/src/test/unit_tests/ci/game_round.test.ts
+++ b/src/test/unit_tests/ci/game_round.test.ts
@@ -64,7 +64,7 @@ describe("game round", () => {
         });
 
         describe("artist collabs", () => {
-            it.only("should record them as two separate artists", () => {
+            it("should record them as two separate artists", () => {
                 gameRound = new GameRound(
                     new QueriedSong({
                         songName: "Poggers Song",

--- a/src/test/unit_tests/ci/game_round.test.ts
+++ b/src/test/unit_tests/ci/game_round.test.ts
@@ -64,7 +64,7 @@ describe("game round", () => {
         });
 
         describe("artist collabs", () => {
-            it("should record them as two separate artists", () => {
+            it.only("should record them as two separate artists", () => {
                 gameRound = new GameRound(
                     new QueriedSong({
                         songName: "Poggers Song",
@@ -136,7 +136,8 @@ describe("game round", () => {
                         songName: "Lovesick Girls",
                         hangulSongName: "상사병에 걸린 소녀들",
                         artistName: " Blackpink + IU             ",
-                        hangulArtistName: "   블랙핑크+아이유                ",
+                        hangulArtistName:
+                            "   블랙핑크 + 아이유                ",
                         youtubeLink: "abcde",
                         originalLink: null,
                         publishDate: new Date(),

--- a/src/test/unit_tests/ci/game_round.test.ts
+++ b/src/test/unit_tests/ci/game_round.test.ts
@@ -70,7 +70,7 @@ describe("game round", () => {
                         songName: "Poggers Song",
                         hangulSongName: "리그마 포트나이트",
                         artistName: "IU + Blackpink",
-                        hangulArtistName: "아이유+블랙핑크",
+                        hangulArtistName: "아이유 + 블랙핑크",
                         youtubeLink: "abcde",
                         originalLink: null,
                         publishDate: new Date(),


### PR DESCRIPTION
`song.artistName.split("+")` was returning an empty string for `24K+` and `Mamamoo+`. Check for collabs using `% + %` instead.   