### PR TITLE
Use BOT_CLIENT_ID secret for the prod Activity build-arg

### DIFF
--- a/.github/workflows/full-deploy.yml
+++ b/.github/workflows/full-deploy.yml
@@ -83,11 +83,12 @@ jobs:
                   push: true
                   platforms: linux/arm64
                   # Vite bakes BOT_CLIENT_ID into the Activity bundle at build
-                  # time; without it the deployed Activity ships an empty client
-                  # ID and can't connect. BOT_CLIENT is the bot's application ID
-                  # (same mapping gci-e2e.yml uses: BOT_CLIENT_ID=$BOT_CLIENT).
+                  # time; without it (or with the wrong value) the deployed
+                  # Activity ships a client ID that can't authenticate and gets
+                  # stuck launching. BOT_CLIENT_ID is the bot's public
+                  # application/client ID.
                   build-args: |
-                      BOT_CLIENT_ID=${{ secrets.BOT_CLIENT }}
+                      BOT_CLIENT_ID=${{ secrets.BOT_CLIENT_ID }}
                   tags: ${{ steps.app-version-parser.outputs.IMAGE_NAME }},ghcr.io/brainicism/kmq_discord:latest
 
     upgrade:


### PR DESCRIPTION
full-deploy baked secrets.BOT_CLIENT into the Activity bundle, but that secret held the wrong application ID (866177219595337749), so the deployed iframe authenticated against the wrong Discord app and hung on launch. Point the build-arg at the new BOT_CLIENT_ID secret (the correct prod client ID, 508759831755096074).

Confirmed by grepping the baked bundles: the broken :10.1.1 image baked 866177219595337749 while the working local build baked 508759831755096074.