### PR TITLE
Add Activity setOption + hub-routing integration tests

### DIFF
--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -233,8 +233,12 @@ function nullableIntInRange(
     min: number,
     max: number,
 ): number | null | undefined {
+    // null explicitly clears the option; a present-but-invalid value (wrong
+    // type or out of range) is signalled as `undefined` so the caller rejects
+    // it with a 400 rather than silently coercing it to a reset.
     if (v === null) return null;
-    return intInRange(v, min, max);
+    const parsed = intInRange(v, min, max);
+    return parsed === null ? undefined : parsed;
 }
 
 function floatInRange(v: unknown, min: number, max: number): number | null {
@@ -251,7 +255,7 @@ function floatInRange(v: unknown, min: number, max: number): number | null {
  * @returns A validated SetOptionBody, or null if the shape/enum mismatch
  * means the caller should respond 400.
  */
-function parseSetOptionBody(body: unknown): SetOptionBody | null {
+export function parseSetOptionBody(body: unknown): SetOptionBody | null {
     if (!body || typeof body !== "object") return null;
     const obj = body as Record<string, unknown>;
     switch (obj["kind"]) {

--- a/src/test/unit_tests/ci/activity_hub.test.ts
+++ b/src/test/unit_tests/ci/activity_hub.test.ts
@@ -5,6 +5,7 @@ import {
     ACTIVITY_REQUEST_TIMEOUT_MS,
 } from "../../../constants";
 import ActivityHub from "../../../activity_hub";
+import GameType from "../../../enums/game_type";
 import assert from "assert";
 import sinon from "sinon";
 import type { ActivitySubscriber } from "../../../activity_hub";
@@ -522,6 +523,141 @@ describe("ActivityHub", () => {
             const res = await hub.searchSongs("tt", "en");
             assert.deepStrictEqual(res, { results: [] });
             assert.strictEqual(fleet.sent.length, 0);
+        });
+    });
+
+    describe("guild-routed action ops", () => {
+        // Each action method resolves the owning cluster for its guild and
+        // forwards a request under a fixed op with the caller's args. These
+        // pin the op name + args shape so a rename/refactor can't silently
+        // reroute a player action. guild "0" → shard 0 → cluster 0.
+        async function dispatch(
+            invoke: (hub: ActivityHub) => Promise<unknown>,
+        ): Promise<SentRequest> {
+            const { hub, fleet } = makeHub(TWO_CLUSTERS);
+            await hub.start();
+            fleet.autoReply = (payload) => {
+                fleet.emit(ACTIVITY_IPC_REPLY, {
+                    cid: payload.cid,
+                    payload: { ok: true },
+                });
+            };
+
+            await invoke(hub);
+            assert.strictEqual(fleet.sent.length, 1);
+            return fleet.sent[0]!;
+        }
+
+        it("submitMcGuess → mcGuess", async () => {
+            const sent = await dispatch((hub) =>
+                hub.submitMcGuess("0", "user1", "choice-uuid", 12345),
+            );
+
+            assert.strictEqual(sent.clusterID, 0);
+            assert.strictEqual(sent.payload.op, "mcGuess");
+            assert.deepStrictEqual(sent.payload.args, {
+                guildID: "0",
+                userID: "user1",
+                choiceID: "choice-uuid",
+                ts: 12345,
+            });
+        });
+
+        it("startGame → startGame", async () => {
+            const args = {
+                guildID: "0",
+                userID: "user1",
+                voiceChannelID: "vc1",
+                textChannelID: "tc1",
+                gameType: GameType.CLASSIC,
+            };
+
+            const sent = await dispatch((hub) => hub.startGame(args));
+            assert.strictEqual(sent.clusterID, 0);
+            assert.strictEqual(sent.payload.op, "startGame");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("skipVote → skipVote", async () => {
+            const args = { guildID: "0", userID: "user1" };
+            const sent = await dispatch((hub) => hub.skipVote(args));
+            assert.strictEqual(sent.payload.op, "skipVote");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("endGame → endGame", async () => {
+            const args = { guildID: "0", userID: "user1" };
+            const sent = await dispatch((hub) => hub.endGame(args));
+            assert.strictEqual(sent.payload.op, "endGame");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("hint → hint", async () => {
+            const args = { guildID: "0", userID: "user1" };
+            const sent = await dispatch((hub) => hub.hint(args));
+            assert.strictEqual(sent.payload.op, "hint");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("bookmark → bookmark", async () => {
+            const args = {
+                guildID: "0",
+                userID: "user1",
+                youtubeLink: "abc123",
+            };
+
+            const sent = await dispatch((hub) => hub.bookmark(args));
+            assert.strictEqual(sent.payload.op, "bookmark");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("setOption → setOption (carries the discriminated payload)", async () => {
+            const args = {
+                guildID: "0",
+                userID: "user1",
+                kind: "limit" as const,
+                limitStart: 0,
+                limitEnd: 100,
+            };
+
+            const sent = await dispatch((hub) => hub.setOption(args));
+            assert.strictEqual(sent.payload.op, "setOption");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("preset → preset", async () => {
+            const args = {
+                guildID: "0",
+                userID: "user1",
+                action: "save" as const,
+                name: "my-preset",
+            };
+
+            const sent = await dispatch((hub) => hub.preset(args));
+            assert.strictEqual(sent.payload.op, "preset");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("profile → profile (forwards the optional target)", async () => {
+            const args = {
+                guildID: "0",
+                userID: "user1",
+                targetUserID: "user2",
+            };
+
+            const sent = await dispatch((hub) => hub.profile(args));
+            assert.strictEqual(sent.payload.op, "profile");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
+        it("routes to the cluster owning the guild, not always cluster 0", async () => {
+            // guild 2^23 → shard 2 → cluster 1
+            const guildID = String(2 ** 23);
+            const sent = await dispatch((hub) =>
+                hub.skipVote({ guildID, userID: "u" }),
+            );
+
+            assert.strictEqual(sent.clusterID, 1);
         });
     });
 });

--- a/src/test/unit_tests/ci/activity_set_option.test.ts
+++ b/src/test/unit_tests/ci/activity_set_option.test.ts
@@ -1,0 +1,377 @@
+import { parseSetOptionBody } from "../../../kmq_web_server";
+import AnswerType from "../../../enums/option_types/answer_type";
+import ArtistType from "../../../enums/option_types/artist_type";
+import GuessModeType from "../../../enums/option_types/guess_mode_type";
+import LanguageType from "../../../enums/option_types/language_type";
+import MultiGuessType from "../../../enums/option_types/multiguess_type";
+import OstPreference from "../../../enums/option_types/ost_preference";
+import ReleaseType from "../../../enums/option_types/release_type";
+import SeekType from "../../../enums/option_types/seek_type";
+import ShuffleType from "../../../enums/option_types/shuffle_type";
+import SpecialType from "../../../enums/option_types/special_type";
+import SubunitsPreference from "../../../enums/option_types/subunit_preference";
+import assert from "assert";
+
+/**
+ * `parseSetOptionBody` is the server-side whitelist for POST /api/activity/option.
+ * It must never trust the client: only the typed value for the declared `kind`
+ * is accepted, every enum is checked against its set, numbers are range-clamped,
+ * and arrays are length-capped. These tests pin that contract for the full
+ * option matrix the Activity exposes.
+ */
+describe("parseSetOptionBody", () => {
+    describe("malformed envelopes", () => {
+        it("rejects non-objects", () => {
+            assert.strictEqual(parseSetOptionBody(null), null);
+            assert.strictEqual(parseSetOptionBody(undefined), null);
+            assert.strictEqual(parseSetOptionBody("gender"), null);
+            assert.strictEqual(parseSetOptionBody(42), null);
+        });
+
+        it("rejects an unknown kind", () => {
+            assert.strictEqual(parseSetOptionBody({ kind: "nonsense" }), null);
+            // Missing kind entirely.
+            assert.strictEqual(parseSetOptionBody({ genders: [] }), null);
+        });
+    });
+
+    describe("gender", () => {
+        it("accepts a valid subset", () => {
+            assert.deepStrictEqual(
+                parseSetOptionBody({ kind: "gender", genders: ["male"] }),
+                { kind: "gender", genders: ["male"] },
+            );
+        });
+
+        it("accepts the full set", () => {
+            const genders = ["male", "female", "coed", "alternating"];
+            assert.deepStrictEqual(
+                parseSetOptionBody({ kind: "gender", genders }),
+                { kind: "gender", genders },
+            );
+        });
+
+        it("rejects an unknown gender value", () => {
+            assert.strictEqual(
+                parseSetOptionBody({ kind: "gender", genders: ["robot"] }),
+                null,
+            );
+        });
+
+        it("rejects a non-array genders payload", () => {
+            assert.strictEqual(
+                parseSetOptionBody({ kind: "gender", genders: "male" }),
+                null,
+            );
+        });
+
+        it("rejects more than four entries", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "gender",
+                    genders: ["male", "female", "coed", "alternating", "male"],
+                }),
+                null,
+            );
+        });
+
+        it("rejects a non-string entry", () => {
+            assert.strictEqual(
+                parseSetOptionBody({ kind: "gender", genders: [1] }),
+                null,
+            );
+        });
+    });
+
+    describe("enum options", () => {
+        // [kind, valueKey, validValue, invalidValue]
+        const cases: Array<[string, string, string, string]> = [
+            ["guessMode", "guessMode", GuessModeType.BOTH, "telepathy"],
+            ["multiguess", "multiguess", MultiGuessType.ON, "maybe"],
+            ["shuffle", "shuffle", ShuffleType.RANDOM, "spiral"],
+            ["seek", "seek", SeekType.BEGINNING, "sideways"],
+            ["language", "language", LanguageType.ALL, "klingon"],
+            ["release", "release", ReleaseType.OFFICIAL, "leaked"],
+            ["artisttype", "artisttype", ArtistType.SOLOIST, "android"],
+            ["subunits", "subunits", SubunitsPreference.INCLUDE, "sometimes"],
+            ["answer", "answer", AnswerType.MULTIPLE_CHOICE_EASY, "telepathy"],
+            ["ost", "ost", OstPreference.EXCLUSIVE, "soundtrackish"],
+        ];
+
+        for (const [kind, key, valid, invalid] of cases) {
+            it(`accepts a valid ${kind}`, () => {
+                assert.deepStrictEqual(
+                    parseSetOptionBody({ kind, [key]: valid }),
+                    { kind, [key]: valid },
+                );
+            });
+
+            it(`rejects an out-of-set ${kind}`, () => {
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, [key]: invalid }),
+                    null,
+                );
+            });
+
+            it(`rejects a non-string ${kind}`, () => {
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, [key]: 5 }),
+                    null,
+                );
+            });
+        }
+    });
+
+    describe("special (nullable enum)", () => {
+        it("accepts a valid modifier", () => {
+            assert.deepStrictEqual(
+                parseSetOptionBody({
+                    kind: "special",
+                    special: SpecialType.REVERSE,
+                }),
+                { kind: "special", special: SpecialType.REVERSE },
+            );
+        });
+
+        it("accepts null (clears the modifier)", () => {
+            assert.deepStrictEqual(
+                parseSetOptionBody({ kind: "special", special: null }),
+                { kind: "special", special: null },
+            );
+        });
+
+        it("rejects an unknown modifier", () => {
+            assert.strictEqual(
+                parseSetOptionBody({ kind: "special", special: "echo" }),
+                null,
+            );
+        });
+    });
+
+    describe("limit (paired ints)", () => {
+        it("accepts a valid ascending range", () => {
+            assert.deepStrictEqual(
+                parseSetOptionBody({
+                    kind: "limit",
+                    limitStart: 0,
+                    limitEnd: 100,
+                }),
+                { kind: "limit", limitStart: 0, limitEnd: 100 },
+            );
+        });
+
+        it("rejects start >= end", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "limit",
+                    limitStart: 100,
+                    limitEnd: 100,
+                }),
+                null,
+            );
+        });
+
+        it("rejects an out-of-range bound", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "limit",
+                    limitStart: 0,
+                    limitEnd: 100_001,
+                }),
+                null,
+            );
+        });
+
+        it("rejects a non-integer bound", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "limit",
+                    limitStart: 0,
+                    limitEnd: 50.5,
+                }),
+                null,
+            );
+        });
+    });
+
+    describe("cutoff (year range)", () => {
+        const now = new Date().getFullYear();
+
+        it("accepts a valid range", () => {
+            assert.deepStrictEqual(
+                parseSetOptionBody({
+                    kind: "cutoff",
+                    beginningYear: 2000,
+                    endYear: now,
+                }),
+                { kind: "cutoff", beginningYear: 2000, endYear: now },
+            );
+        });
+
+        it("rejects begin > end", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "cutoff",
+                    beginningYear: 2010,
+                    endYear: 2000,
+                }),
+                null,
+            );
+        });
+
+        it("rejects a year before the earliest searchable year", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "cutoff",
+                    beginningYear: 1899,
+                    endYear: now,
+                }),
+                null,
+            );
+        });
+
+        it("rejects a future end year", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "cutoff",
+                    beginningYear: 2000,
+                    endYear: now + 1,
+                }),
+                null,
+            );
+        });
+    });
+
+    describe("nullable scalar options", () => {
+        // [kind, key, validValue, tooLow, tooHigh]
+        const cases: Array<[string, string, number, number, number]> = [
+            ["goal", "goal", 50, 0, 100_001],
+            ["timer", "timer", 30, 1, 181],
+            ["duration", "duration", 120, 1, 601],
+        ];
+
+        for (const [kind, key, valid, tooLow, tooHigh] of cases) {
+            it(`accepts a valid ${kind}`, () => {
+                assert.deepStrictEqual(
+                    parseSetOptionBody({ kind, [key]: valid }),
+                    { kind, [key]: valid },
+                );
+            });
+
+            it(`accepts null ${kind} (resets it)`, () => {
+                assert.deepStrictEqual(
+                    parseSetOptionBody({ kind, [key]: null }),
+                    { kind, [key]: null },
+                );
+            });
+
+            it(`rejects a below-range ${kind}`, () => {
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, [key]: tooLow }),
+                    null,
+                );
+            });
+
+            it(`rejects an above-range ${kind}`, () => {
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, [key]: tooHigh }),
+                    null,
+                );
+            });
+        }
+    });
+
+    describe("artist lists", () => {
+        for (const kind of ["groups", "includes", "excludes"]) {
+            it(`accepts a valid ${kind} list`, () => {
+                assert.deepStrictEqual(
+                    parseSetOptionBody({ kind, artistIDs: [1, 2, 3] }),
+                    { kind, artistIDs: [1, 2, 3] },
+                );
+            });
+
+            it(`accepts an empty ${kind} list`, () => {
+                assert.deepStrictEqual(
+                    parseSetOptionBody({ kind, artistIDs: [] }),
+                    { kind, artistIDs: [] },
+                );
+            });
+
+            it(`rejects a non-positive id in ${kind}`, () => {
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, artistIDs: [1, 0] }),
+                    null,
+                );
+            });
+
+            it(`rejects a non-integer id in ${kind}`, () => {
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, artistIDs: [1.5] }),
+                    null,
+                );
+            });
+
+            it(`rejects more than 200 ids in ${kind}`, () => {
+                const artistIDs = Array.from({ length: 201 }, (_, i) => i + 1);
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, artistIDs }),
+                    null,
+                );
+            });
+
+            it(`rejects a non-array ${kind} payload`, () => {
+                assert.strictEqual(
+                    parseSetOptionBody({ kind, artistIDs: 5 }),
+                    null,
+                );
+            });
+        }
+    });
+
+    describe("playlist", () => {
+        it("accepts a URL string", () => {
+            assert.deepStrictEqual(
+                parseSetOptionBody({
+                    kind: "playlist",
+                    playlistURL: "https://open.spotify.com/playlist/abc",
+                }),
+                {
+                    kind: "playlist",
+                    playlistURL: "https://open.spotify.com/playlist/abc",
+                },
+            );
+        });
+
+        it("accepts null (clears the playlist)", () => {
+            assert.deepStrictEqual(
+                parseSetOptionBody({ kind: "playlist", playlistURL: null }),
+                { kind: "playlist", playlistURL: null },
+            );
+        });
+
+        it("rejects an over-long URL", () => {
+            assert.strictEqual(
+                parseSetOptionBody({
+                    kind: "playlist",
+                    playlistURL: "x".repeat(2049),
+                }),
+                null,
+            );
+        });
+
+        it("rejects a non-string URL", () => {
+            assert.strictEqual(
+                parseSetOptionBody({ kind: "playlist", playlistURL: 5 }),
+                null,
+            );
+        });
+    });
+
+    describe("reset", () => {
+        it("accepts a bare reset", () => {
+            assert.deepStrictEqual(parseSetOptionBody({ kind: "reset" }), {
+                kind: "reset",
+            });
+        });
+    });
+});


### PR DESCRIPTION
Adds integration test coverage for the two under-tested seams left from the Activity option / multiple-choice work.

## What's covered

**`parseSetOptionBody`** — the server-side whitelist for `POST /api/activity/option` (new `activity_set_option.test.ts`, 84 cases). Full matrix per option kind:
- gender subset / full set / unknown value / non-array / >4 cap / non-string entry
- every enum kind (`guessMode`, `multiguess`, `shuffle`, `seek`, `language`, `release`, `artisttype`, `subunits`, `answer`, `ost`): valid accept, out-of-set reject, wrong-type reject
- nullable `special` (valid / null clears / unknown)
- paired-int `limit` (ascending, start≥end, out-of-range, non-integer)
- `cutoff` year range (valid, begin>end, before earliest year, future end)
- nullable scalars `goal` / `timer` / `duration` (valid, null resets, below/above range)
- artist lists `groups` / `includes` / `excludes` (valid, empty, non-positive id, non-integer id, >200 cap, non-array)
- `playlist` (URL, null clears, over-long, non-string) and `reset`

The validator is exported for the test.

**`ActivityHub` guild-routed action ops** (+10 cases in `activity_hub.test.ts`, now 35): `submitMcGuess`, `startGame`, `skipVote`, `endGame`, `hint`, `bookmark`, `setOption`, `preset`, `profile`. Each pins the op name + args forwarding, and that the request routes to the cluster owning the guild (not always cluster 0).

## Bug found & fixed

The matrix surfaced a latent bug in `nullableIntInRange`: it returned `null` (not `undefined`) for a present-but-invalid `goal` / `timer` / `duration`, so the handler's `=== undefined` reject guard was dead code. An out-of-range or wrong-type value was silently coerced to `null` — clearing the option — instead of being rejected with a 400. It now signals invalid as `undefined` so the caller rejects it; an explicit `null` still legitimately clears the option.

## Verification

- `tsc --noEmit` clean on touched files
- `lint-ci` exit 0, prettier clean
- 119 tests passing