### PR TITLE
Activity UI polish: win celebration, animations, overlap fix

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import {
     EXTERNAL_YOUTUBE_PROXY_PREFIX,
@@ -307,6 +307,124 @@ function useCanHover(): boolean {
         return () => mq.removeEventListener?.("change", onChange);
     }, []);
     return can;
+}
+
+// Keeps a conditionally-rendered element mounted through its close transition.
+// While `open`, it mounts and — after a frame, so the enter transition runs
+// from the closed state — flips `visible` true. When `open` goes false it flips
+// `visible` false (playing the exit transition) and unmounts after `ms`. Drive
+// opacity/transform/height off `visible` in CSS so both directions animate.
+function usePresence(
+    open: boolean,
+    ms: number,
+): { mounted: boolean; visible: boolean } {
+    const [mounted, setMounted] = useState(open);
+    const [visible, setVisible] = useState(open);
+    useEffect(() => {
+        if (open) {
+            setMounted(true);
+            // Double rAF: let the browser paint the closed state once before
+            // flipping `visible`, so the enter transition reliably runs.
+            let inner = 0;
+            const outer = requestAnimationFrame(() => {
+                inner = requestAnimationFrame(() => setVisible(true));
+            });
+            return () => {
+                cancelAnimationFrame(outer);
+                cancelAnimationFrame(inner);
+            };
+        }
+
+        setVisible(false);
+        const id = window.setTimeout(() => setMounted(false), ms);
+        return () => window.clearTimeout(id);
+    }, [open, ms]);
+    return { mounted, visible };
+}
+
+// Crossfades between successive children identified by `viewKey`, AND animates
+// the container's height from the old view's to the new view's so the content
+// below moves smoothly instead of snapping (the round-area's in-round stage is
+// much taller than the reveal/idle states). On a key change the previous
+// children linger briefly as an absolutely-stacked layer fading out while the
+// new children fade in; the wrapper's height is locked to the old height then
+// transitioned to the new one. Re-renders that keep the same key pass through.
+// Outlasts the CSS height transition (0.26s) plus the 2-frame rAF lead-in, so
+// the cleanup (unlock height, drop the leaving layer) doesn't cut it short.
+const CROSSFADE_MS = 320;
+
+function CrossFade({
+    viewKey,
+    children,
+}: {
+    viewKey: string;
+    children: React.ReactNode;
+}) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const prevKey = useRef(viewKey);
+    const prevNode = useRef<React.ReactNode>(children);
+    // Last natural (auto) height, recorded after every settled commit so a swap
+    // knows the height to animate FROM (the new height isn't measurable until
+    // after React commits the new children).
+    const naturalHeight = useRef<number | null>(null);
+    const [outgoing, setOutgoing] = useState<{
+        key: string;
+        node: React.ReactNode;
+    } | null>(null);
+    const [lockedHeight, setLockedHeight] = useState<number | null>(null);
+
+    // Detects a view swap. Declared FIRST so it reads the pre-swap node/height
+    // (captured by the bookkeeping effect below on the previous commit) before
+    // that effect overwrites them for this commit.
+    useLayoutEffect(() => {
+        if (prevKey.current === viewKey) return undefined;
+
+        const fromH = naturalHeight.current;
+        const toH = containerRef.current?.offsetHeight ?? null;
+        setOutgoing({ key: prevKey.current, node: prevNode.current });
+        prevKey.current = viewKey;
+
+        if (fromH !== null && toH !== null && fromH !== toH) {
+            setLockedHeight(fromH);
+            requestAnimationFrame(() =>
+                requestAnimationFrame(() => setLockedHeight(toH)),
+            );
+        }
+
+        const id = window.setTimeout(() => {
+            setOutgoing(null);
+            setLockedHeight(null);
+        }, CROSSFADE_MS);
+        return () => window.clearTimeout(id);
+    }, [viewKey]);
+
+    // Runs after every commit (after the swap effect above). Keeps the
+    // previous-node snapshot fresh and, while not mid-transition, records the
+    // natural height for the next swap to animate from.
+    useLayoutEffect(() => {
+        if (lockedHeight === null && containerRef.current) {
+            naturalHeight.current = containerRef.current.offsetHeight;
+        }
+
+        prevNode.current = children;
+    });
+
+    return (
+        <div
+            ref={containerRef}
+            className="crossfade"
+            style={lockedHeight !== null ? { height: lockedHeight } : undefined}
+        >
+            {outgoing && (
+                <div className="crossfade-layer leaving" aria-hidden>
+                    {outgoing.node}
+                </div>
+            )}
+            <div key={viewKey} className="crossfade-layer entering">
+                {children}
+            </div>
+        </div>
+    );
 }
 
 function formatProfileNumber(n: number): string {
@@ -705,6 +823,14 @@ function Scoreboard({
     const closeTimer = useRef<number | null>(null);
     const canViewProfiles = accessToken !== null && instanceId !== null;
 
+    // Keep the popover mounted through its close animation. `popoverID` latches
+    // the last-open row's id so that row still renders the (now exiting)
+    // popover while it fades out, after `activeID` has already cleared.
+    const popover = usePresence(activeID !== null, 200);
+    const lastActiveID = useRef<string | null>(activeID);
+    if (activeID !== null) lastActiveID.current = activeID;
+    const popoverID = popover.mounted ? lastActiveID.current : null;
+
     const clearCloseTimer = (): void => {
         if (closeTimer.current !== null) {
             window.clearTimeout(closeTimer.current);
@@ -819,9 +945,11 @@ function Scoreboard({
                                 </span>
                             )}
                         </button>
-                        {open && (
+                        {canViewProfiles && popoverID === p.id && (
                             <div
-                                className="profile-popover"
+                                className={`profile-popover${
+                                    popover.visible ? " visible" : ""
+                                }`}
                                 style={
                                     canHover && anchorRect
                                         ? popoverFixedStyle(anchorRect)
@@ -903,6 +1031,7 @@ function CurrentRound({
     reveal,
     bookmarkSlot,
     winnerText,
+    viewerWon,
     history,
     guesses,
     t,
@@ -913,6 +1042,9 @@ function CurrentRound({
     /** If non-null, the round-area idle state renders the session-end winner
      *  line in place of "Waiting for next round". */
     winnerText: string | null;
+    /** Whether the viewer won the just-ended game — triggers the confetti +
+     *  celebratory styling on the winner line. */
+    viewerWon: boolean;
     /** Songs played this session, used to build the end-of-game montage. */
     history: UiState["roundHistory"];
     /** Live guesses, shown in the in-round stage as they come in. */
@@ -921,188 +1053,214 @@ function CurrentRound({
 }) {
     return (
         <section className="round-area">
-            {round ? (
-                <div className="round-area-body in-round">
-                    {/* Full-width "stage": big countdown is the focal point,
+            <CrossFade viewKey={round ? "round" : reveal ? "reveal" : "idle"}>
+                {round ? (
+                    <div className="round-area-body in-round">
+                        {/* Full-width "stage": big countdown is the focal point,
                         with the live guess feed below — replaces the old
                         decorative listening animation that left this space
                         doing nothing while the round was most active. */}
-                    <div className="stage">
-                        {bookmarkSlot && (
-                            <div className="stage-bookmark">{bookmarkSlot}</div>
-                        )}
-                        <div className="stage-header">
-                            <span className="stage-round-label">
-                                {t("roundLabel", {
-                                    num: round.roundIndex + 1,
+                        <div className="stage">
+                            {bookmarkSlot && (
+                                <div className="stage-bookmark">
+                                    {bookmarkSlot}
+                                </div>
+                            )}
+                            <div className="stage-header">
+                                <span className="stage-round-label">
+                                    {t("roundLabel", {
+                                        num: round.roundIndex + 1,
+                                    })}
+                                </span>
+                                <span className="live-badge">
+                                    <span className="live-dot" />
+                                    LIVE
+                                </span>
+                            </div>
+                            <div className="stage-countdown">
+                                <RoundTimer
+                                    songStartedAt={round.songStartedAt}
+                                    timerStartedAt={round.timerStartedAt}
+                                    guessTimeoutSec={round.guessTimeoutSec}
+                                />
+                            </div>
+                            {guesses.length > 0 ? (
+                                <GuessTicker guesses={guesses} />
+                            ) : (
+                                <div className="stage-notes" aria-hidden>
+                                    <span className="note-float">♪</span>
+                                    <span className="note-float">♫</span>
+                                    <span className="note-float">♩</span>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                ) : reveal ? (
+                    <div className="round-area-body has-reveal">
+                        <div className="round-area-text">
+                            <div className="reveal-header">
+                                <h3>{reveal.song.songName}</h3>
+                                {bookmarkSlot}
+                            </div>
+                            <p className="artist-line">
+                                {reveal.song.artistName} (
+                                {reveal.song.publishYear})
+                            </p>
+                            <ul className="winners">
+                                {reveal.correctGuessers.map((g) => {
+                                    const quick =
+                                        g.timeToGuessMs !== null &&
+                                        g.timeToGuessMs <= QUICK_GUESS_MS;
+                                    return (
+                                        <li key={g.id}>
+                                            {t("revealWinners", {
+                                                username: g.username,
+                                                points: g.pointsEarned,
+                                                exp: g.expGain,
+                                            })}
+                                            {g.streak >=
+                                                STREAK_DISPLAY_THRESHOLD && (
+                                                <span
+                                                    className="winner-streak"
+                                                    title={t("streakTitle", {
+                                                        streak: g.streak,
+                                                    })}
+                                                >
+                                                    🔥{g.streak}
+                                                </span>
+                                            )}
+                                            {g.timeToGuessMs !== null && (
+                                                <span
+                                                    className={`winner-time ${
+                                                        quick ? "quick" : ""
+                                                    }`}
+                                                >
+                                                    {quick ? "⚡" : ""}
+                                                    {(
+                                                        g.timeToGuessMs / 1000
+                                                    ).toFixed(1)}
+                                                    s
+                                                </span>
+                                            )}
+                                        </li>
+                                    );
                                 })}
-                            </span>
-                            <span className="live-badge">
-                                <span className="live-dot" />
-                                LIVE
-                            </span>
+                            </ul>
+                            <p className="song-counter">
+                                {t("songCounterLine", {
+                                    played: reveal.songCounter
+                                        .uniqueSongsPlayed,
+                                    total: reveal.songCounter.totalSongs,
+                                })}
+                            </p>
+                            {reveal.allGuesses.length > 0 && (
+                                <details className="all-guesses" open>
+                                    <summary>
+                                        {t("revealAllGuessesSummary", {
+                                            count: reveal.allGuesses.length,
+                                        })}
+                                    </summary>
+                                    <ul>
+                                        {reveal.allGuesses
+                                            .slice()
+                                            .sort((a, b) => a.ts - b.ts)
+                                            .map((g) => (
+                                                <li
+                                                    key={g.userID}
+                                                    className={
+                                                        g.isCorrect
+                                                            ? "correct"
+                                                            : ""
+                                                    }
+                                                >
+                                                    <span className="g-name">
+                                                        {g.username}
+                                                    </span>
+                                                    <span className="g-text">
+                                                        {g.guess || "—"}
+                                                    </span>
+                                                    {g.isCorrect && (
+                                                        <span className="g-mark">
+                                                            ✓
+                                                        </span>
+                                                    )}
+                                                </li>
+                                            ))}
+                                    </ul>
+                                </details>
+                            )}
                         </div>
-                        <div className="stage-countdown">
-                            <RoundTimer
-                                songStartedAt={round.songStartedAt}
-                                timerStartedAt={round.timerStartedAt}
-                                guessTimeoutSec={round.guessTimeoutSec}
-                            />
+                        <div className="thumbnail-slot">
+                            <button
+                                type="button"
+                                className="thumbnail-link"
+                                onClick={() =>
+                                    openExternalUrl(
+                                        `${YOUTUBE_WATCH_URL_PREFIX}${reveal.song.youtubeLink}`,
+                                    )
+                                }
+                                title={t("openOnYouTube")}
+                            >
+                                <RevealThumbnail
+                                    key={reveal.song.thumbnailUrl}
+                                    thumbnailUrl={reveal.song.thumbnailUrl}
+                                    alt=""
+                                />
+                                <span className="thumbnail-overlay">
+                                    {t("youtubePlayLabel")}
+                                </span>
+                            </button>
                         </div>
-                        {guesses.length > 0 ? (
-                            <GuessTicker guesses={guesses} />
+                    </div>
+                ) : (
+                    <div
+                        className={`round-area-body idle${
+                            winnerText && viewerWon ? " viewer-won" : ""
+                        }`}
+                    >
+                        {winnerText && viewerWon && <Confetti />}
+                        <div className="round-area-text">
+                            {winnerText ? (
+                                <p
+                                    className={`session-winner${
+                                        viewerWon ? " won" : ""
+                                    }`}
+                                >
+                                    {winnerText}
+                                </p>
+                            ) : (
+                                <p className="empty">
+                                    {t("waitingForNextRound")}
+                                </p>
+                            )}
+                        </div>
+                        {winnerText ? (
+                            history.length > 0 ? (
+                                <div className="thumbnail-slot session-montage">
+                                    <SongMontage history={history} />
+                                </div>
+                            ) : (
+                                <div className="thumbnail-slot session-winner-art">
+                                    <img src={thumbsUpUrl} alt="" />
+                                </div>
+                            )
                         ) : (
-                            <div className="stage-notes" aria-hidden>
+                            <div
+                                className="thumbnail-slot placeholder"
+                                aria-hidden
+                            >
                                 <span className="note-float">♪</span>
                                 <span className="note-float">♫</span>
                                 <span className="note-float">♩</span>
+                                <span className="note-main">🎵</span>
+                                <span className="listening-text">
+                                    waiting...
+                                </span>
                             </div>
                         )}
                     </div>
-                </div>
-            ) : reveal ? (
-                <div className="round-area-body has-reveal">
-                    <div className="round-area-text">
-                        <div className="reveal-header">
-                            <h3>{reveal.song.songName}</h3>
-                            {bookmarkSlot}
-                        </div>
-                        <p className="artist-line">
-                            {reveal.song.artistName} ({reveal.song.publishYear})
-                        </p>
-                        <ul className="winners">
-                            {reveal.correctGuessers.map((g) => {
-                                const quick =
-                                    g.timeToGuessMs !== null &&
-                                    g.timeToGuessMs <= QUICK_GUESS_MS;
-                                return (
-                                    <li key={g.id}>
-                                        {t("revealWinners", {
-                                            username: g.username,
-                                            points: g.pointsEarned,
-                                            exp: g.expGain,
-                                        })}
-                                        {g.streak >=
-                                            STREAK_DISPLAY_THRESHOLD && (
-                                            <span
-                                                className="winner-streak"
-                                                title={t("streakTitle", {
-                                                    streak: g.streak,
-                                                })}
-                                            >
-                                                🔥{g.streak}
-                                            </span>
-                                        )}
-                                        {g.timeToGuessMs !== null && (
-                                            <span
-                                                className={`winner-time ${
-                                                    quick ? "quick" : ""
-                                                }`}
-                                            >
-                                                {quick ? "⚡" : ""}
-                                                {(
-                                                    g.timeToGuessMs / 1000
-                                                ).toFixed(1)}
-                                                s
-                                            </span>
-                                        )}
-                                    </li>
-                                );
-                            })}
-                        </ul>
-                        <p className="song-counter">
-                            {t("songCounterLine", {
-                                played: reveal.songCounter.uniqueSongsPlayed,
-                                total: reveal.songCounter.totalSongs,
-                            })}
-                        </p>
-                        {reveal.allGuesses.length > 0 && (
-                            <details className="all-guesses" open>
-                                <summary>
-                                    {t("revealAllGuessesSummary", {
-                                        count: reveal.allGuesses.length,
-                                    })}
-                                </summary>
-                                <ul>
-                                    {reveal.allGuesses
-                                        .slice()
-                                        .sort((a, b) => a.ts - b.ts)
-                                        .map((g) => (
-                                            <li
-                                                key={g.userID}
-                                                className={
-                                                    g.isCorrect ? "correct" : ""
-                                                }
-                                            >
-                                                <span className="g-name">
-                                                    {g.username}
-                                                </span>
-                                                <span className="g-text">
-                                                    {g.guess || "—"}
-                                                </span>
-                                                {g.isCorrect && (
-                                                    <span className="g-mark">
-                                                        ✓
-                                                    </span>
-                                                )}
-                                            </li>
-                                        ))}
-                                </ul>
-                            </details>
-                        )}
-                    </div>
-                    <div className="thumbnail-slot">
-                        <button
-                            type="button"
-                            className="thumbnail-link"
-                            onClick={() =>
-                                openExternalUrl(
-                                    `${YOUTUBE_WATCH_URL_PREFIX}${reveal.song.youtubeLink}`,
-                                )
-                            }
-                            title={t("openOnYouTube")}
-                        >
-                            <RevealThumbnail
-                                key={reveal.song.thumbnailUrl}
-                                thumbnailUrl={reveal.song.thumbnailUrl}
-                                alt=""
-                            />
-                            <span className="thumbnail-overlay">
-                                {t("youtubePlayLabel")}
-                            </span>
-                        </button>
-                    </div>
-                </div>
-            ) : (
-                <div className="round-area-body idle">
-                    <div className="round-area-text">
-                        {winnerText ? (
-                            <p className="session-winner">{winnerText}</p>
-                        ) : (
-                            <p className="empty">{t("waitingForNextRound")}</p>
-                        )}
-                    </div>
-                    {winnerText ? (
-                        history.length > 0 ? (
-                            <div className="thumbnail-slot session-montage">
-                                <SongMontage history={history} />
-                            </div>
-                        ) : (
-                            <div className="thumbnail-slot session-winner-art">
-                                <img src={thumbsUpUrl} alt="" />
-                            </div>
-                        )
-                    ) : (
-                        <div className="thumbnail-slot placeholder" aria-hidden>
-                            <span className="note-float">♪</span>
-                            <span className="note-float">♫</span>
-                            <span className="note-float">♩</span>
-                            <span className="note-main">🎵</span>
-                            <span className="listening-text">waiting...</span>
-                        </div>
-                    )}
-                </div>
-            )}
+                )}
+            </CrossFade>
         </section>
     );
 }
@@ -1725,6 +1883,52 @@ function resolveWinnerText(
     });
 }
 
+/** Whether the viewer is among the (possibly tied) winners — drives the
+ *  end-of-game celebration. */
+function didViewerWin(
+    scoreboard: ActivityScoreboardSnapshot | null,
+    viewerUserID: string | null,
+): boolean {
+    if (!scoreboard || viewerUserID === null || scoreboard.highestScore === 0) {
+        return false;
+    }
+
+    return scoreboard.winnerIDs.includes(viewerUserID);
+}
+
+// A short, purely-decorative confetti shower for the win celebration. Pieces
+// are a fixed set (deterministic so renders are stable) with staggered delays
+// and varied colors/positions; the fall + fade is CSS-driven (see `.confetti`).
+const CONFETTI_PIECES = Array.from({ length: 16 }, (_, i) => ({
+    left: (i * 100) / 16 + (i % 3) * 2,
+    delay: (i % 6) * 0.18,
+    duration: 2.4 + (i % 4) * 0.35,
+    color: ["#e23b4e", "#f7b500", "#2dba75", "#4a8cff", "#b14aff"][i % 5]!,
+    drift: (i % 2 === 0 ? 1 : -1) * (12 + (i % 4) * 8),
+}));
+
+function Confetti() {
+    return (
+        <div className="confetti" aria-hidden>
+            {CONFETTI_PIECES.map((p, i) => (
+                <span
+                    key={i}
+                    className="confetti-piece"
+                    style={
+                        {
+                            left: `${p.left}%`,
+                            background: p.color,
+                            animationDelay: `${p.delay}s`,
+                            animationDuration: `${p.duration}s`,
+                            "--drift": `${p.drift}px`,
+                        } as React.CSSProperties
+                    }
+                />
+            ))}
+        </div>
+    );
+}
+
 const GENDER_OPTIONS: ActivityGender[] = ["male", "female", "coed"];
 const GUESS_MODE_OPTIONS: ActivityGuessMode[] = ["song", "artist", "both"];
 const SHUFFLE_OPTIONS: ActivityShuffle[] = [
@@ -1878,7 +2082,11 @@ function OptionsCategory({
                 <span>{label}</span>
                 <span className="options-chevron">▾</span>
             </button>
-            {open && <div className="options-panel">{children}</div>}
+            <div className={`collapse${open ? " open" : ""}`}>
+                <div className="collapse-inner">
+                    <div className="options-panel">{children}</div>
+                </div>
+            </div>
         </div>
     );
 }
@@ -3011,6 +3219,7 @@ function SongHistory({
     history,
     bookmarkedLinks,
     auth,
+    active,
     onBookmarked,
     t,
 }: {
@@ -3019,6 +3228,9 @@ function SongHistory({
     /** Auth context for bookmarking from the list; null before auth resolves
      *  (no buttons rendered then). */
     auth: { accessToken: string; instanceId: string } | null;
+    /** Whether a game is currently in progress. Bookmarking is only meaningful
+     *  during an active game, so the per-row stars are hidden otherwise. */
+    active: boolean;
     onBookmarked: (link: string) => void;
     t: Translator;
 }) {
@@ -3043,7 +3255,7 @@ function SongHistory({
                                 {song.artistName} ({song.publishYear})
                             </div>
                         </div>
-                        {auth && (
+                        {auth && active && (
                             <BookmarkStar
                                 accessToken={auth.accessToken}
                                 instanceId={auth.instanceId}
@@ -3119,6 +3331,10 @@ export default function App() {
     const profileCacheRef = useRef<ProfileCache>(new Map());
     const [profileRefreshNonce, setProfileRefreshNonce] = useState(0);
     const [myProfileOpen, setMyProfileOpen] = useState(false);
+    // Mount-through-close presence for the overlays so they animate out, not
+    // just in. (The `&& authState/ui.options` guards live at the render site.)
+    const myProfile = usePresence(myProfileOpen, 200);
+    const optionsPanel = usePresence(optionsOpen, 220);
 
     // A finished round (roundHistory grows) or a session end can change EXP /
     // level, so invalidate open profile cards by bumping the nonce.
@@ -3437,6 +3653,7 @@ export default function App() {
                         <SongHistory
                             history={ui.roundHistory}
                             bookmarkedLinks={ui.bookmarkedLinks}
+                            active={ui.session !== null && !ui.sessionEnded}
                             auth={
                                 authState
                                     ? {
@@ -3556,15 +3773,19 @@ export default function App() {
                             )}
                         </header>
 
-                        {authState && myProfileOpen && (
+                        {authState && myProfile.mounted && (
                             <div
-                                className="profile-modal-overlay"
+                                className={`profile-modal-overlay${
+                                    myProfile.visible ? " visible" : ""
+                                }`}
                                 role="dialog"
                                 aria-modal="true"
                                 onClick={() => setMyProfileOpen(false)}
                             >
                                 <div
-                                    className="profile-modal"
+                                    className={`profile-modal${
+                                        myProfile.visible ? " visible" : ""
+                                    }`}
                                     onClick={(e) => e.stopPropagation()}
                                 >
                                     <button
@@ -3625,6 +3846,15 @@ export default function App() {
                                           authState?.userID ?? null,
                                       )
                                     : null
+                            }
+                            viewerWon={
+                                ui.sessionEnded &&
+                                ui.hadSession &&
+                                !ui.lastReveal &&
+                                didViewerWin(
+                                    ui.scoreboard,
+                                    authState?.userID ?? null,
+                                )
                             }
                             bookmarkSlot={
                                 authState &&
@@ -3795,25 +4025,37 @@ export default function App() {
                                     <span>⚙ {t("options.heading")}</span>
                                     <span className="options-chevron">▾</span>
                                 </button>
-                                {optionsOpen && (
-                                    <OptionsPanel
-                                        accessToken={authState.accessToken}
-                                        instanceId={authState.instanceId}
-                                        options={ui.options}
-                                        t={t}
-                                        onOptimistic={(next) =>
-                                            setUi((prev) => ({
-                                                ...prev,
-                                                options: next,
-                                            }))
-                                        }
-                                        onRollback={(prevOpts) =>
-                                            setUi((prev) => ({
-                                                ...prev,
-                                                options: prevOpts,
-                                            }))
-                                        }
-                                    />
+                                {optionsPanel.mounted && (
+                                    <div
+                                        className={`collapse${
+                                            optionsPanel.visible ? " open" : ""
+                                        }`}
+                                    >
+                                        <div className="collapse-inner">
+                                            <OptionsPanel
+                                                accessToken={
+                                                    authState.accessToken
+                                                }
+                                                instanceId={
+                                                    authState.instanceId
+                                                }
+                                                options={ui.options}
+                                                t={t}
+                                                onOptimistic={(next) =>
+                                                    setUi((prev) => ({
+                                                        ...prev,
+                                                        options: next,
+                                                    }))
+                                                }
+                                                onRollback={(prevOpts) =>
+                                                    setUi((prev) => ({
+                                                        ...prev,
+                                                        options: prevOpts,
+                                                    }))
+                                                }
+                                            />
+                                        </div>
+                                    </div>
                                 )}
                             </div>
                         )}

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -168,6 +168,17 @@ body::before {
         display: grid;
         grid-template-columns: minmax(0, 1fr) var(--rail-width, 320px);
     }
+
+    /* The left toggle cluster (history / theme / profile) stays fixed at the
+       viewport's left edge, reaching 56px in. In the grid range the 320px rail
+       squeezes the centred .kmq-app close to that edge, so its logo would slide
+       under the toggles. Reserve the cluster's width as left padding on the
+       column — this holds the card clear at every desktop width (no fragile
+       upper breakpoint) and keeps the header aligned with the content below,
+       rather than indenting the logo alone. */
+    .kmq-main {
+        padding-left: 64px;
+    }
 }
 
 .kmq-app {
@@ -926,6 +937,71 @@ body::before {
     line-height: 1.4;
 }
 
+/* ---- WIN CELEBRATION (viewer won) ---- */
+.round-area-body.idle.viewer-won {
+    position: relative;
+    overflow: hidden;
+}
+
+/* The winner line already carries a 🏆 from its i18n string; the celebration
+   here is the confetti + a one-shot pop-in (no extra trophy emoji). */
+.session-winner.won {
+    position: relative;
+    z-index: 6;
+    animation: winner-pop 0.5s cubic-bezier(0.2, 0.9, 0.3, 1.4);
+}
+
+@keyframes winner-pop {
+    0% {
+        opacity: 0;
+        transform: scale(0.6);
+    }
+    60% {
+        transform: scale(1.08);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/* A short one-shot confetti shower. Pieces fall once from the top of the
+   round area, drifting + spinning, then fade — see CONFETTI_PIECES in App.tsx
+   for the per-piece left/delay/duration/color/drift. */
+.confetti {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 5;
+}
+
+.confetti-piece {
+    position: absolute;
+    top: -14px;
+    width: 8px;
+    height: 13px;
+    border-radius: 2px;
+    opacity: 0;
+    animation-name: confetti-fall;
+    animation-timing-function: ease-in;
+    animation-fill-mode: forwards;
+}
+
+@keyframes confetti-fall {
+    0% {
+        opacity: 0;
+        transform: translateY(-14px) translateX(0) rotate(0deg);
+    }
+    12% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(380px) translateX(var(--drift, 0)) rotate(560deg);
+    }
+}
+
 /* ---- BOOKMARK STAR ---- */
 .bookmark-star {
     width: 30px;
@@ -1329,6 +1405,19 @@ body::before {
     background: var(--bg-surface);
     border: 1px solid var(--border);
     color: var(--text-tertiary);
+    /* Stable keys (userID+ts) → only the just-arrived guess pops in. */
+    animation: guess-pop-in 0.25s cubic-bezier(0.2, 0.9, 0.3, 1.3);
+}
+
+@keyframes guess-pop-in {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
 }
 
 .guess-ticker li.correct {
@@ -2226,6 +2315,21 @@ fieldset.options-override:disabled .options-group {
     background: var(--bg-elevated);
     border-radius: var(--radius-sm);
     transition: background 0.1s;
+    /* Newly-revealed songs are prepended (newest-first); the stable React keys
+       mean only the freshly-mounted top row plays this entrance, not the whole
+       list on every update. */
+    animation: history-row-in 0.32s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+@keyframes history-row-in {
+    from {
+        opacity: 0;
+        transform: translateY(-6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .song-history li:hover {
@@ -2441,5 +2545,209 @@ fieldset.options-override:disabled .options-group {
 @media (max-width: 600px) {
     .vote-row {
         grid-template-columns: 1fr;
+    }
+}
+
+/* ---- MOTION POLISH ----
+   Entrance + interaction animations layered onto existing components. Each
+   round-area state is a separate JSX branch that mounts on transition, so a
+   CSS `animation` plays once on the swap and isn't replayed by re-renders
+   within a state. All of this is neutralised by the prefers-reduced-motion
+   guard below. */
+
+/* Round-area state swaps. The in-round stage (tall, full-width) collapses to
+   the shorter reveal/idle split post-round; a fade/scale entrance softens that
+   jump (a true height morph isn't possible across the separate DOM subtrees). */
+.round-area-body.in-round,
+.round-area-body.idle {
+    animation: round-state-in 0.3s ease;
+}
+
+.round-area-body.has-reveal {
+    animation: round-reveal-in 0.34s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+@keyframes round-state-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes round-reveal-in {
+    from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.985);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Stagger the revealed song's lines so they settle in top-to-bottom. */
+.round-area-body.has-reveal .reveal-header {
+    animation: reveal-line-in 0.3s ease both 0.04s;
+}
+.round-area-body.has-reveal .artist-line {
+    animation: reveal-line-in 0.3s ease both 0.1s;
+}
+.round-area-body.has-reveal .winners {
+    animation: reveal-line-in 0.3s ease both 0.16s;
+}
+.round-area-body.has-reveal .song-counter {
+    animation: reveal-line-in 0.3s ease both 0.22s;
+}
+
+@keyframes reveal-line-in {
+    from {
+        opacity: 0;
+        transform: translateX(-6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/* Height collapse for the options panel and its sub-categories. The grid-rows
+   0fr→1fr transition animates open AND close (no fixed height needed); the
+   inner wrapper clips the content while the row height grows/shrinks. Mount /
+   unmount of the panel is delayed (usePresence) so the close plays too. */
+.collapse {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.22s ease;
+}
+
+.collapse.open {
+    grid-template-rows: 1fr;
+}
+
+.collapse-inner {
+    overflow: hidden;
+    min-height: 0;
+}
+
+/* Scoreboard hover/tap → profile popover. Mount/unmount is delayed (usePresence
+   adds `.visible` a frame after mount and removes it before unmount), so the
+   opacity transition plays both ways. Desktop adds a scale/slide from the row's
+   right edge; the centred mobile variant (which keeps a translate(-50%,-50%))
+   only fades so the transition doesn't fight the centring. */
+.profile-popover {
+    opacity: 0;
+    transition:
+        opacity 0.2s ease,
+        transform 0.2s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+.profile-popover.visible {
+    opacity: 1;
+}
+
+@media (min-width: 901px) {
+    .profile-popover {
+        transform-origin: right center;
+        transform: scale(0.94) translateX(6px);
+    }
+
+    .profile-popover.visible {
+        transform: scale(1) translateX(0);
+    }
+}
+
+/* Profile modal: backdrop fade + card pop-in, both reversible on close. */
+.profile-modal-overlay {
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.profile-modal-overlay.visible {
+    opacity: 1;
+}
+
+.profile-modal {
+    opacity: 0;
+    transform: translateY(12px) scale(0.96);
+    transition:
+        opacity 0.2s ease,
+        transform 0.2s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+.profile-modal.visible {
+    opacity: 1;
+    transform: none;
+}
+
+/* Round-area crossfade: on a state swap the outgoing view stays briefly as an
+   absolutely-stacked layer fading out (clipped to the new view's height) while
+   the new view fades in on top. Entrance animations on the new view's content
+   still play; they're suppressed on the leaving copy so it doesn't re-animate. */
+.crossfade {
+    position: relative;
+    overflow: hidden;
+    /* Height is locked + transitioned by CrossFade during a swap so content
+       below moves smoothly; otherwise it's auto (no inline height). */
+    transition: height 0.26s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.crossfade-layer.entering {
+    position: relative;
+    z-index: 1;
+}
+
+.crossfade-layer.leaving {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    animation: crossfade-out 0.22s ease forwards;
+}
+
+.crossfade-layer.leaving * {
+    animation: none !important;
+}
+
+@keyframes crossfade-out {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+
+/* The session-ended banner slides in when the game wraps. */
+.banner {
+    animation: hint-slide-in 0.3s ease;
+}
+
+/* Tactile press feedback (hover states already lift; active presses in). */
+.control-buttons button:active:not(:disabled),
+.hint-control button:active:not(:disabled) {
+    transform: scale(0.96);
+}
+
+.sidebar-toggle:active {
+    transform: scale(0.94);
+}
+
+/* Respect users who opt out of motion at the OS level: drop the decorative
+   loops (confetti, floating notes, etc.) and collapse entrance animations /
+   transitions to a near-instant change. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    .confetti {
+        display: none;
     }
 }


### PR DESCRIPTION
- Confetti + a one-shot pop-in on the end screen when the viewer is among the winners (reuses the existing winner text, which already carries its own trophy emoji — no duplicate trophy).
- Animate round-area state swaps both ways via a CrossFade wrapper: the outgoing view fades out (clipped) while the next fades in, so round end -> next round no longer hard-cuts; revealed song lines stagger in.
- Enter AND exit animations for the overlays via a usePresence hook (delayed unmount + a `.visible` class driving CSS transitions): scoreboard->profile popover (hover-off / close button) and the profile modal now animate closed, not just open.
- Options panel + sub-categories use a grid-rows height collapse, so opening and closing both animate.
- Song-history rows and guess-ticker entries animate in on arrival; stable React keys mean only genuinely new rows animate.
- Press feedback (:active) on the Start/End, skip/hint, and corner toggle buttons; session-ended banner slides in.
- Add a prefers-reduced-motion guard (drops confetti + decorative loops, collapses transitions) for users who opt out.
- Hide the per-row song-history bookmark stars unless a game is active.
- Fix the left toggle cluster overlapping the KMQ logo in the desktop grid range (901px+): the 320px rail squeezes the centred card toward the viewport's left edge, under the fixed toggles. Reserve the cluster's width as left padding on the main column so the card stays clear at every desktop width. (The sub-900px header padding is left at its original 52px — overlap wasn't an issue there.)