### PR TITLE
Fix double sort discarding endLevel tiebreaker for level-up messages

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -477,9 +477,7 @@ export default class GameSession extends Session {
             const levelUpMessages = leveledUpPlayers
                 .sort((a, b) => {
                     const levelsGainedDiff =
-                        b.endLevel -
-                        b.startLevel -
-                        (a.endLevel - a.startLevel);
+                        b.endLevel - b.startLevel - (a.endLevel - a.startLevel);
                     return levelsGainedDiff !== 0
                         ? levelsGainedDiff
                         : b.endLevel - a.endLevel;

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -478,6 +478,7 @@ export default class GameSession extends Session {
                 .sort((a, b) => {
                     const levelsGainedDiff =
                         b.endLevel - b.startLevel - (a.endLevel - a.startLevel);
+
                     return levelsGainedDiff !== 0
                         ? levelsGainedDiff
                         : b.endLevel - a.endLevel;

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -475,11 +475,15 @@ export default class GameSession extends Session {
         // send level up message
         if (leveledUpPlayers.length > 0) {
             const levelUpMessages = leveledUpPlayers
-                .sort((a, b) => b.endLevel - a.endLevel)
-                .sort(
-                    (a, b) =>
-                        b.endLevel - b.startLevel - (a.endLevel - a.startLevel),
-                )
+                .sort((a, b) => {
+                    const levelsGainedDiff =
+                        b.endLevel -
+                        b.startLevel -
+                        (a.endLevel - a.startLevel);
+                    return levelsGainedDiff !== 0
+                        ? levelsGainedDiff
+                        : b.endLevel - a.endLevel;
+                })
                 .map((leveledUpPlayer) =>
                     i18n.translate(this.guildID, "misc.levelUp.entry", {
                         user: this.scoreboard.getPlayerDisplayedName(


### PR DESCRIPTION
Two chained .sort() calls meant the first sort (by endLevel) was immediately discarded by the second (by levelsGained). Merged into a single comparator that sorts by levelsGained descending, with endLevel as the tiebreaker.