### PR TITLE
Fix 6 medium-severity bugs: NaN propagation, includes bypass, cleanup locks, bot VC leave, missing guess counts, duration footer

### DIFF
--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -1247,9 +1247,7 @@ export default class PlayCommand implements BaseCommand {
                     lives = ELIMINATION_DEFAULT_LIVES;
                 } else {
                     lives = parseInt(livesOrClipDurationArg, 10);
-                    if (Number.isNaN(lives)) {
-                        lives = ELIMINATION_DEFAULT_LIVES;
-                    } else if (lives < ELIMINATION_MIN_LIVES) {
+                    if (lives < ELIMINATION_MIN_LIVES) {
                         lives = ELIMINATION_MIN_LIVES;
                     } else if (lives > ELIMINATION_MAX_LIVES) {
                         lives = ELIMINATION_MAX_LIVES;
@@ -1263,15 +1261,11 @@ export default class PlayCommand implements BaseCommand {
                     clipDuration = CLIP_DEFAULT_DURATION_SEC;
                 } else {
                     clipDuration = parseFloat(livesOrClipDurationArg);
-                    if (Number.isNaN(clipDuration)) {
-                        clipDuration = CLIP_DEFAULT_DURATION_SEC;
-                    } else {
-                        clipDuration = Math.round(clipDuration! * 100) / 100;
-                        if (clipDuration < CLIP_MIN_DURATION_SEC) {
-                            clipDuration = CLIP_MIN_DURATION_SEC;
-                        } else if (clipDuration > CLIP_MAX_DURATION_SEC) {
-                            clipDuration = CLIP_MAX_DURATION_SEC;
-                        }
+                    clipDuration = Math.round(clipDuration! * 100) / 100;
+                    if (clipDuration < CLIP_MIN_DURATION_SEC) {
+                        clipDuration = CLIP_MIN_DURATION_SEC;
+                    } else if (clipDuration > CLIP_MAX_DURATION_SEC) {
+                        clipDuration = CLIP_MAX_DURATION_SEC;
                     }
                 }
             }

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -1247,7 +1247,9 @@ export default class PlayCommand implements BaseCommand {
                     lives = ELIMINATION_DEFAULT_LIVES;
                 } else {
                     lives = parseInt(livesOrClipDurationArg, 10);
-                    if (lives < ELIMINATION_MIN_LIVES) {
+                    if (isNaN(lives)) {
+                        lives = ELIMINATION_DEFAULT_LIVES;
+                    } else if (lives < ELIMINATION_MIN_LIVES) {
                         lives = ELIMINATION_MIN_LIVES;
                     } else if (lives > ELIMINATION_MAX_LIVES) {
                         lives = ELIMINATION_MAX_LIVES;
@@ -1261,11 +1263,15 @@ export default class PlayCommand implements BaseCommand {
                     clipDuration = CLIP_DEFAULT_DURATION_SEC;
                 } else {
                     clipDuration = parseFloat(livesOrClipDurationArg);
-                    clipDuration = Math.round(clipDuration! * 100) / 100;
-                    if (clipDuration < CLIP_MIN_DURATION_SEC) {
-                        clipDuration = CLIP_MIN_DURATION_SEC;
-                    } else if (clipDuration > CLIP_MAX_DURATION_SEC) {
-                        clipDuration = CLIP_MAX_DURATION_SEC;
+                    if (isNaN(clipDuration)) {
+                        clipDuration = CLIP_DEFAULT_DURATION_SEC;
+                    } else {
+                        clipDuration = Math.round(clipDuration! * 100) / 100;
+                        if (clipDuration < CLIP_MIN_DURATION_SEC) {
+                            clipDuration = CLIP_MIN_DURATION_SEC;
+                        } else if (clipDuration > CLIP_MAX_DURATION_SEC) {
+                            clipDuration = CLIP_MAX_DURATION_SEC;
+                        }
                     }
                 }
             }

--- a/src/commands/game_commands/play.ts
+++ b/src/commands/game_commands/play.ts
@@ -1247,7 +1247,7 @@ export default class PlayCommand implements BaseCommand {
                     lives = ELIMINATION_DEFAULT_LIVES;
                 } else {
                     lives = parseInt(livesOrClipDurationArg, 10);
-                    if (isNaN(lives)) {
+                    if (Number.isNaN(lives)) {
                         lives = ELIMINATION_DEFAULT_LIVES;
                     } else if (lives < ELIMINATION_MIN_LIVES) {
                         lives = ELIMINATION_MIN_LIVES;
@@ -1263,7 +1263,7 @@ export default class PlayCommand implements BaseCommand {
                     clipDuration = CLIP_DEFAULT_DURATION_SEC;
                 } else {
                     clipDuration = parseFloat(livesOrClipDurationArg);
-                    if (isNaN(clipDuration)) {
+                    if (Number.isNaN(clipDuration)) {
                         clipDuration = CLIP_DEFAULT_DURATION_SEC;
                     } else {
                         clipDuration = Math.round(clipDuration! * 100) / 100;

--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -29,10 +29,7 @@ export default async function voiceChannelLeaveHandler(
             `gid: ${oldChannel.guild.id} | Bot was removed from voice channel, ending session`,
         );
 
-        await session.endSession(
-            "Bot was removed from voice channel",
-            false,
-        );
+        await session.endSession("Bot was removed from voice channel", false);
         return;
     }
 

--- a/src/events/client/voiceChannelLeave.ts
+++ b/src/events/client/voiceChannelLeave.ts
@@ -25,6 +25,14 @@ export default async function voiceChannelLeaveHandler(
     }
 
     if (member.id === process.env.BOT_CLIENT_ID) {
+        logger.info(
+            `gid: ${oldChannel.guild.id} | Bot was removed from voice channel, ending session`,
+        );
+
+        await session.endSession(
+            "Bot was removed from voice channel",
+            false,
+        );
         return;
     }
 

--- a/src/helpers/playlist_manager.ts
+++ b/src/helpers/playlist_manager.ts
@@ -823,7 +823,7 @@ export default class PlaylistManager {
     cleanupPlaylistParsingLocks(): void {
         for (const guildID of Object.keys(this.guildsParseInProgress)) {
             const guildParse = this.guildsParseInProgress[guildID];
-            if (!guildParse) return;
+            if (!guildParse) continue;
             if (guildParse < new Date(Date.now() - 1000 * 60 * 10)) {
                 logger.warn(
                     `Guild ${guildID} got stuck parsing Playlist at ${guildParse}`,

--- a/src/structures/elimination_scoreboard.ts
+++ b/src/structures/elimination_scoreboard.ts
@@ -29,6 +29,7 @@ export default class EliminationScoreboard extends Scoreboard {
         for (const guessResult of guessResults) {
             const correctGuesser = this.players[guessResult.userID]!;
             correctGuesser.incrementExp(guessResult.expGain);
+            correctGuesser.incrementCorrectGuessCount();
         }
 
         const guesserIDs = guessResults.map((x) => x.userID);

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -1210,7 +1210,7 @@ export default abstract class Session {
         timeRemaining: number | null,
         nonEmptyFooter: boolean,
     ): string {
-        if (!timeRemaining) {
+        if (timeRemaining == null) {
             return "";
         }
 

--- a/src/structures/song_selector.ts
+++ b/src/structures/song_selector.ts
@@ -625,12 +625,34 @@ export default class SongSelector {
 
             // Kyseley does not like it when you provide an empty array or array of size 1 to OR/AND
             const finalExpressions: Expression<SqlBool>[] = [];
+
+            // Apply includes filter, but also enforce excludes on included artists
             if (includesInnerArtistFilterExpressions.length === 1) {
-                finalExpressions.push(includesInnerArtistFilterExpressions[0]!);
+                if (excludesGroupIDs.length > 0) {
+                    finalExpressions.push(
+                        and([
+                            includesInnerArtistFilterExpressions[0]!,
+                            eb("id_artist", "not in", excludesGroupIDs),
+                        ]),
+                    );
+                } else {
+                    finalExpressions.push(
+                        includesInnerArtistFilterExpressions[0]!,
+                    );
+                }
             } else if (includesInnerArtistFilterExpressions.length > 1) {
-                finalExpressions.push(
-                    and(includesInnerArtistFilterExpressions),
-                );
+                if (excludesGroupIDs.length > 0) {
+                    finalExpressions.push(
+                        and([
+                            ...includesInnerArtistFilterExpressions,
+                            eb("id_artist", "not in", excludesGroupIDs),
+                        ]),
+                    );
+                } else {
+                    finalExpressions.push(
+                        and(includesInnerArtistFilterExpressions),
+                    );
+                }
             }
 
             if (mainArtistFilterExpressions.length === 1) {

--- a/src/structures/team_scoreboard.ts
+++ b/src/structures/team_scoreboard.ts
@@ -40,6 +40,7 @@ export default class TeamScoreboard extends Scoreboard {
             const correctGuesser = this.getPlayer(guessResult.userID);
             if (correctGuesser) {
                 correctGuesser.incrementExp(guessResult.expGain);
+                correctGuesser.incrementCorrectGuessCount();
             }
         }
 


### PR DESCRIPTION
## Fix 6 Medium-Severity Bugs

### 1. NaN propagation for non-numeric text command arguments
**File:** `src/commands/game_commands/play.ts`
**Bug:** `parseInt("abc")` returns `NaN`. All comparisons against `NaN` are false, so clamping guards are skipped. `NaN` is passed as `lives` or `clipDuration` to `GameSession`.
**Impact:** Text commands with non-numeric arguments (e.g. `,play elimination abc`) silently pass `NaN` into game sessions, causing undefined behavior downstream. Slash commands are protected by Discord type validation, but text commands are not.
**Fix:** Added `isNaN()` check after `parseInt`/`parseFloat` for both `lives` and `clipDuration`. Falls back to default values when the argument is not a valid number.

---

### 2. Includes filter bypasses exclude list
**File:** `src/structures/song_selector.ts`
**Bug:** The includes filter (`includesInnerArtistFilterExpressions`) and main filter (`mainArtistFilterExpressions`, which contains excludes, gender, and artist type) are combined with `or()`. This means any included artist appears in the song pool regardless of whether they are in the exclude list.
**Impact:** Excluded artists still appear in the song pool if they happen to be in an included group. The exclude feature is undermined when includes are also active.
**Fix:** When building the includes filter expression, also apply the exclude list (`id_artist NOT IN excludesGroupIDs`) via `and()`, so included artists that are also excluded are properly filtered out.

---

### 3. `cleanupPlaylistParsingLocks` uses `return` instead of `continue`
**File:** `src/helpers/playlist_manager.ts`
**Bug:** Inside a `for` loop over guild IDs, if any guild's parse entry is `undefined`, the function uses `return` which exits the entire function instead of `continue` which would skip to the next guild.
**Impact:** One `undefined` entry stops cleanup for all remaining guilds in the loop, leaving stale parsing locks permanently in place. These stale locks prevent those guilds from ever parsing new playlists.
**Fix:** Changed `return` to `continue`.

---

### 4. Bot kicked from VC does not end session
**File:** `src/events/client/voiceChannelLeave.ts`
**Bug:** When the bot itself is forcefully disconnected from voice by an admin, the handler early-returns without ending the game session. The session continues running silently with no audio output.
**Impact:** After the bot is kicked from VC, the game session continues in a zombie state — rounds keep advancing, timers keep running, but no audio plays. Players have no idea what is happening and cannot interact with the game normally.
**Fix:** When the bot is the member that left the voice channel, call `session.endSession()` with a descriptive reason before returning, matching the same pattern used when the voice channel becomes empty.

---

### 5. Missing `incrementCorrectGuessCount()` in Elimination & Team scoreboards
**Files:** `src/structures/elimination_scoreboard.ts`, `src/structures/team_scoreboard.ts`
**Bug:** Both `EliminationScoreboard.update()` and `TeamScoreboard.update()` call `incrementExp()` but never call `incrementCorrectGuessCount()`. The parent `Scoreboard.update()` correctly calls both.
**Impact:** Correct guess counts are always 0 for elimination and team game modes. Any stats, achievements, leaderboards, or displays that rely on correct guess counts show incorrect data (zero) for these modes.
**Fix:** Added `correctGuesser.incrementCorrectGuessCount()` after the `incrementExp()` call in both scoreboard implementations.

---

### 6. `getDurationFooter` treats `timeRemaining === 0` as no duration
**File:** `src/structures/session.ts`
**Bug:** `if (!timeRemaining)` uses a falsy check. Since `0` is falsy in JavaScript, when `timeRemaining` is exactly `0`, the function returns an empty string instead of displaying the "Time finished!" message.
**Impact:** The "⏰ Time finished!" footer message never displays when the timer reaches exactly zero. It only shows for negative values (after the timer has already passed zero).
**Fix:** Changed to `if (timeRemaining == null)` to only return empty string when the value is `null` or `undefined`, not when it is `0`.