### PR TITLE
Increase voiceDataTimeout for /special mode

### DIFF
--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -860,6 +860,15 @@ export default abstract class Session {
 
             await this.ensureConnectionReady();
 
+            let voiceDataTimeout: number | undefined;
+            if (isClipMode) {
+                voiceDataTimeout = CLIP_VC_END_TIMEOUT_MS;
+            } else if (specialType) {
+                voiceDataTimeout = 7500;
+            } else {
+                voiceDataTimeout = 2000;
+            }
+
             this.connection.play(stream, {
                 inputArgs,
                 encoderArgs: Object.entries(encoderArgs).flatMap((x) => [
@@ -867,9 +876,7 @@ export default abstract class Session {
                     x[1].join(","),
                 ]),
                 opusPassthrough: specialType === null && !isClipMode,
-                voiceDataTimeout: isClipMode
-                    ? CLIP_VC_END_TIMEOUT_MS
-                    : undefined,
+                voiceDataTimeout,
             });
         } catch (e) {
             if (e instanceof Error) {


### PR DESCRIPTION
Voice connection automatically calls `stopPlaying` and emits `'end'` when `voiceDataTimeout` time passes before any audio is played. For some `/special` modes, time to first audio output is longer than the default of 2000ms.