### PR TITLE
Upgrade to gemini-1.5-flash

### DIFF
--- a/src/helpers/gemini_client.ts
+++ b/src/helpers/gemini_client.ts
@@ -48,7 +48,7 @@ export default class GeminiClient {
 
     constructor() {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        this.client = genAI.getGenerativeModel({ model: "gemini-1.0-pro" });
+        this.client = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
     }
 
     async getPostSummary(


### PR DESCRIPTION
Gemini 1.0 pro is deprecated on February 15. For 1.0's free tier, 15 RPM, 32,000 TPM, and 1,500 RPD are supported. For 1.5's free tier, 15 RPM, 1 million TPM, and 1,500 RPD are supported, so additional rate limiting is not expected.

https://ai.google.dev/gemini-api/docs/models/gemini#gemini-1.0-pro