### PR TITLE
 fix(session): prevent stale round from starting after bot is removed from VC

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,9 @@
 FROM mcr.microsoft.com/devcontainers/python:3.14-bookworm
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install -y nodejs && \
+    corepack enable && corepack prepare yarn@stable --activate
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
                 "ms-azuretools.vscode-docker",
                 "eamodio.gitlens",
                 "github.vscode-pull-request-github",
+                "anthropic.claude-code"
             ],
         },
     },

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -1076,7 +1076,6 @@ export default class GameSession extends Session {
             return;
         }
 
-
         // sets the round to null
         await super.endRound(false, messageContext);
 

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -134,6 +134,10 @@ export default class GameSession extends Session {
     /** Manages updating a message with current guessers with hidden enabled */
     private hiddenUpdateTimer: NodeJS.Timeout | null;
 
+    /** Set immediately when endSession is requested, before the mutex is acquired.
+     *  Allows startRoundCore to abort its between-round delay even while the mutex is held. */
+    private pendingEndSession = false;
+
     constructor(
         guildPreference: GuildPreference,
         textChannelID: string,
@@ -293,6 +297,7 @@ export default class GameSession extends Session {
      * @param endedDueToError - Whether the session ended due to an error
      */
     async endSession(reason: string, endedDueToError: boolean): Promise<void> {
+        this.pendingEndSession = true;
         const waitStart = Date.now();
         try {
             await this.lifecycleMutex.runExclusive(async () => {
@@ -1016,7 +1021,7 @@ export default class GameSession extends Session {
             );
         }
 
-        if (this.finished || this.round) {
+        if (this.finished || this.round || this.pendingEndSession) {
             return null;
         }
 
@@ -1062,6 +1067,15 @@ export default class GameSession extends Session {
         }
 
         round.finished = true;
+
+        if (this.pendingEndSession) {
+            // Session end was requested while we held the mutex — skip round scoring/messages
+            // and leave the state at ROUND_ACTIVE so endSession can transition directly to ENDING.
+            this.round = null;
+            this.stopGuessTimeout();
+            return;
+        }
+
 
         // sets the round to null
         await super.endRound(false, messageContext);


### PR DESCRIPTION
 When the bot was kicked from the voice channel mid-round, two async operations raced for the lifecycle mutex:

  1. The voice connection's "end" event fired, calling endRound() → endRoundCore()
  2. voiceChannelLeave fired, calling endSession()

  endRound consistently won the mutex because it was dispatched first. endRoundCore then called startRoundCore() while   
  still holding the mutex — and startRoundCore holds the mutex across a configurable between-round delay (e.g. 3s). By
  the time the delay elapsed and startRoundCore checked this.finished, endSession still hadn't run, so the check passed  
  and a new round started. endSession then got the mutex and tore down the live round (ROUND_ACTIVE → ENDING), producing
  the visible bug: the bot rejoined, played a song, then immediately ended the game.

  Fix: Introduce a pendingEndSession flag that is set synchronously in endSession() before acquiring the mutex, making   
  the intent to end visible to code running inside the mutex.
                                                                                                                         
  - endRoundCore now checks pendingEndSession after marking the round finished. If set, it does minimal cleanup          
  (this.round = null, stop timeout) and returns without calling super.endRound() — leaving the state machine at
  ROUND_ACTIVE rather than advancing it to BETWEEN_ROUNDS.                                                               
  - startRoundCore also checks pendingEndSession after its between-round delay as a second line of defence.
  - endSession then acquires the mutex and drives the correct direct transition: ROUND_ACTIVE → ENDING → ENDED. 