### PR TITLE
Pass BOT_CLIENT_ID build-arg to the prod Activity image build

### DIFF
--- a/.github/workflows/full-deploy.yml
+++ b/.github/workflows/full-deploy.yml
@@ -82,6 +82,12 @@ jobs:
                   file: docker/kmq/Dockerfile
                   push: true
                   platforms: linux/arm64
+                  # Vite bakes BOT_CLIENT_ID into the Activity bundle at build
+                  # time; without it the deployed Activity ships an empty client
+                  # ID and can't connect. BOT_CLIENT is the bot's application ID
+                  # (same mapping gci-e2e.yml uses: BOT_CLIENT_ID=$BOT_CLIENT).
+                  build-args: |
+                      BOT_CLIENT_ID=${{ secrets.BOT_CLIENT }}
                   tags: ${{ steps.app-version-parser.outputs.IMAGE_NAME }},ghcr.io/brainicism/kmq_discord:latest
 
     upgrade:

--- a/.github/workflows/upgrade-prod.yml
+++ b/.github/workflows/upgrade-prod.yml
@@ -30,7 +30,7 @@ jobs:
             - name: Redeploy over SSH
               run: ssh ${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_ADDRESS }} "source ~/.zshrc; ./.github/workflows/redeploy_prod.sh $KMQ_DIR ${{ inputs.image-name }}"
             - name: Wait for KMQ up
-              run: timeout 120 bash -c 'until curl -s -o /dev/null -w "%{http_code}" 127.0.0.1:5858/ping | grep -q "^200$"; do sleep 5; done' || { echo "KMQ did not return 200 within 1 minute"; exit 1; }
+              run: timeout 600 bash -c 'until curl -s -o /dev/null -w "%{http_code}" 127.0.0.1:5858/ping | grep -q "^200$"; do sleep 5; done' || { echo "KMQ did not return 200 within 10 minutes"; exit 1; }
             - name: Run basic options test
               run: ssh ${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_ADDRESS }} "docker exec kmq-prod sh -c '. ./.env && npx ts-node --swc src/test/end-to-end-tests/test-runner-bot.ts --test-suite=BASIC_OPTIONS --debug --stage-delay=5'"
             - name: Run basic gameplay test


### PR DESCRIPTION
This PR bundles two prod-deploy workflow fixes uncovered by the last `full-deploy`.

## 1. Pass `BOT_CLIENT_ID` to the Activity image build

### Problem
After a `full-deploy`, launching the Discord Activity failed at the connection step, and the reconnect button didn't recover it.

### Root cause
The Activity SPA reads the Discord client ID from `import.meta.env.BOT_CLIENT_ID`, which **Vite bakes into the bundle at build time** (`activity/vite.config.ts` widens `envPrefix` to include `BOT_CLIENT_ID`). `docker/kmq/Dockerfile` takes it as a build-arg:

```dockerfile
ARG BOT_CLIENT_ID=""
ENV BOT_CLIENT_ID=$BOT_CLIENT_ID
RUN cd activity && yarn install --frozen-lockfile && yarn build
```

`full-deploy.yml` never passed that build-arg, so the prod image built with the empty default. The shipped bundle had no client ID, so `activity/src/discordSdk.ts` rejected with *"BOT_CLIENT_ID is not configured"* before connecting — and reconnect just re-ran the same failing setup. The dev path works because `docker/docker-compose.yml` already forwards it.

### Fix
Forward the existing `BOT_CLIENT` secret (the bot's application ID) as the `BOT_CLIENT_ID` build-arg, matching the mapping `gci-e2e.yml` already uses (`BOT_CLIENT_ID=$BOT_CLIENT`). No value is hardcoded and no new secret is needed.

## 2. Increase the prod healthcheck timeout to 10 minutes

`upgrade-prod.yml`'s "Wait for KMQ up" step polls `127.0.0.1:5858/ping` after redeploy and failed the deploy if it didn't return `200` within `timeout 120` (2 minutes — the log message even mislabeled it as "1 minute"). Prod now needs longer than that to come up healthy after a redeploy, so the gate was tripping prematurely. Bumped to `timeout 600` (10 minutes) and corrected the message.

## After merge
Re-run **full-deploy** — the currently running image still has the empty client ID baked in, so it needs a fresh build to pick up fix #1.