### PR TITLE
Log whether a game was started via the Activity

### DIFF
--- a/src/structures/activity_bridge.ts
+++ b/src/structures/activity_bridge.ts
@@ -702,6 +702,7 @@ function ensureWorkerHandlerRegistered(): void {
                                 );
                             }
 
+                            gameSession.startedViaActivity = true;
                             State.gameSessions[startArgs.guildID] = gameSession;
                             // Safe to forward-reference: IPC handlers only
                             // fire after module load is complete.

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -94,6 +94,9 @@ export default abstract class Session extends EventEmitter {
     /** Whether the Session is active yet */
     public sessionInitialized: boolean;
 
+    /** Whether the Session was started through the Discord Activity (vs the legacy slash-command path) */
+    public startedViaActivity: boolean;
+
     /** State machine tracking session lifecycle */
     public readonly stateMachine: SessionStateMachine;
 
@@ -134,6 +137,7 @@ export default abstract class Session extends EventEmitter {
         this.finished = false;
         this.round = null;
         this.sessionInitialized = false;
+        this.startedViaActivity = false;
         this.roundsPlayed = 0;
         this.bookmarkedSongs = {};
         this.guildPreference.songSelector.resetSessionState();
@@ -190,7 +194,9 @@ export default abstract class Session extends EventEmitter {
             logger.info(
                 `${getDebugLogHeader(
                     messageContext,
-                )} | ${this.sessionName()} initializing session`,
+                )} | ${this.sessionName()} initializing session | startedViaActivity: ${
+                    this.startedViaActivity
+                }`,
             );
         } else {
             logger.info(


### PR DESCRIPTION
## Summary
Game-start logs didn't distinguish between games started through the Discord Activity and the legacy slash-command path. This adds a `startedViaActivity` boolean to the session-init log so the two paths can be told apart.

## Changes
- `src/structures/session.ts` — added a `startedViaActivity` field on the base `Session` (defaults to `false`) and appended it to the session-init log line: `... initializing session | startedViaActivity: <bool>`.
- `src/structures/activity_bridge.ts` — sets `gameSession.startedViaActivity = true` on the Activity start path.

The legacy slash-command path keeps the default `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)