### PR TITLE
Fix forceRefreshMetadata always false on first round

### DIFF
--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -186,11 +186,12 @@ export default abstract class Session {
             return null;
         }
 
+        const isFirstRound = !this.sessionInitialized;
         this.sessionInitialized = true;
         if (this.guildPreference.songSelector.getSongs().songs.size === 0) {
             try {
                 await this.guildPreference.songSelector.reloadSongs(
-                    !this.sessionInitialized,
+                    isFirstRound,
                 );
             } catch (err) {
                 await sendErrorMessage(messageContext, {


### PR DESCRIPTION
sessionInitialized was set to true before the !this.sessionInitialized check, so reloadSongs was always called with forceRefreshMetadata=false, even on the very first round of a session.