### PR TITLE
Force stereo audio

### DIFF
--- a/src/helpers/kmq_song_downloader.ts
+++ b/src/helpers/kmq_song_downloader.ts
@@ -408,6 +408,7 @@ export default class KmqSongDownloader {
                 .audioCodec("libopus")
                 .audioFilters(`volume=${volumeDifferential}dB`)
                 .output(oggFfmpegOutputStream)
+                .audioChannels(6) // Set to 6 channels for 5.1 surround
                 .on("end", async () => {
                     try {
                         await fs.promises.rename(

--- a/src/helpers/kmq_song_downloader.ts
+++ b/src/helpers/kmq_song_downloader.ts
@@ -408,7 +408,7 @@ export default class KmqSongDownloader {
                 .audioCodec("libopus")
                 .audioFilters(`volume=${volumeDifferential}dB`)
                 .output(oggFfmpegOutputStream)
-                .audioChannels(6) // Set to 6 channels for 5.1 surround
+                .audioChannels(2) // discord only supports stereo
                 .on("end", async () => {
                     try {
                         await fs.promises.rename(


### PR DESCRIPTION
[libopus @ 0x5574da8208c0] Invalid channel layout 5.1(side) for specified mapping family -1.
Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
Conversion failed!

fEqkhH1pUbA

Discord only supports stereo