### PR TITLE
Ack Activity MC guesses before round transition

### DIFF
--- a/src/structures/activity_bridge.ts
+++ b/src/structures/activity_bridge.ts
@@ -571,20 +571,39 @@ function ensureWorkerHandlerRegistered(): void {
                         session.guildID,
                     );
 
+                    // Reply at most once. The pick is accepted (and recorded)
+                    // before the round-lifecycle transition runs, so we ack as
+                    // soon as it's accepted via onAccepted rather than waiting
+                    // for guessSong → endRound, which can block on the
+                    // lifecycleMutex for many seconds and blow past the
+                    // client's request timeout even though the guess landed.
+                    let replied = false;
+                    const replyOnce = (
+                        payload: ActivityGuessResponse,
+                    ): void => {
+                        if (replied) return;
+                        replied = true;
+                        reply(payload);
+                    };
+
                     session
                         .submitMultipleChoiceGuess(
                             mcArgs.userID,
                             mcArgs.choiceID,
                             mcArgs.ts,
                             messageContext,
-                        )
-                        .then((result) => {
-                            // INELIGIBLE = no round / already picked / not
-                            // eligible → reject so the client can surface it.
+                            undefined,
                             // CORRECT/INCORRECT both accepted the pick; the
                             // client learns correctness from the guessReceived
                             // / roundEnd events.
-                            reply(
+                            () => replyOnce({ ok: true }),
+                        )
+                        .then((result) => {
+                            // onAccepted never fired → INELIGIBLE (no round /
+                            // already picked / not eligible). Reject so the
+                            // client can surface it. (If it did fire, this is a
+                            // no-op.)
+                            replyOnce(
                                 result === MultipleChoiceGuessResult.INELIGIBLE
                                     ? { ok: false, reason: "no_round" }
                                     : { ok: true },
@@ -594,7 +613,9 @@ function ensureWorkerHandlerRegistered(): void {
                             logger.error(
                                 `Error in activity mc-guess for gid=${mcArgs.guildID}, uid=${mcArgs.userID}. err=${e}`,
                             );
-                            reply({ ok: false, reason: "internal" });
+                            // If we already acked the accepted pick, the round
+                            // transition just failed downstream — keep the ack.
+                            replyOnce({ ok: false, reason: "internal" });
                         });
 
                     return;

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -606,6 +606,11 @@ export default class GameSession extends Session {
      * @param messageContext - context for the synthesized guess
      * @param onCorrect - invoked once, right before the correct-guess scoring
      * runs, so an interaction-based caller can acknowledge within the deadline
+     * @param onAccepted - invoked once with the (incorrect/correct) outcome as
+     * soon as the pick is accepted, BEFORE the round-lifecycle transition
+     * (guessSong → endRound) runs. Lets a caller acknowledge immediately
+     * instead of blocking on the lifecycleMutex, which can be contended for
+     * many seconds. Not called for ineligible picks.
      * @returns whether the pick was ineligible, incorrect, or correct
      */
     async submitMultipleChoiceGuess(
@@ -614,6 +619,11 @@ export default class GameSession extends Session {
         createdAt: number,
         messageContext: MessageContext,
         onCorrect?: () => Promise<unknown>,
+        onAccepted?: (
+            outcome:
+                | MultipleChoiceGuessResult.INCORRECT
+                | MultipleChoiceGuessResult.CORRECT,
+        ) => void,
     ): Promise<MultipleChoiceGuessResult> {
         const round = this.round;
         if (!round) return MultipleChoiceGuessResult.INELIGIBLE;
@@ -644,6 +654,7 @@ export default class GameSession extends Session {
                     (button) => button.custom_id === choiceID,
                 )?.label ?? "";
 
+            onAccepted?.(MultipleChoiceGuessResult.INCORRECT);
             await this.guessSong(messageContext, chosenLabel, createdAt);
             return MultipleChoiceGuessResult.INCORRECT;
         }
@@ -652,6 +663,7 @@ export default class GameSession extends Session {
             await onCorrect();
         }
 
+        onAccepted?.(MultipleChoiceGuessResult.CORRECT);
         await this.guessSong(
             messageContext,
             this.guildPreference.gameOptions.guessModeType !==


### PR DESCRIPTION
## Problem

Activity multiple-choice guesses (the Activity's primary input) time out under load. In prod logs, `op=mcGuess` accounts for ~all `Activity request timed out` warnings — normally ~10–50/day, with a 504-event spike on 2026-06-26 concentrated in a single guild.

Root cause is a timeout/mutex mismatch:
- `ACTIVITY_REQUEST_TIMEOUT_MS = 10_000` (`src/constants.ts`)
- `lifecycleMutex = withTimeout(new Mutex(), 30_000)` (`src/structures/session.ts`)

The `mcGuess` reply is gated behind `submitMultipleChoiceGuess → guessSong → endRound`, and `endRound` runs inside `lifecycleMutex.runExclusive(...)`. Under contention that mutex is held for many seconds (observed `endRound() waited …` up to ~21s), so the 10s Activity request times out **even though the pick was already accepted and recorded** — surfacing a spurious error to the player and unlocking the choice grid for a re-pick.

## Fix

The accept/reject decision is known *before* the lifecycle transition, and the client learns correctness from `guessReceived` / `roundEnd` stream events rather than the reply payload. Add an `onAccepted` callback to `submitMultipleChoiceGuess` that fires as soon as the pick is accepted (before `guessSong`), and have the Activity bridge reply from it (guarded so it replies at most once), letting `endRound` complete in the background.

- Ineligible picks still reply `no_round` via the resolved promise.
- If the background transition throws after we've already acked, the ack is kept (error is logged).
- The Discord button path is unchanged — it doesn't pass `onAccepted`.

## Testing

- `tsc --noEmit`: clean
- eslint / prettier: clean
- `mocha` activity_hub + activity_set_option + game_round suites: 154 passing