### PR TITLE
Phase 6: SessionActionResult type + clean API surface

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -23,6 +23,9 @@ export function delay(delayDuration: number): Promise<void> {
 /**
  * Like delay(), but can be cancelled via an AbortSignal.
  * Resolves normally if the signal fires (does NOT reject/throw).
+ * @param delayDuration - Delay in milliseconds
+ * @param signal - Optional AbortSignal to cancel the delay
+ * @returns A promise that resolves after the delay or on abort
  */
 export function cancellableDelay(
     delayDuration: number,
@@ -31,6 +34,7 @@ export function cancellableDelay(
     if (signal?.aborted) return Promise.resolve();
     return new Promise((resolve) => {
         const onAbort = (): void => {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
             clearTimeout(timer);
             resolve();
         };

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -8,7 +8,6 @@ import {
     cancellableDelay,
     chunkArray,
     codeLine,
-    delay,
     getOrdinalNum,
     setDifference,
 } from "../helpers/utils";

--- a/src/structures/listening_session.ts
+++ b/src/structures/listening_session.ts
@@ -124,6 +124,7 @@ export default class ListeningSession extends Session {
         return round;
     }
 
+    // eslint-disable-next-line @typescript-eslint/member-ordering
     async endRound(
         isError: boolean,
         messageContext?: MessageContext,
@@ -141,6 +142,7 @@ export default class ListeningSession extends Session {
         await super.endRound(isError, messageContext);
     }
 
+    // eslint-disable-next-line @typescript-eslint/member-ordering
     async endSession(reason: string): Promise<void> {
         await this.withLifecycleLock(() => this.endSessionCore(reason));
     }
@@ -164,6 +166,7 @@ export default class ListeningSession extends Session {
         await super.endSession(reason, false);
     }
 
+    // eslint-disable-next-line @typescript-eslint/member-ordering
     async handleComponentInteraction(
         interaction: Eris.ComponentInteraction,
         messageContext: MessageContext,
@@ -241,6 +244,7 @@ export default class ListeningSession extends Session {
      * @param randomSong - The queried song
      * @returns the new GameRound
      */
+    // eslint-disable-next-line @typescript-eslint/member-ordering
     protected prepareRound(randomSong: QueriedSong): Round {
         return new ListeningRound(randomSong, this.guildID);
     }

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -23,6 +23,7 @@ import {
     tryCreateInteractionErrorAcknowledgement,
     tryCreateInteractionSuccessAcknowledgement,
     tryInteractionAcknowledge,
+    getMajorityCount,
 } from "../helpers/discord_utils";
 import {
     delay,
@@ -60,6 +61,11 @@ import type QueriedSong from "./queried_song";
 import type Round from "./round";
 
 import { SessionState, SessionStateMachine } from "./session_state";
+import {
+    actionFail,
+    actionOkVoid,
+    type SessionActionResult,
+} from "./session_action_result";
 
 const logger = new IPCLogger("session");
 
@@ -649,6 +655,53 @@ export default abstract class Session extends EventEmitter {
             clearTimeout(this.guessTimeoutFunc);
         }
     }
+
+    // ── Session API: actions that commands call ─────────────────────────
+
+    /**
+     * Process a skip vote from a user. Returns a result indicating
+     * whether the vote was counted and whether skip threshold was reached.
+     */
+    processSkipVote(
+        userID: string,
+        messageContext: MessageContext,
+    ): SessionActionResult<{ skipAchieved: boolean; skipCount: number; skipThreshold: number }> {
+        if (!this.round || this.round.finished || this.round.skipAchieved) {
+            return actionFail("no_active_round");
+        }
+
+        if (!this.stateMachine.isAcceptingInput) {
+            return actionFail("not_accepting_input");
+        }
+
+        this.round.userSkipped(userID);
+
+        const skipCount = this.round.getSkipCount();
+        const skipThreshold = getMajorityCount(this.guildID);
+        const skipAchieved = skipCount >= skipThreshold;
+
+        return {
+            ok: true,
+            value: { skipAchieved, skipCount, skipThreshold },
+        };
+    }
+
+    /**
+     * Force-skip the current song (end round + start new one).
+     * Called when skip majority is reached.
+     */
+    async forceSkip(messageContext: MessageContext): Promise<SessionActionResult> {
+        if (!this.round) {
+            return actionFail("no_active_round");
+        }
+
+        this.round.skipAchieved = true;
+        await this.endRound(false, messageContext);
+        await this.startRound(messageContext);
+        return actionOkVoid();
+    }
+
+    // ── End Session API ───────────────────────────────────────────────
 
     /**
      * Updates the Session's lastActive timestamp and it's value in the data store

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -17,13 +17,13 @@ import {
     getAverageVolume,
     getCurrentVoiceMembers,
     getDebugLogHeader,
+    getMajorityCount,
     sendBookmarkedSongs,
     sendErrorMessage,
     sendInfoMessage,
     tryCreateInteractionErrorAcknowledgement,
     tryCreateInteractionSuccessAcknowledgement,
     tryInteractionAcknowledge,
-    getMajorityCount,
 } from "../helpers/discord_utils";
 import {
     delay,
@@ -60,12 +60,13 @@ import type ListeningSession from "./listening_session";
 import type QueriedSong from "./queried_song";
 import type Round from "./round";
 
-import { SessionState, SessionStateMachine } from "./session_state";
 import {
+    type SessionActionResult,
+    SessionRejectReason,
     actionFail,
     actionOkVoid,
-    type SessionActionResult,
 } from "./session_action_result";
+import { SessionState, SessionStateMachine } from "./session_state";
 
 const logger = new IPCLogger("session");
 
@@ -661,17 +662,24 @@ export default abstract class Session extends EventEmitter {
     /**
      * Process a skip vote from a user. Returns a result indicating
      * whether the vote was counted and whether skip threshold was reached.
+     * @param userID - The ID of the user voting to skip
+     * @param _messageContext - The message context (unused)
+     * @returns A SessionActionResult with skip status
      */
     processSkipVote(
         userID: string,
         _messageContext: MessageContext,
-    ): SessionActionResult<{ skipAchieved: boolean; skipCount: number; skipThreshold: number }> {
+    ): SessionActionResult<{
+        skipAchieved: boolean;
+        skipCount: number;
+        skipThreshold: number;
+    }> {
         if (!this.round || this.round.finished || this.round.skipAchieved) {
-            return actionFail("no_active_round");
+            return actionFail(SessionRejectReason.NO_ACTIVE_ROUND);
         }
 
         if (!this.stateMachine.isAcceptingInput) {
-            return actionFail("not_accepting_input");
+            return actionFail(SessionRejectReason.NOT_ACCEPTING_INPUT);
         }
 
         this.round.userSkipped(userID);
@@ -686,10 +694,15 @@ export default abstract class Session extends EventEmitter {
         };
     }
 
-    /** Force-skip the current song (end round + start new one). */
-    async forceSkip(messageContext: MessageContext): Promise<SessionActionResult> {
+    /**
+     * Force-skip the current song (end round + start new one).
+     * @param messageContext - The message context for the command
+     */
+    async forceSkip(
+        messageContext: MessageContext,
+    ): Promise<SessionActionResult> {
         if (!this.round) {
-            return actionFail("no_active_round");
+            return actionFail(SessionRejectReason.NO_ACTIVE_ROUND);
         }
 
         this.round.skipAchieved = true;

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -664,7 +664,7 @@ export default abstract class Session extends EventEmitter {
      */
     processSkipVote(
         userID: string,
-        messageContext: MessageContext,
+        _messageContext: MessageContext,
     ): SessionActionResult<{ skipAchieved: boolean; skipCount: number; skipThreshold: number }> {
         if (!this.round || this.round.finished || this.round.skipAchieved) {
             return actionFail("no_active_round");
@@ -686,10 +686,7 @@ export default abstract class Session extends EventEmitter {
         };
     }
 
-    /**
-     * Force-skip the current song (end round + start new one).
-     * Called when skip majority is reached.
-     */
+    /** Force-skip the current song (end round + start new one). */
     async forceSkip(messageContext: MessageContext): Promise<SessionActionResult> {
         if (!this.round) {
             return actionFail("no_active_round");

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -101,15 +101,11 @@ export default abstract class Session extends EventEmitter {
     /** Whether the Session is active yet */
     public sessionInitialized: boolean;
 
-    /** Aborted in endSession to cancel in-flight cancellableDelay() calls */
-    protected sessionAbortController = new AbortController();
-
-    protected get abortSignal(): AbortSignal {
-        return this.sessionAbortController.signal;
-    }
-
     /** State machine tracking session lifecycle */
     public readonly stateMachine: SessionStateMachine;
+
+    /** Aborted in endSession to cancel in-flight cancellableDelay() calls */
+    protected sessionAbortController = new AbortController();
 
     /** Mutex to serialize lifecycle operations (startRound, endRound, endSession).
      *  Wrapped with a 30s timeout to prevent permanent deadlocks from blocking
@@ -173,21 +169,6 @@ export default abstract class Session extends EventEmitter {
             this.stateMachine.state !== SessionState.CREATED &&
             this.stateMachine.state !== SessionState.INITIALIZING
         );
-    }
-
-    /** Run fn while holding the lifecycle mutex. Returns null if session is ending/ended. */
-    protected withLifecycleLock<T>(fn: () => Promise<T>): Promise<T | null> {
-        if (!this.stateMachine.isAlive) {
-            return Promise.resolve(null);
-        }
-
-        return this.lifecycleMutex.runExclusive(async () => {
-            if (!this.stateMachine.isAlive) {
-                return null;
-            }
-
-            return fn();
-        });
     }
 
     static getSession(guildID: string): Session | undefined {
@@ -836,6 +817,29 @@ export default abstract class Session extends EventEmitter {
         }
 
         return false;
+    }
+
+    protected get abortSignal(): AbortSignal {
+        return this.sessionAbortController.signal;
+    }
+
+    /**
+     * Run fn while holding the lifecycle mutex.
+     * @param fn - The async function to execute under the lock
+     * @returns The result of fn, or null if session is ending/ended
+     */
+    protected withLifecycleLock<T>(fn: () => Promise<T>): Promise<T | null> {
+        if (!this.stateMachine.isAlive) {
+            return Promise.resolve(null);
+        }
+
+        return this.lifecycleMutex.runExclusive(async () => {
+            if (!this.stateMachine.isAlive) {
+                return null;
+            }
+
+            return fn();
+        });
     }
 
     /**

--- a/src/structures/session_action_result.ts
+++ b/src/structures/session_action_result.ts
@@ -1,0 +1,22 @@
+/**
+ * Result type for session actions, providing typed success/failure
+ * information to command callers without exposing internal state.
+ */
+export type SessionActionResult<T = void> =
+    | { ok: true; value: T }
+    | { ok: false; reason: string };
+
+/** Helper to create a success result */
+export function actionOk<T>(value: T): SessionActionResult<T> {
+    return { ok: true, value };
+}
+
+/** Helper to create a success result with void value */
+export function actionOkVoid(): SessionActionResult<void> {
+    return { ok: true, value: undefined };
+}
+
+/** Helper to create a failure result */
+export function actionFail<T = void>(reason: string): SessionActionResult<T> {
+    return { ok: false, reason };
+}

--- a/src/structures/session_action_result.ts
+++ b/src/structures/session_action_result.ts
@@ -1,22 +1,44 @@
 /**
+ * Typed reasons for rejecting a session action.
+ */
+export enum SessionRejectReason {
+    NO_ACTIVE_ROUND = "no_active_round",
+    NOT_ACCEPTING_INPUT = "not_accepting_input",
+    SESSION_ENDED = "session_ended",
+}
+
+/**
  * Result type for session actions, providing typed success/failure
  * information to command callers without exposing internal state.
  */
 export type SessionActionResult<T = void> =
     | { ok: true; value: T }
-    | { ok: false; reason: string };
+    | { ok: false; reason: SessionRejectReason };
 
-/** Helper to create a success result */
+/**
+ * Helper to create a success result
+ * @param value - The success payload
+ * @returns A success SessionActionResult containing the value
+ */
 export function actionOk<T>(value: T): SessionActionResult<T> {
     return { ok: true, value };
 }
 
-/** Helper to create a success result with void value */
+/**
+ * Helper to create a success result with void value
+ * @returns A success SessionActionResult with undefined value
+ */
 export function actionOkVoid(): SessionActionResult<void> {
     return { ok: true, value: undefined };
 }
 
-/** Helper to create a failure result */
-export function actionFail<T = void>(reason: string): SessionActionResult<T> {
+/**
+ * Helper to create a failure result
+ * @param reason - The rejection reason
+ * @returns A failure SessionActionResult containing the reason
+ */
+export function actionFail<T = void>(
+    reason: SessionRejectReason,
+): SessionActionResult<T> {
     return { ok: false, reason };
 }

--- a/src/structures/session_state.ts
+++ b/src/structures/session_state.ts
@@ -93,6 +93,8 @@ export class SessionStateMachine {
     /**
      * Attempt a state transition. Returns true if valid and applied,
      * false if rejected (invalid transition).
+     * @param to - The target state to transition to
+     * @returns whether the transition was valid and applied
      */
     transition(to: SessionState): boolean {
         const allowed = VALID_TRANSITIONS[this.currentState];

--- a/src/test/unit_tests/ci/session_action_result.test.ts
+++ b/src/test/unit_tests/ci/session_action_result.test.ts
@@ -1,0 +1,88 @@
+import {
+    type SessionActionResult,
+    SessionRejectReason,
+    actionFail,
+    actionOk,
+    actionOkVoid,
+} from "../../../structures/session_action_result";
+import assert from "assert";
+
+describe("SessionActionResult", () => {
+    describe("actionOk", () => {
+        it("should create a success result with value", () => {
+            const result = actionOk(42);
+            assert.strictEqual(result.ok, true);
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (result.ok) {
+                assert.strictEqual(result.value, 42);
+            }
+        });
+
+        it("should work with complex types", () => {
+            const result = actionOk({
+                skipAchieved: true,
+                skipCount: 3,
+                skipThreshold: 3,
+            });
+
+            assert.strictEqual(result.ok, true);
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (result.ok) {
+                assert.strictEqual(result.value.skipAchieved, true);
+                assert.strictEqual(result.value.skipCount, 3);
+            }
+        });
+    });
+
+    describe("actionOkVoid", () => {
+        it("should create a success result with undefined value", () => {
+            const result = actionOkVoid();
+            assert.strictEqual(result.ok, true);
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (result.ok) {
+                assert.strictEqual(result.value, undefined);
+            }
+        });
+    });
+
+    describe("actionFail", () => {
+        it("should create a failure result with reason", () => {
+            const result = actionFail(SessionRejectReason.NO_ACTIVE_ROUND);
+            assert.strictEqual(result.ok, false);
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (!result.ok) {
+                assert.strictEqual(
+                    result.reason,
+                    SessionRejectReason.NO_ACTIVE_ROUND,
+                );
+            }
+        });
+    });
+
+    describe("type narrowing", () => {
+        it("should narrow correctly on ok check", () => {
+            const result: SessionActionResult<number> = actionOk(10);
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (result.ok) {
+                const val: number = result.value;
+                assert.strictEqual(val, 10);
+            } else {
+                assert.fail("Expected ok result");
+            }
+        });
+
+        it("should narrow correctly on failure check", () => {
+            const result: SessionActionResult<number> = actionFail(
+                SessionRejectReason.SESSION_ENDED,
+            );
+
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (!result.ok) {
+                const reason: SessionRejectReason = result.reason;
+                assert.strictEqual(reason, "session_ended");
+            } else {
+                assert.fail("Expected failure result");
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Session Architecture Redesign — Phase 6 of 8

### What
Add a typed result type for session actions and create clean API methods on Session so commands become thin callers.

### New File: `src/structures/session_action_result.ts`
```typescript
type SessionActionResult<T = void> =
  | { ok: true; value: T }
  | { ok: false; reason: string };
```
Plus helper constructors: `actionOk()`, `actionOkVoid()`, `actionFail()`

### New Session Methods

**`processSkipVote(userID, messageContext)`** → `SessionActionResult<{ skipAchieved, skipCount, skipThreshold }>`
- State machine guard: rejects if `!isAcceptingInput`
- Calls `round.userSkipped()` and checks majority
- Returns typed result with all info the command needs

**`forceSkip(messageContext)`** → `SessionActionResult`
- Sets `round.skipAchieved = true`
- Calls `endRound()` + `startRound()`
- State machine guards via lifecycle methods

### Why
Commands currently reach into `session.round` directly and call `session.endRound()`/`startRound()` themselves. This:
1. Couples commands to internal session state
2. Skips state machine guards
3. Makes it harder to add cross-cutting concerns (logging, events)

By moving this logic to Session, commands become thin callers that handle messaging only.

### Risk: Zero — purely additive
SkipCommand still works exactly as before. A follow-up can migrate it to use the new methods.

### Stack Order
```
  Phase 1 — Foundation
  Phase 2 — Enforce state machine
  Phase 3 — Consolidate mutex
  Phase 4 — Voice manager extraction
  Phase 5 — Scoreboard hardening
► Phase 6 (this PR) — Clean API surface (depends on Phase 3)
  Phase 7 — Event system + timer manager
  Phase 8 — Registry replaces State maps
```