### PR TITLE
Fix medium MC difficulty pulling same-artist songs as distractors

### DIFF
--- a/src/helpers/game_utils.ts
+++ b/src/helpers/game_utils.ts
@@ -314,7 +314,7 @@ export async function getMultipleChoiceOptions(
                             ...sameArtistSongs,
                             correctSongPayload.displayedName,
                         ])
-                        .where("id_artist", "=", artistID)
+                        .where("id_artist", "!=", artistID)
                         .orderBy(sql`RAND()`)
                         .execute()
                 )


### PR DESCRIPTION
`sameGenderSongs` query used `id_artist = artistID`, making it select songs from the same artist — identical to the hard mode pool. Changed to `id_artist != artistID` so medium distractors come from different artists of the same gender.

https://github.com/Brainicism/KMQ_Discord/commit/4c3cc57b