### PR TITLE
Activity: game-type selection (classic/sudden death/elimination/clip)

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -281,11 +281,19 @@ function RoundTimer({
 
 function Scoreboard({
     scoreboard,
+    gameType,
+    selfID,
     t,
 }: {
     scoreboard: ActivityScoreboardSnapshot;
+    gameType: string | null;
+    selfID: string | null;
     t: Translator;
 }) {
+    // In elimination, a player's "score" is their remaining lives; keep
+    // out-of-lives players visible (so they read as eliminated) as long as
+    // they're still in the channel.
+    const isElimination = gameType === "elimination";
     const sorted = [...scoreboard.players]
         .filter((p) => p.score > 0 || p.inVC)
         .sort((a, b) => b.score - a.score);
@@ -296,37 +304,56 @@ function Scoreboard({
 
     return (
         <ol className="scoreboard">
-            {sorted.map((p, i) => (
-                <li
-                    key={p.id}
-                    className={
-                        scoreboard.winnerIDs.includes(p.id) ? "winner" : ""
-                    }
-                >
-                    <span className="rank">#{i + 1}</span>
-                    {p.avatarUrl && (
-                        <img
-                            className="avatar"
-                            src={p.avatarUrl}
-                            alt=""
-                            width={24}
-                            height={24}
-                        />
-                    )}
-                    <span className="name">
-                        {p.username}
-                        {!p.inVC && (
-                            <span className="afk"> {t("scoreboardLeft")}</span>
+            {sorted.map((p, i) => {
+                const eliminated = isElimination && p.score === 0;
+                return (
+                    <li
+                        key={p.id}
+                        className={[
+                            scoreboard.winnerIDs.includes(p.id) ? "winner" : "",
+                            p.id === selfID ? "self" : "",
+                            eliminated ? "eliminated" : "",
+                        ]
+                            .filter(Boolean)
+                            .join(" ")}
+                    >
+                        <span className="rank">#{i + 1}</span>
+                        {p.avatarUrl && (
+                            <img
+                                className="avatar"
+                                src={p.avatarUrl}
+                                alt=""
+                                width={24}
+                                height={24}
+                            />
                         )}
-                    </span>
-                    <span className="score">{p.score}</span>
-                    {p.expGain > 0 && (
-                        <span className="exp">
-                            {t("scoreboardExpGain", { exp: p.expGain })}
+                        <span className="name">
+                            {p.username}
+                            {!p.inVC && (
+                                <span className="afk">
+                                    {" "}
+                                    {t("scoreboardLeft")}
+                                </span>
+                            )}
                         </span>
-                    )}
-                </li>
-            ))}
+                        {isElimination ? (
+                            <span
+                                className="score lives"
+                                title={t("gameType.lives")}
+                            >
+                                {eliminated ? "☠️" : `♥ ${p.score}`}
+                            </span>
+                        ) : (
+                            <span className="score">{p.score}</span>
+                        )}
+                        {p.expGain > 0 && (
+                            <span className="exp">
+                                {t("scoreboardExpGain", { exp: p.expGain })}
+                            </span>
+                        )}
+                    </li>
+                );
+            })}
         </ol>
     );
 }
@@ -2808,6 +2835,28 @@ export default function App() {
                                     {t("appTitle")}{" "}
                                     <span className="logo-heart">♥</span>
                                 </h1>
+                                {ui.session?.gameType === "elimination" &&
+                                    authState &&
+                                    (() => {
+                                        // Surface the current player's own
+                                        // remaining lives prominently in the
+                                        // header for the duration of the game.
+                                        const me = ui.scoreboard?.players.find(
+                                            (p) => p.id === authState.userID,
+                                        );
+                                        if (!me) return null;
+                                        const out = me.score === 0;
+                                        return (
+                                            <span
+                                                className={`lives-badge ${
+                                                    out ? "out" : ""
+                                                }`}
+                                                title={t("gameType.lives")}
+                                            >
+                                                {out ? "☠️" : `♥ ${me.score}`}
+                                            </span>
+                                        );
+                                    })()}
                                 {ui.session &&
                                     (() => {
                                         const completed =
@@ -3113,7 +3162,12 @@ export default function App() {
                     </div>
                     <div className="sidebar-body">
                         {ui.scoreboard ? (
-                            <Scoreboard scoreboard={ui.scoreboard} t={t} />
+                            <Scoreboard
+                                scoreboard={ui.scoreboard}
+                                gameType={ui.session?.gameType ?? null}
+                                selfID={authState?.userID ?? null}
+                                t={t}
+                            />
                         ) : (
                             <p className="empty">{t("scoreboardEmpty")}</p>
                         )}

--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -43,7 +43,11 @@ import type {
     ActivitySubunits,
 } from "./types/activity_options_snapshot";
 import type ActivityOptionsSnapshot from "./types/activity_options_snapshot";
-import type { SetOptionRequest } from "./api";
+import type {
+    ActivityGameType,
+    SetOptionRequest,
+    StartGameOptions,
+} from "./api";
 import type { Translator } from "./i18n/translator";
 import type ActivityEvent from "./types/activity_event";
 import type ActivityRoundMeta from "./types/activity_round_meta";
@@ -585,6 +589,11 @@ function ControlButtons({
 }) {
     const [busy, setBusy] = useState<null | "start" | "end">(null);
     const [feedback, setFeedback] = useState<string | null>(null);
+    const [gameType, setGameType] = useState<ActivityGameType>("classic");
+    const [lives, setLives] = useState(String(ELIMINATION_DEFAULT_LIVES));
+    const [clipDuration, setClipDuration] = useState(
+        String(CLIP_DEFAULT_DURATION_SEC),
+    );
 
     // Auto-clear the action feedback so a stale message (e.g. "join the voice
     // channel first" after the user has since joined) doesn't linger and look
@@ -612,23 +621,94 @@ function ControlButtons({
         }
     };
 
+    const buildStartOptions = (): StartGameOptions => {
+        const options: StartGameOptions = { gameType };
+        if (gameType === "elimination") {
+            const n = Math.round(Number(lives));
+            options.eliminationLives =
+                Number.isFinite(n) && n >= 1 && n <= ELIMINATION_MAX_LIVES
+                    ? n
+                    : ELIMINATION_DEFAULT_LIVES;
+        } else if (gameType === "clip") {
+            const n = Number(clipDuration);
+            options.clipDuration =
+                Number.isFinite(n) &&
+                n >= CLIP_MIN_DURATION_SEC &&
+                n <= CLIP_MAX_DURATION_SEC
+                    ? n
+                    : CLIP_DEFAULT_DURATION_SEC;
+        }
+
+        return options;
+    };
+
     return (
         <div className="control-buttons">
             {!hasSession && (
-                <button
-                    type="button"
-                    className="primary"
-                    disabled={busy !== null}
-                    onClick={() =>
-                        run("start", () =>
-                            apiStartGame(accessToken, instanceId),
-                        )
-                    }
-                >
-                    {busy === "start"
-                        ? t("startGameBusy")
-                        : t("startGameButton")}
-                </button>
+                <div className="start-config">
+                    <div className="pills start-game-types">
+                        {GAME_TYPE_OPTIONS.map((gt) => (
+                            <button
+                                key={gt}
+                                type="button"
+                                className={`pill ${
+                                    gameType === gt ? "on" : ""
+                                }`}
+                                disabled={busy !== null}
+                                onClick={() => setGameType(gt)}
+                            >
+                                {t(`gameType.${gt}`)}
+                            </button>
+                        ))}
+                    </div>
+                    {gameType === "elimination" && (
+                        <label className="start-param">
+                            <span>{t("gameType.lives")}</span>
+                            <input
+                                type="number"
+                                className="option-number"
+                                min={1}
+                                max={ELIMINATION_MAX_LIVES}
+                                value={lives}
+                                onChange={(e) => setLives(e.target.value)}
+                            />
+                        </label>
+                    )}
+                    {gameType === "clip" && (
+                        <label className="start-param">
+                            <span>{t("gameType.clipDuration")}</span>
+                            <input
+                                type="number"
+                                className="option-number"
+                                min={CLIP_MIN_DURATION_SEC}
+                                max={CLIP_MAX_DURATION_SEC}
+                                step={0.25}
+                                value={clipDuration}
+                                onChange={(e) =>
+                                    setClipDuration(e.target.value)
+                                }
+                            />
+                        </label>
+                    )}
+                    <button
+                        type="button"
+                        className="primary"
+                        disabled={busy !== null}
+                        onClick={() =>
+                            run("start", () =>
+                                apiStartGame(
+                                    accessToken,
+                                    instanceId,
+                                    buildStartOptions(),
+                                ),
+                            )
+                        }
+                    >
+                        {busy === "start"
+                            ? t("startGameBusy")
+                            : t("startGameButton")}
+                    </button>
+                </div>
             )}
             {hasSession && (
                 <button
@@ -1158,6 +1238,20 @@ const SPECIAL_OPTIONS: (ActivitySpecial | null)[] = [
     "highpitch",
     "nightcore",
 ];
+
+// Game types selectable from the Activity start screen. Mirrors the server's
+// ACTIVITY_GAME_TYPES (teams/competition excluded). Bounds mirror src/constants.
+const GAME_TYPE_OPTIONS: ActivityGameType[] = [
+    "classic",
+    "suddendeath",
+    "elimination",
+    "clip",
+];
+const ELIMINATION_DEFAULT_LIVES = 10;
+const ELIMINATION_MAX_LIVES = 10000;
+const CLIP_DEFAULT_DURATION_SEC = 1;
+const CLIP_MIN_DURATION_SEC = 0.25;
+const CLIP_MAX_DURATION_SEC = 5;
 
 /**
  * An option's heading plus an optional ⓘ that reveals a short explanation

--- a/activity/src/api.ts
+++ b/activity/src/api.ts
@@ -118,6 +118,7 @@ async function postAction(
     accessToken: string,
     instanceId: string,
     path: "start" | "skip" | "end" | "hint",
+    extra?: Record<string, unknown>,
 ): Promise<GuessResult> {
     const resp = await fetch(`${ACTIVITY_PROXY_BASE}/${path}`, {
         method: "POST",
@@ -125,7 +126,7 @@ async function postAction(
             "Content-Type": "application/json",
             Authorization: `Bearer ${accessToken}`,
         },
-        body: JSON.stringify({ instance_id: instanceId }),
+        body: JSON.stringify({ instance_id: instanceId, ...extra }),
     });
 
     if (resp.ok) return { ok: true };
@@ -143,8 +144,27 @@ async function postAction(
     return { ok: false, reason: parsed.error ?? "internal" };
 }
 
-export const startGame = (accessToken: string, instanceId: string) =>
-    postAction(accessToken, instanceId, "start");
+// Game types the Activity can start (teams/competition are excluded — see
+// ACTIVITY_GAME_TYPES server-side).
+export type ActivityGameType =
+    | "classic"
+    | "suddendeath"
+    | "elimination"
+    | "clip";
+
+export interface StartGameOptions {
+    gameType: ActivityGameType;
+    /** Required for elimination; ignored otherwise. */
+    eliminationLives?: number;
+    /** Required for clip; ignored otherwise. */
+    clipDuration?: number;
+}
+
+export const startGame = (
+    accessToken: string,
+    instanceId: string,
+    options: StartGameOptions,
+) => postAction(accessToken, instanceId, "start", { ...options });
 
 export const skipVote = (accessToken: string, instanceId: string) =>
     postAction(accessToken, instanceId, "skip");

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -466,6 +466,43 @@ body::before {
     font-size: 0.85rem;
 }
 
+/* ---- START-GAME CONFIG (game type + params) ---- */
+.start-config {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+}
+
+.start-game-types {
+    margin-bottom: 0;
+}
+
+/* The generic `.control-buttons button` rule (bigger padding, transparent
+   border) would clobber the pill look; re-assert the pill specifics with a
+   higher-specificity selector. */
+.start-config .pill {
+    padding: 4px 12px;
+    font-size: 0.73rem;
+    border: 1px solid var(--border);
+}
+
+.start-config .pill.on {
+    border-color: var(--red-primary);
+}
+
+.start-param {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.76rem;
+    font-weight: 600;
+}
+
+.start-param .option-number {
+    width: 96px;
+}
+
 /* ---- ROUND AREA (card) ---- */
 .round-area {
     background: var(--bg-surface);

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -392,6 +392,30 @@ body::before {
     color: var(--text-secondary);
 }
 
+/* Current player's remaining lives, shown prominently next to the title in
+   elimination games. */
+.lives-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: var(--red-light);
+    color: var(--red-primary);
+    border: 1px solid var(--red-primary);
+    padding: 3px 10px;
+    border-radius: var(--radius-pill);
+    font-size: 0.95rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    box-shadow: var(--shadow-sm);
+    white-space: nowrap;
+}
+
+.lives-badge.out {
+    background: var(--bg-surface);
+    color: var(--text-tertiary);
+    border-color: var(--border);
+}
+
 .meta-pill {
     background: var(--bg-surface);
     border: 1px solid var(--border);
@@ -1392,6 +1416,31 @@ body::before {
     font-size: 0.72rem;
     color: var(--pink);
     font-weight: 600;
+}
+
+/* Highlight the viewing player's own row. */
+.scoreboard li.self {
+    outline: 2px solid var(--red-primary);
+    outline-offset: -2px;
+}
+
+/* Lives readout (elimination mode) — the heart is the cue, so make it red. */
+.scoreboard .score.lives {
+    color: var(--red-primary);
+    white-space: nowrap;
+}
+
+/* Players who've run out of lives read as dimmed/struck-through. */
+.scoreboard li.eliminated {
+    opacity: 0.55;
+}
+
+.scoreboard li.eliminated .name {
+    text-decoration: line-through;
+}
+
+.scoreboard li.eliminated .score.lives {
+    color: var(--text-tertiary);
 }
 
 /* ---- SIDEBAR OPTIONS PANEL ---- */

--- a/activity/src/types/activity_session_meta.ts
+++ b/activity/src/types/activity_session_meta.ts
@@ -3,7 +3,8 @@ export default interface ActivitySessionMeta {
     voiceChannelID: string;
     textChannelID: string;
     startedAt: number;
-    gameType: number;
+    /** Server-side GameType string, e.g. "classic" | "elimination" | "clip". */
+    gameType: string;
     roundsPlayed: number;
     correctGuesses: number;
     ownerID: string;

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -31,6 +31,14 @@
         "connectFailed": "Konnte keine Verbindung zu KMQ herstellen. Bitte versuche es erneut.",
         "endGameBusy": "Wird beendet…",
         "endGameButton": "Spiel beenden",
+        "gameType": {
+            "classic": "Klassisch",
+            "clip": "Klammer",
+            "clipDuration": "Cliplänge (Sekunden)",
+            "elimination": "Beseitigung",
+            "lives": "Leben",
+            "suddendeath": "Plötzlicher Tod"
+        },
         "guessButton": "Raten",
         "guessPlaceholderActive": "Gib deine Vermutung ein…",
         "guessPlaceholderWaiting": "Warten auf Runde…",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -31,6 +31,14 @@
         "connectFailed": "Couldn't connect to KMQ. Please try again.",
         "endGameBusy": "Ending...",
         "endGameButton": "End game",
+        "gameType": {
+            "classic": "Classic",
+            "clip": "Clip",
+            "clipDuration": "Clip length (seconds)",
+            "elimination": "Elimination",
+            "lives": "Lives",
+            "suddendeath": "Sudden Death"
+        },
         "guessButton": "Guess",
         "guessPlaceholderActive": "Type your guess...",
         "guessPlaceholderWaiting": "Waiting for round...",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -31,6 +31,14 @@
         "connectFailed": "No se pudo conectar a KMQ. Por favor, inténtalo de nuevo.",
         "endGameBusy": "Finalizando…",
         "endGameButton": "Finalizar partida",
+        "gameType": {
+            "classic": "Clásico",
+            "clip": "Clip",
+            "clipDuration": "Duración del clip (segundos)",
+            "elimination": "Eliminación",
+            "lives": "Vidas",
+            "suddendeath": "Muerte súbita"
+        },
         "guessButton": "Adivinar",
         "guessPlaceholderActive": "Escribe tu respuesta…",
         "guessPlaceholderWaiting": "Esperando ronda…",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -31,6 +31,14 @@
         "connectFailed": "Impossible de se connecter à KMQ. Veuillez réessayer.",
         "endGameBusy": "Fin en cours…",
         "endGameButton": "Terminer la partie",
+        "gameType": {
+            "classic": "Classique",
+            "clip": "Clip",
+            "clipDuration": "Longueur du clip (secondes)",
+            "elimination": "Élimination",
+            "lives": "Vies",
+            "suddendeath": "Mort subite"
+        },
         "guessButton": "Deviner",
         "guessPlaceholderActive": "Entrez votre réponse…",
         "guessPlaceholderWaiting": "En attente du tour…",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -31,6 +31,14 @@
         "connectFailed": "KMQ से कनेक्ट नहीं हो सका। कृपया फिर से प्रयास करें।",
         "endGameBusy": "समाप्त हो रहा है…",
         "endGameButton": "खेल समाप्त करें",
+        "gameType": {
+            "classic": "क्लासिक",
+            "clip": "क्लिप",
+            "clipDuration": "क्लिप लंबाई (सेकंड)",
+            "elimination": "बहिष्कार",
+            "lives": "जिंदगियाँ",
+            "suddendeath": "अचानक मृत्यु"
+        },
         "guessButton": "अनुमान लगाएँ",
         "guessPlaceholderActive": "अपना अनुमान लिखें…",
         "guessPlaceholderWaiting": "राउंड का इंतज़ार है…",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -31,6 +31,14 @@
         "connectFailed": "Tidak dapat terhubung ke KMQ. Silakan coba lagi.",
         "endGameBusy": "Mengakhiri…",
         "endGameButton": "Akhiri permainan",
+        "gameType": {
+            "classic": "Klasik",
+            "clip": "Klip",
+            "clipDuration": "Panjang klip (detik)",
+            "elimination": "Eliminasi",
+            "lives": "Nyawa",
+            "suddendeath": "Kematian Mendadak"
+        },
         "guessButton": "Tebak",
         "guessPlaceholderActive": "Ketik tebakanmu…",
         "guessPlaceholderWaiting": "Menunggu ronde…",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -31,6 +31,14 @@
         "connectFailed": "KMQに接続できませんでした。もう一度お試しください。",
         "endGameBusy": "終了中…",
         "endGameButton": "ゲーム終了",
+        "gameType": {
+            "classic": "クラシック",
+            "clip": "クリップ",
+            "clipDuration": "クリップの長さ (秒)",
+            "elimination": "排除",
+            "lives": "ライフ",
+            "suddendeath": "サドンデス"
+        },
         "guessButton": "回答",
         "guessPlaceholderActive": "回答を入力…",
         "guessPlaceholderWaiting": "ラウンド待機中…",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -31,6 +31,14 @@
         "connectFailed": "KMQ에 연결할 수 없습니다. 다시 시도해 주세요.",
         "endGameBusy": "종료 중…",
         "endGameButton": "게임 종료",
+        "gameType": {
+            "classic": "클래식",
+            "clip": "클립",
+            "clipDuration": "클립 길이 (초)",
+            "elimination": "제거",
+            "lives": "목숨",
+            "suddendeath": "갑작스러운 죽음"
+        },
         "guessButton": "정답",
         "guessPlaceholderActive": "정답을 입력하세요…",
         "guessPlaceholderWaiting": "라운드 대기 중…",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -31,6 +31,14 @@
         "connectFailed": "Kon geen verbinding maken met KMQ. Probeer het opnieuw.",
         "endGameBusy": "Beëindigen…",
         "endGameButton": "Spel beëindigen",
+        "gameType": {
+            "classic": "Klassiek",
+            "clip": "Clip",
+            "clipDuration": "Cliplengte (seconden)",
+            "elimination": "Eliminatie",
+            "lives": "Levens",
+            "suddendeath": "Plotse Dood"
+        },
         "guessButton": "Raden",
         "guessPlaceholderActive": "Typ je antwoord…",
         "guessPlaceholderWaiting": "Wachten op ronde…",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -31,6 +31,14 @@
         "connectFailed": "Não foi possível conectar ao KMQ. Por favor, tente novamente.",
         "endGameBusy": "Encerrando…",
         "endGameButton": "Encerrar jogo",
+        "gameType": {
+            "classic": "Clássico",
+            "clip": "Clipe",
+            "clipDuration": "Duração do clipe (segundos)",
+            "elimination": "Eliminação",
+            "lives": "Vidas",
+            "suddendeath": "Morte Súbita"
+        },
         "guessButton": "Palpitar",
         "guessPlaceholderActive": "Digite seu palpite…",
         "guessPlaceholderWaiting": "Aguardando rodada…",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -31,6 +31,14 @@
         "connectFailed": "Не удалось подключиться к KMQ. Пожалуйста, попробуйте снова.",
         "endGameBusy": "Завершение…",
         "endGameButton": "Завершить игру",
+        "gameType": {
+            "classic": "Классический",
+            "clip": "Клип",
+            "clipDuration": "Длина клипа (в секундах)",
+            "elimination": "Устранение",
+            "lives": "Жизни",
+            "suddendeath": "Внезапная смерть"
+        },
         "guessButton": "Ответить",
         "guessPlaceholderActive": "Введите ответ…",
         "guessPlaceholderWaiting": "Ожидание раунда…",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -31,6 +31,14 @@
         "connectFailed": "无法连接到KMQ。请再试一次。",
         "endGameBusy": "正在结束…",
         "endGameButton": "结束游戏",
+        "gameType": {
+            "classic": "经典",
+            "clip": "剪辑",
+            "clipDuration": "剪辑长度（秒）",
+            "elimination": "淘汰",
+            "lives": "生命",
+            "suddendeath": "猝死"
+        },
         "guessButton": "猜",
         "guessPlaceholderActive": "输入你的答案…",
         "guessPlaceholderWaiting": "等待回合…",

--- a/src/interfaces/activity_start_game_args.ts
+++ b/src/interfaces/activity_start_game_args.ts
@@ -1,6 +1,15 @@
+import type GameType from "../enums/game_type";
+
 export default interface ActivityStartGameArgs {
     guildID: string;
     userID: string;
     voiceChannelID: string;
     textChannelID: string;
+    /** Defaults to CLASSIC. Restricted server-side to the Activity-supported
+     *  subset (classic / suddendeath / elimination / clip). */
+    gameType: GameType;
+    /** Lives per player for elimination mode; ignored otherwise. */
+    eliminationLives?: number;
+    /** Clip length in seconds for clip mode; ignored otherwise. */
+    clipDuration?: number;
 }

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -11,11 +11,16 @@ import {
     ACTIVITY_RATE_LIMIT_TOKEN,
     ACTIVITY_WS_HEARTBEAT_INTERVAL_MS,
     ACTIVITY_WS_TICKET_TTL_MS,
+    CLIP_DEFAULT_DURATION_SEC,
+    CLIP_MAX_DURATION_SEC,
+    CLIP_MIN_DURATION_SEC,
     DEFAULT_LOCALE,
     DISCORD_ACTIVITY_INSTANCE_URL,
     DISCORD_OAUTH_TOKEN_URL,
     DISCORD_USERS_ME_URL,
     EARLIEST_BEGINNING_SEARCH_YEAR,
+    ELIMINATION_DEFAULT_LIVES,
+    ELIMINATION_MAX_LIVES,
 } from "./constants";
 import { IPCLogger } from "./logger";
 import { availableGenders } from "./enums/option_types/gender";
@@ -24,6 +29,7 @@ import { sql } from "kysely";
 import { userVoted } from "./helpers/bot_listing_manager";
 import AnswerType from "./enums/option_types/answer_type";
 import ArtistType from "./enums/option_types/artist_type";
+import GameType from "./enums/game_type";
 import GuessModeType from "./enums/option_types/guess_mode_type";
 import LanguageType from "./enums/option_types/language_type";
 import LocaleType from "./enums/locale_type";
@@ -165,6 +171,15 @@ const PRESET_ACTIONS: ReadonlySet<string> = new Set([
     "delete",
 ]);
 
+// Game types the Activity can start. Teams (needs a lobby) and competition
+// (moderator-gated) are intentionally excluded.
+const ACTIVITY_GAME_TYPES: ReadonlySet<string> = new Set([
+    GameType.CLASSIC,
+    GameType.SUDDEN_DEATH,
+    GameType.ELIMINATION,
+    GameType.CLIP,
+]);
+
 // Numeric bounds for the Activity options panel. Kept in sync with the
 // slash-command handlers (src/commands/game_options/{limit,timer,...}.ts);
 // validated server-side so a malicious client can't persist out-of-range
@@ -220,6 +235,12 @@ function nullableIntInRange(
 ): number | null | undefined {
     if (v === null) return null;
     return intInRange(v, min, max);
+}
+
+function floatInRange(v: unknown, min: number, max: number): number | null {
+    if (typeof v !== "number" || !Number.isFinite(v)) return null;
+    if (v < min || v > max) return null;
+    return v;
 }
 
 /**
@@ -1121,12 +1142,69 @@ export default class KmqWebServer {
                     return;
                 }
 
+                const startBody = (request.body ?? {}) as {
+                    gameType?: unknown;
+                    eliminationLives?: unknown;
+                    clipDuration?: unknown;
+                };
+
+                const rawType =
+                    typeof startBody.gameType === "string"
+                        ? startBody.gameType
+                        : GameType.CLASSIC;
+
+                if (!ACTIVITY_GAME_TYPES.has(rawType)) {
+                    await reply.code(400).send({ error: "Invalid game type" });
+                    return;
+                }
+
+                const gameType = rawType as GameType;
+
+                let eliminationLives: number | undefined;
+                if (gameType === GameType.ELIMINATION) {
+                    eliminationLives =
+                        startBody.eliminationLives === undefined
+                            ? ELIMINATION_DEFAULT_LIVES
+                            : (intInRange(
+                                  startBody.eliminationLives,
+                                  1,
+                                  ELIMINATION_MAX_LIVES,
+                              ) ?? undefined);
+
+                    if (eliminationLives === undefined) {
+                        await reply.code(400).send({ error: "Invalid lives" });
+                        return;
+                    }
+                }
+
+                let clipDuration: number | undefined;
+                if (gameType === GameType.CLIP) {
+                    clipDuration =
+                        startBody.clipDuration === undefined
+                            ? CLIP_DEFAULT_DURATION_SEC
+                            : (floatInRange(
+                                  startBody.clipDuration,
+                                  CLIP_MIN_DURATION_SEC,
+                                  CLIP_MAX_DURATION_SEC,
+                              ) ?? undefined);
+
+                    if (clipDuration === undefined) {
+                        await reply
+                            .code(400)
+                            .send({ error: "Invalid clip duration" });
+                        return;
+                    }
+                }
+
                 try {
                     const result = await this.activityHub!.startGame({
                         guildID: ctx.instance.guildID,
                         userID: ctx.user.id,
                         voiceChannelID: ctx.instance.channelID,
                         textChannelID: ctx.instance.channelID,
+                        gameType,
+                        eliminationLives,
+                        clipDuration,
                     });
 
                     if (!result.ok) {

--- a/src/structures/activity_bridge.ts
+++ b/src/structures/activity_bridge.ts
@@ -667,13 +667,26 @@ function ensureWorkerHandlerRegistered(): void {
                                 );
 
                             const gameOwner = new KmqMember(startArgs.userID);
+                            // Clip mode plays a fresh portion each round (the
+                            // slash command's default `new_clip` is false, but
+                            // for the lobby-less Activity a new song per round
+                            // matches every other mode's behaviour).
                             const gameSession = new GameSession(
                                 guildPreference,
                                 startArgs.textChannelID,
                                 startVoiceChannelID,
                                 startArgs.guildID,
                                 gameOwner,
-                                GameType.CLASSIC,
+                                startArgs.gameType,
+                                startArgs.gameType === GameType.ELIMINATION
+                                    ? startArgs.eliminationLives
+                                    : undefined,
+                                startArgs.gameType === GameType.CLIP
+                                    ? startArgs.clipDuration
+                                    : undefined,
+                                startArgs.gameType === GameType.CLIP
+                                    ? true
+                                    : undefined,
                             );
 
                             // Swap out any stale non-initialized session


### PR DESCRIPTION
The Activity could only start classic games. Adds a game-type selector to the pre-game start screen.

Server:
- `ActivityStartGameArgs` gains `gameType` + optional `eliminationLives` / `clipDuration`.
- `POST /api/activity/start` parses + validates them against the supported subset (`ACTIVITY_GAME_TYPES`) and the same bounds as the slash command (lives 1..10000, clip 0.25..5s).
- The bridge's `GameSession` construction uses the selected type and passes lives / clip duration (clip plays a fresh portion each round).

Client:
- Game-type pills (classic / sudden death / elimination / clip) on the start screen, with a lives input (elimination) and a clip-length input (clip) shown when relevant. Start posts the chosen options.

Excluded by design: **teams** (needs a pre-game lobby + team scoreboard — a standalone follow-up) and **competition** (moderator-gated).

i18n: `gameType.*` keys, propagated to all locales.