### PR TITLE
Add punycode error as exception for error check

### DIFF
--- a/.github/workflows/gci-e2e.yml
+++ b/.github/workflows/gci-e2e.yml
@@ -147,7 +147,14 @@ jobs:
               run: docker exec --env-file	./.env kmq-gci sh -c 'npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=PLAY --debug; exit $?'
             - name: Check for errors
               if: always()
-              run: docker logs kmq-gci 2>&1 | grep -i "\[Error\]" && echo "Errors found in container logs." && exit 1 || echo "No errors found in container logs." && exit 0
+              run: |
+                  if docker logs kmq-gci 2>&1 | grep -i "\[Error\]" | grep -vi "punycode"; then
+                    echo "Errors found in container logs."
+                    exit 1
+                  else
+                    echo "No errors found in container logs."
+                    exit 0
+                  fi
             - name: Print logs
               if: always()
               run: |


### PR DESCRIPTION
```
Run docker logs kmq-gci 2>&1 | grep -i "\[Error\]" && echo "Errors found in container logs." && exit 1 || echo "No errors found in container logs." && exit 0
Error: 26-03-06T02:39:45.728Z [ERROR] - Service kmq_service | (node:84) [DEP0040] DeprecationWarning: The punycode module is deprecated. Please use a userland alternative instead.
Error: 26-03-06T02:39:45.799Z [ERROR] - Cluster 0 | (node:85) [DEP0040] DeprecationWarning: The punycode module is deprecated. Please use a userland alternative instead.
Errors found in container logs.
Error: Process completed with exit code 1.
```


We can't remove punycode dependency without effort, so adding it as an exclusion for the error check
