### PR TITLE
Fix num_participants counting all players instead of in-VC players

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -1305,7 +1305,7 @@ export default class GameSession extends Session {
                 guild_id: this.guildID,
                 num_participants: this.scoreboard
                     .getPlayers()
-                    .map((x) => x.inVC).length,
+                    .filter((x) => x.inVC).length,
                 avg_guess_time: averageGuessTime,
                 session_length: sessionLength,
                 rounds_played: this.roundsPlayed,


### PR DESCRIPTION
`.map((x) => x.inVC).length` returns the total array length regardless of the inVC value; `.filter((x) => x.inVC).length` correctly counts only players who were in the voice channel.