### PR TITLE
Add check for completely empty better audio column

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:18-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-bullseye
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends git \ 

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -578,6 +578,16 @@ async function updateKpopDatabase(
         await seedDb(db, bootstrap);
         await postSeedDataCleaning(db);
         const oldBetterAudioMapping = await getBetterAudioMapping(db);
+        const numSongsWithBetterAudio = Object.values(
+            oldBetterAudioMapping,
+        ).filter((x) => !!x).length;
+
+        if (numSongsWithBetterAudio === 0) {
+            throw new Error(
+                "Number of songs with better audio links is 0, this is unexpected. Please inspect the database state, do not re-seed.",
+            );
+        }
+
         await generateExpectedAvailableSongs(db);
         const newBetterAudioMapping = await getBetterAudioMapping(db);
         for (const primarySongLink in oldBetterAudioMapping) {

--- a/src/typings/kpop_videos_db.d.ts
+++ b/src/typings/kpop_videos_db.d.ts
@@ -90,6 +90,7 @@ export interface AppKpopGroup {
     is_deceased: Generated<"n" | "y">;
     issolo: Generated<"n" | "y">;
     kname: string;
+    melonid: Generated<number>;
     members: "coed" | "female" | "male";
     mslevel: Generated<number>;
     name: string;
@@ -97,6 +98,7 @@ export interface AppKpopGroup {
     pak_total: Generated<number>;
     previous_kname: Generated<string>;
     previous_name: Generated<string>;
+    releases: Generated<string | null>;
     sales: Generated<number>;
     social: Generated<string>;
     views: Generated<number>;
@@ -124,6 +126,7 @@ export interface AppKpopGroupSafe {
     is_deceased: Generated<"n" | "y">;
     issolo: Generated<"n" | "y">;
     kname: string;
+    melonid: Generated<number>;
     members: "coed" | "female" | "male";
     mslevel: Generated<number>;
     name: string;
@@ -131,6 +134,7 @@ export interface AppKpopGroupSafe {
     pak_total: Generated<number>;
     previous_kname: Generated<string>;
     previous_name: Generated<string>;
+    releases: Generated<string | null>;
     sales: Generated<number>;
     social: Generated<string>;
     views: Generated<number>;


### PR DESCRIPTION
There's a strange bug where the `better_audio_column` is seemingly empty, despite Daisuki data looking good. This causes the seed to delete all of those videos that previously had a better audio, since it thinks it never had one and needs to download a new one. 