### PR TITLE
Fix BOTH guess mode overwriting song reward with artist reward

### DIFF
--- a/src/structures/game_round.ts
+++ b/src/structures/game_round.ts
@@ -292,7 +292,7 @@ export default class GameRound extends Round {
                 break;
             case GuessModeType.BOTH:
                 if (isSongGuessCorrect) pointReward = 1;
-                if (isArtistGuessCorrect) pointReward = 0.2;
+                else if (isArtistGuessCorrect) pointReward = 0.2;
                 break;
             default:
                 logger.error(`Unexpected guessModeType: ${guessModeType}`);

--- a/src/test/unit_tests/ci/game_round.test.ts
+++ b/src/test/unit_tests/ci/game_round.test.ts
@@ -610,6 +610,41 @@ describe("game round", () => {
                         );
                     });
                 });
+
+                describe("guess matches both song name and artist name", () => {
+                    it("should return 1 point (song takes priority over artist)", () => {
+                        const sharedName = "samename";
+                        const roundWithIdenticalSongArtist = new GameRound(
+                            new QueriedSong({
+                                songName: sharedName,
+                                cleanSongName: sharedName,
+                                hangulSongName: null,
+                                artistName: sharedName,
+                                hangulArtistName: null,
+                                youtubeLink: "shared",
+                                betterAudioLink: null,
+                                publishDate: new Date(),
+                                members: "female",
+                                artistID: 99,
+                                isSolo: "y",
+                                views: 1,
+                                tags: "",
+                                vtype: "main",
+                                selectionWeight: 1,
+                            }),
+                            5,
+                            guildID,
+                        );
+
+                        assert.strictEqual(
+                            roundWithIdenticalSongArtist.checkGuess(
+                                sharedName,
+                                GuessModeType.BOTH,
+                            ),
+                            1,
+                        );
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
In GuessModeType.BOTH, a correct song guess (1 pt) was being silently downgraded to an artist guess (0.2 pt) when the guess also matched the artist name. Changed second `if` to `else if` so the higher song reward takes priority.