### PR TITLE
Phase 2: Enforce state machine transitions

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -335,6 +335,8 @@ export default class GameSession extends Session {
         guess: string,
         createdAt: number,
     ): Promise<void> {
+        if (!this.stateMachine.isAcceptingInput) return;
+
         // Allow clip mode guesses in between clip replays
         if (!this.isClipMode()) {
             if (!this.connection) return;
@@ -452,7 +454,7 @@ export default class GameSession extends Session {
 
     /** Updates owner to the first player to join the game that didn't leave VC */
     async updateOwner(): Promise<void> {
-        if (this.finished) {
+        if (this.isFinished) {
             return;
         }
 
@@ -1018,7 +1020,7 @@ export default class GameSession extends Session {
             ? 0
             : this.guildPreference.getSongStartDelay() * 1000;
 
-        if (this.sessionInitialized) {
+        if (this.isSessionActive) {
             // Only add a delay if the game has already started
             await delay(
                 this.multiguessDelayIsActive(this.guildPreference)
@@ -1027,7 +1029,7 @@ export default class GameSession extends Session {
             );
         }
 
-        if (this.finished || this.round || this.pendingEndSession) {
+        if (this.isFinished || this.round || this.pendingEndSession) {
             return null;
         }
 
@@ -1068,7 +1070,7 @@ export default class GameSession extends Session {
         );
 
         // ensure that only one invocation can proceed
-        if (!round || round.finished) {
+        if (!round || round.finished || this.isFinished) {
             return;
         }
 
@@ -1261,7 +1263,7 @@ export default class GameSession extends Session {
         reason: string,
         endedDueToError: boolean,
     ): Promise<void> {
-        if (this.finished) {
+        if (this.isFinished) {
             return;
         }
 

--- a/src/structures/listening_session.ts
+++ b/src/structures/listening_session.ts
@@ -43,7 +43,7 @@ export default class ListeningSession extends Session {
     }
 
     async updateOwner(): Promise<void> {
-        if (this.finished) {
+        if (this.isFinished) {
             return;
         }
 
@@ -78,7 +78,7 @@ export default class ListeningSession extends Session {
      * @param messageContext - An object containing relevant parts of Eris.Message
      */
     async startRound(messageContext: MessageContext): Promise<Round | null> {
-        if (this.finished || this.round) {
+        if (this.isFinished || this.round) {
             return null;
         }
 
@@ -125,7 +125,7 @@ export default class ListeningSession extends Session {
     }
 
     async endSession(reason: string): Promise<void> {
-        if (this.finished) {
+        if (this.isFinished) {
             return;
         }
 

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -142,6 +142,26 @@ export default abstract class Session extends EventEmitter {
 
     abstract sessionName(): string;
 
+    /**
+     * Whether the session is in a terminal state (ending or ended).
+     * Prefer this over reading `this.finished` directly.
+     */
+    get isFinished(): boolean {
+        return !this.stateMachine.isAlive;
+    }
+
+    /**
+     * Whether the session has completed initialization (first round started).
+     * Prefer this over reading `this.sessionInitialized` directly.
+     */
+    get isSessionActive(): boolean {
+        return (
+            this.stateMachine.state !== SessionState.CREATED &&
+            this.stateMachine.state !== SessionState.INITIALIZING &&
+            this.stateMachine.state !== SessionState.LOBBY
+        );
+    }
+
     static getSession(guildID: string): Session | undefined {
         return State.gameSessions[guildID] ?? State.listeningSessions[guildID];
     }

--- a/src/structures/session_state.ts
+++ b/src/structures/session_state.ts
@@ -66,8 +66,7 @@ const VALID_TRANSITIONS: Record<SessionState, Set<SessionState>> = {
 
 /**
  * Manages session state transitions with validation and logging.
- * Invalid transitions are logged as warnings but still applied
- * to avoid breaking existing behavior during rollout.
+ * Invalid transitions are rejected and logged as warnings.
  */
 export class SessionStateMachine {
     private currentState: SessionState = SessionState.CREATED;
@@ -82,11 +81,10 @@ export class SessionStateMachine {
     }
 
     /**
-     * Attempt a state transition. Returns true if the transition was valid.
-     * Invalid transitions are logged as warnings but still applied to avoid
-     * breaking existing behavior during rollout.
+     * Attempt a state transition. Returns true if valid and applied,
+     * false if rejected (invalid transition).
      * @param to - The target state to transition to
-     * @returns whether the transition was valid
+     * @returns whether the transition was valid and applied
      */
     transition(to: SessionState): boolean {
         const allowed = VALID_TRANSITIONS[this.currentState];
@@ -94,9 +92,10 @@ export class SessionStateMachine {
         const from = this.currentState;
 
         if (!isValid) {
-            logger.error(
-                `gid: ${this.guildID} | Invalid state transition: ${from} → ${to}`,
+            logger.warn(
+                `gid: ${this.guildID} | Invalid state transition rejected: ${from} → ${to}`,
             );
+            return false;
         }
 
         this.currentState = to;

--- a/src/test/unit_tests/ci/session_state.test.ts
+++ b/src/test/unit_tests/ci/session_state.test.ts
@@ -220,4 +220,51 @@ describe("SessionStateMachine", () => {
             );
         });
     });
+
+    describe("Phase 2: enforcement (rejected transitions preserve state)", () => {
+        it("invalid transition should not change state", () => {
+            assert.strictEqual(sm.state, SessionState.CREATED);
+            sm.transition(SessionState.ROUND_ACTIVE); // invalid
+            assert.strictEqual(sm.state, SessionState.CREATED);
+        });
+
+        it("state should remain unchanged after multiple rejected transitions", () => {
+            sm.transition(SessionState.INITIALIZING);
+            sm.transition(SessionState.ROUND_ACTIVE);
+            assert.strictEqual(sm.state, SessionState.ROUND_ACTIVE);
+
+            // Try several invalid transitions
+            sm.transition(SessionState.CREATED);
+            sm.transition(SessionState.LOBBY);
+            sm.transition(SessionState.BETWEEN_ROUNDS);
+            sm.transition(SessionState.ENDED);
+
+            // State should still be ROUND_ACTIVE
+            assert.strictEqual(sm.state, SessionState.ROUND_ACTIVE);
+        });
+
+        it("ENDED state should be truly terminal", () => {
+            sm.transition(SessionState.ENDING);
+            sm.transition(SessionState.ENDED);
+
+            const allStates = Object.values(SessionState);
+            for (const state of allStates) {
+                const result = sm.transition(state);
+                assert.strictEqual(result, false);
+            }
+
+            assert.strictEqual(sm.state, SessionState.ENDED);
+        });
+
+        it("valid transition after rejected one should still work", () => {
+            // Try invalid transition
+            sm.transition(SessionState.ROUND_ACTIVE);
+            assert.strictEqual(sm.state, SessionState.CREATED);
+
+            // Now do valid transition
+            const result = sm.transition(SessionState.INITIALIZING);
+            assert.strictEqual(result, true);
+            assert.strictEqual(sm.state, SessionState.INITIALIZING);
+        });
+    });
 });


### PR DESCRIPTION
## Session Architecture Redesign — Phase 2 of 8

### What
Convert state machine from logging-only (Phase 1) to enforcing transitions. Replace boolean flag checks with state machine queries.

### Changes

**`session_state.ts`**: `transition()` now rejects invalid transitions (returns `false` without applying) instead of applying anyway with a warning.

**`session.ts`**: Added convenience getters:
- `get isFinished()` — delegates to `!stateMachine.isAlive` (replaces raw `this.finished` reads)
- `get isSessionActive()` — checks state is past CREATED/INITIALIZING (replaces raw `this.sessionInitialized` reads)

**`game_session.ts`**:
- `startRoundCore()`: `this.finished` → `this.isFinished`, `this.sessionInitialized` → `this.isSessionActive`
- `endRoundCore()`: Added `this.isFinished` to the `round.finished` guard for defense-in-depth
- `endSessionCore()`: `this.finished` → `this.isFinished`
- `guessSong()`: Added `stateMachine.isAcceptingInput` early return (only accepts guesses in ROUND_ACTIVE)
- `updateOwner()`: `this.finished` → `this.isFinished`

**`listening_session.ts`**: All `this.finished` reads → `this.isFinished`. Kept `this.finished = true` writes for backward compat.

### Risk: Low
The state machine mirrors the existing boolean checks — it was already transitioning at the correct lifecycle points from Phase 1. The behavioral change is minimal: the only new behavior is `guessSong()` rejecting guesses when the state machine says the round isn't active, which was already guarded by `round.finished` and connection listener checks.

### Stack Order
```
  Phase 1 — Foundation
► Phase 2 (this PR) — Enforce state machine (depends on Phase 1)
  Phase 3 — Consolidate mutex (depends on Phase 2)
  Phase 4 — Voice manager extraction (depends on Phase 1)
  Phase 5 — Scoreboard hardening (depends on Phase 1)
  Phase 6 — Clean API surface (depends on Phase 3)
  Phase 7 — Event system + timer manager (depends on Phase 1)
  Phase 8 — Registry replaces State maps (depends on Phase 3)
```