### PR TITLE
refactor: save better_audio files by actual YouTube ID

### DIFF
--- a/sql/procedures/030-create_kmq_data_tables_procedure.sql
+++ b/sql/procedures/030-create_kmq_data_tables_procedure.sql
@@ -33,7 +33,7 @@ BEGIN
 		dead,
 		daisuki_id
 	FROM expected_available_songs
-	INNER JOIN kmq.cached_song_duration ON expected_available_songs.link = kmq.cached_song_duration.vlink
+	INNER JOIN kmq.cached_song_duration ON kmq.cached_song_duration.vlink = COALESCE(expected_available_songs.better_audio_link, expected_available_songs.link)
 	LEFT JOIN kmq.not_downloaded ON expected_available_songs.link = kmq.not_downloaded.vlink
 	WHERE kmq.not_downloaded.vlink IS NULL
 	AND expected_available_songs.link NOT IN (SELECT vlink FROM kmq.dead_links);

--- a/src/commands/misc_commands/lookup.ts
+++ b/src/commands/misc_commands/lookup.ts
@@ -481,11 +481,15 @@ export default class LookupCommand implements BaseCommand {
             views = kmqSongEntry.views;
             publishDate = kmqSongEntry.publishDate;
 
+            // Duration is cached under the actual audio file ID, which may
+            // be the better_audio link rather than the original video ID.
+            const audioFileId = kmqSongEntry.betterAudioLink ?? videoID;
+
             const durationInSeconds = (
                 await dbContext.kmq
                     .selectFrom("cached_song_duration")
                     .select("duration")
-                    .where("vlink", "=", videoID)
+                    .where("vlink", "=", audioFileId)
                     .executeTakeFirst()
             )?.duration;
 

--- a/src/helpers/kmq_song_downloader.ts
+++ b/src/helpers/kmq_song_downloader.ts
@@ -98,8 +98,11 @@ export default class KmqSongDownloader {
             let songsToDownload = allSongs;
 
             if (songOverrides) {
-                songsToDownload = songsToDownload.filter((x) =>
-                    songOverrides.includes(x.youtubeLink),
+                songsToDownload = songsToDownload.filter(
+                    (x) =>
+                        songOverrides.includes(x.youtubeLink) ||
+                        (x.betterAudioLink !== null &&
+                            songOverrides.includes(x.betterAudioLink)),
                 );
             }
 
@@ -147,7 +150,10 @@ export default class KmqSongDownloader {
 
             logger.info(`Total songs in database: ${allSongs.length}`);
             songsToDownload = songsToDownload.filter(
-                (x) => !currentlyDownloadedFiles.has(`${x.youtubeLink}.ogg`),
+                (x) =>
+                    !currentlyDownloadedFiles.has(
+                        `${x.betterAudioLink ?? x.youtubeLink}.ogg`,
+                    ) && !currentlyDownloadedFiles.has(`${x.youtubeLink}.ogg`),
             );
 
             songsToDownload = songsToDownload.filter(
@@ -201,30 +207,32 @@ export default class KmqSongDownloader {
                         );
                     }
 
-                    const cachedSongLocation = path.join(
-                        process.env.SONG_DOWNLOAD_DIR as string,
-                        `${song.youtubeLink}.m4a`,
-                    );
-
+                    let downloadedId: string;
                     try {
                         if (process.env.MOCK_AUDIO === "true") {
+                            downloadedId =
+                                song.betterAudioLink ?? song.youtubeLink;
+
                             logger.info(
-                                `Mocking downloading for ${song.youtubeLink}`,
+                                `Mocking downloading for ${downloadedId}`,
                             );
 
                             await fs.promises.copyFile(
                                 path.resolve(__dirname, "../test/silence.m4a"),
-                                cachedSongLocation,
+                                path.join(
+                                    process.env.SONG_DOWNLOAD_DIR as string,
+                                    `${downloadedId}.m4a`,
+                                ),
                             );
                         } else {
                             try {
-                                await this.downloadYouTubeAudioWithFallback(
-                                    db,
-                                    song.youtubeLink,
-                                    song.betterAudioLink,
-                                    cachedSongLocation,
-                                    proxy,
-                                );
+                                downloadedId =
+                                    await this.downloadYouTubeAudioWithFallback(
+                                        db,
+                                        song.youtubeLink,
+                                        song.betterAudioLink,
+                                        proxy,
+                                    );
                             } catch (e) {
                                 throw new Error(
                                     `Failed to download video for '${song.youtubeLink}'. error = ${e}`,
@@ -240,13 +248,19 @@ export default class KmqSongDownloader {
                     }
 
                     logger.info(
-                        `Encoding song: '${song.songName}' by ${song.artistName} | ${song.youtubeLink}`,
+                        `Encoding song: '${song.songName}' by ${song.artistName} | ${downloadedId}`,
                     );
                     try {
-                        await this.encodeToOpus(cachedSongLocation, db);
+                        await this.encodeToOpus(
+                            path.join(
+                                process.env.SONG_DOWNLOAD_DIR as string,
+                                `${downloadedId}.m4a`,
+                            ),
+                            db,
+                        );
                     } catch (err) {
                         logger.error(
-                            `Error encoding song ${song.youtubeLink}, exiting... err = ${err}`,
+                            `Error encoding song ${downloadedId}, exiting... err = ${err}`,
                         );
                         break;
                     }
@@ -493,22 +507,33 @@ export default class KmqSongDownloader {
         }
     }
 
+    /**
+     * Downloads audio, preferring the better audio link if available.
+     * Files are saved under the actual downloaded YouTube ID so that
+     * filenames on disk reflect the real audio source.
+     * @returns the YouTube ID that was actually downloaded
+     */
     private async downloadYouTubeAudioWithFallback(
         db: DatabaseContext,
         videoId: string,
         videoIdBetterAudio: string | null,
-        outputFile: string,
         proxy: string | undefined,
-    ): Promise<void> {
+    ): Promise<string> {
+        const downloadDir = process.env.SONG_DOWNLOAD_DIR as string;
         if (videoIdBetterAudio) {
             try {
+                const outputFile = path.join(
+                    downloadDir,
+                    `${videoIdBetterAudio}.m4a`,
+                );
+
                 await this.downloadYouTubeAudio(
                     db,
                     videoIdBetterAudio,
                     outputFile,
                     proxy,
                 );
-                return;
+                return videoIdBetterAudio;
             } catch (e) {
                 logger.warn(
                     `Failed to download better audio link ${videoIdBetterAudio}, falling back to main link ${videoId}. err = ${e}`,
@@ -516,7 +541,9 @@ export default class KmqSongDownloader {
             }
         }
 
+        const outputFile = path.join(downloadDir, `${videoId}.m4a`);
         await this.downloadYouTubeAudio(db, videoId, outputFile, proxy);
+        return videoId;
     }
 
     private async downloadYouTubeAudio(
@@ -599,6 +626,7 @@ export default class KmqSongDownloader {
             views: number;
             artistName: string;
             youtubeLink: string;
+            betterAudioLink: string | null;
         }>,
     ): Promise<void> {
         // update list of non-downloaded songs
@@ -607,7 +635,10 @@ export default class KmqSongDownloader {
 
         const songIDsNotDownloaded = songs
             .filter(
-                (x) => !currentlyDownloadedFiles.has(`${x.youtubeLink}.ogg`),
+                (x) =>
+                    !currentlyDownloadedFiles.has(
+                        `${x.betterAudioLink ?? x.youtubeLink}.ogg`,
+                    ) && !currentlyDownloadedFiles.has(`${x.youtubeLink}.ogg`),
             )
             .map((x) => ({ vlink: x.youtubeLink }));
 

--- a/src/helpers/kmq_song_downloader.ts
+++ b/src/helpers/kmq_song_downloader.ts
@@ -511,6 +511,10 @@ export default class KmqSongDownloader {
      * Downloads audio, preferring the better audio link if available.
      * Files are saved under the actual downloaded YouTube ID so that
      * filenames on disk reflect the real audio source.
+     * @param db - The database context
+     * @param videoId - The original video ID
+     * @param videoIdBetterAudio - The better audio video ID, if any
+     * @param proxy - Optional proxy to use for downloading
      * @returns the YouTube ID that was actually downloaded
      */
     private async downloadYouTubeAudioWithFallback(

--- a/src/scripts/remove-dangling-songs.ts
+++ b/src/scripts/remove-dangling-songs.ts
@@ -19,8 +19,13 @@ const program = new Command().option("--delete", "Delete the songs");
     const options = program.opts();
     const db = getNewConnection();
     const availableSongs = (
-        await db.kmq.selectFrom("available_songs").select("link").execute()
-    ).map((x) => x["link"]);
+        await db.kmq
+            .selectFrom("available_songs")
+            .select(["link", "better_audio_link"])
+            .execute()
+    ).flatMap((x) =>
+        x.better_audio_link ? [x.link, x.better_audio_link] : [x.link],
+    );
 
     const downloadedSongs = (
         await fs.promises.readdir(process.env.SONG_DOWNLOAD_DIR as string)

--- a/src/seed/seed_db.ts
+++ b/src/seed/seed_db.ts
@@ -602,14 +602,18 @@ async function checkModifiedBetterAudioLinks(
 
     for (const songToDelete of invalidatedBetterAudioToDelete) {
         logger.info(`Deleting old better audio for ${songToDelete}`);
+
+        // File is now saved under the actual audio ID (better_audio or original)
+        const oldBetterAudioLink = oldBetterAudioMapping[songToDelete];
+        const audioFileId = oldBetterAudioLink ?? songToDelete;
         const songAudioPath = path.resolve(
             process.env.SONG_DOWNLOAD_DIR!,
-            `${songToDelete}.ogg`,
+            `${audioFileId}.ogg`,
         );
 
         await db.kmq
             .deleteFrom("cached_song_duration")
-            .where("vlink", "=", songToDelete)
+            .where("vlink", "=", audioFileId)
             .execute();
 
         if (await pathExists(songAudioPath)) {

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -29,6 +29,7 @@ import {
     extractErrorString,
     friendlyFormattedNumber,
     getMention,
+    pathExistsSync,
     truncatedString,
     underline,
 } from "../helpers/utils";
@@ -801,17 +802,22 @@ export default abstract class Session extends EventEmitter {
             return false;
         }
 
-        let songLocation = `${process.env.SONG_DOWNLOAD_DIR}/${round.song.youtubeLink}.ogg`;
+        let songLocation = Session.resolveSongAudioPath(round.song);
 
         const seekType = this.isListeningSession()
             ? SeekType.BEGINNING
             : this.guildPreference.gameOptions.seekType;
 
+        // Duration is cached under the actual audio file ID, which may
+        // be the better_audio link rather than the original video ID.
+        const audioFileId =
+            round.song.betterAudioLink ?? round.song.youtubeLink;
+
         let songDuration = (
             await dbContext.kmq
                 .selectFrom("cached_song_duration")
                 .select(["duration"])
-                .where("vlink", "=", round.song.youtubeLink)
+                .where("vlink", "=", audioFileId)
                 .executeTakeFirst()
         )?.duration;
 
@@ -1303,6 +1309,27 @@ export default abstract class Session extends EventEmitter {
      */
     private getDebugSongDetails(round: Round): string {
         return `${round.song.songName}:${round.song.artistName}:${round.song.youtubeLink}`;
+    }
+
+    /**
+     * Resolves the audio file path for a song, preferring the better_audio file.
+     * Files are saved by their actual YouTube ID, so a song with betterAudioLink
+     * will have its file named after the betterAudioLink ID.
+     */
+    private static resolveSongAudioPath(song: QueriedSong): string {
+        const dir = process.env.SONG_DOWNLOAD_DIR!;
+        if (song.betterAudioLink) {
+            const betterPath = `${dir}/${song.betterAudioLink}.ogg`;
+            if (pathExistsSync(betterPath)) {
+                return betterPath;
+            }
+
+            logger.warn(
+                `Better audio file missing for ${song.youtubeLink} (expected ${song.betterAudioLink}.ogg), falling back to original`,
+            );
+        }
+
+        return `${dir}/${song.youtubeLink}.ogg`;
     }
 
     private getDurationFooter(

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -1315,6 +1315,8 @@ export default abstract class Session extends EventEmitter {
      * Resolves the audio file path for a song, preferring the better_audio file.
      * Files are saved by their actual YouTube ID, so a song with betterAudioLink
      * will have its file named after the betterAudioLink ID.
+     * @param song - The queried song to resolve the audio path for
+     * @returns the resolved file path to the song's audio
      */
     private static resolveSongAudioPath(song: QueriedSong): string {
         const dir = process.env.SONG_DOWNLOAD_DIR!;


### PR DESCRIPTION
## Problem

Songs with a `better_audio_link` were downloaded from the better audio source but saved under the **original** video's YouTube ID. This hid which video the audio actually came from — if better_audio download silently failed and fell back, or if the mapping changed, the filename told you nothing about what was really inside the `.ogg` file.

## Solution

Save files under the ID of the video that was **actually downloaded**. At playback time, resolve the correct file with a fallback chain.

## Changes (6 files)

| File | Change |
|------|--------|
| `kmq_song_downloader.ts` | `downloadYouTubeAudioWithFallback` returns the downloaded ID, files saved as `{downloadedId}.m4a/.ogg`, is-downloaded + not_downloaded + songOverrides checks match either ID |
| `session.ts` | New `resolveSongAudioPath()` resolves better_audio file on disk with fallback to original, `cached_song_duration` lookup uses `audioFileId` |
| `seed_db.ts` | `checkModifiedBetterAudioLinks` deletes/renames files by the old better_audio ID |
| `lookup.ts` | Duration lookup resolves via `betterAudioLink` — users see correct duration without any awareness of better_audio |
| `remove-dangling-songs.ts` | Collects both `link` and `better_audio_link` as valid filenames to prevent false deletions |
| `procedure 030` | `cached_song_duration` JOIN uses `COALESCE(better_audio_link, link)` |

## Deployment note

Existing songs on disk are named by the original ID. After deploying, either:
1. Run a one-time migration script to rename files, or
2. Let the next full re-download align filenames naturally

New downloads will use the correct naming immediately. The playback fallback in `resolveSongAudioPath()` handles the transition period gracefully — it checks for the better_audio file first, falls back to the original filename if missing.