### PR TITLE
Batch news generation into one Gemini request per range

### DIFF
--- a/src/helpers/gemini_client.ts
+++ b/src/helpers/gemini_client.ts
@@ -1,12 +1,48 @@
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GoogleGenerativeAI, SchemaType } from "@google/generative-ai";
 import { IPCLogger } from "../logger";
 import { standardDateFormat } from "./utils";
 import LocaleType from "../enums/locale_type";
 import NewsRange from "../enums/news_range";
-import type { GenerativeModel } from "@google/generative-ai";
+import type { GenerativeModel, ResponseSchema } from "@google/generative-ai";
 import type { KpopNewsRedditPost } from "./reddit_client";
 
 const logger = new IPCLogger("gemini_client");
+
+// One batched request returns a summary for every locale, so the response is
+// far larger than a single-locale one. Cap it high enough to fit all locales
+// without truncating the JSON (which would make the whole batch unparseable).
+const NEWS_MAX_OUTPUT_TOKENS = 16384;
+
+// Human-readable language names help the model emit the correct language for
+// region-tagged codes (e.g. zh-CN, pt-BR, es-ES).
+const localeToLanguageName: Record<LocaleType, string> = {
+    [LocaleType.EN]: "English",
+    [LocaleType.KO]: "Korean",
+    [LocaleType.JA]: "Japanese",
+    [LocaleType.ES]: "European Spanish",
+    [LocaleType.FR]: "French",
+    [LocaleType.ZH]: "Simplified Chinese",
+    [LocaleType.NL]: "Dutch",
+    [LocaleType.ID]: "Indonesian",
+    [LocaleType.PT]: "Brazilian Portuguese",
+    [LocaleType.RU]: "Russian",
+    [LocaleType.DE]: "German",
+    [LocaleType.HI]: "Hindi",
+};
+
+// Force structured JSON output so a single multi-locale response can be parsed
+// deterministically (one entry per requested locale).
+const BATCHED_NEWS_SCHEMA: ResponseSchema = {
+    type: SchemaType.ARRAY,
+    items: {
+        type: SchemaType.OBJECT,
+        properties: {
+            locale: { type: SchemaType.STRING },
+            summary: { type: SchemaType.STRING },
+        },
+        required: ["locale", "summary"],
+    },
+};
 
 enum PromptInterval {
     DAY = "today",
@@ -27,20 +63,20 @@ const newsRangeToPromptInterval = (newsRange: NewsRange): PromptInterval => {
     }
 };
 
-const getNewsPrompt = (
+const getBatchedNewsPrompt = (
     posts: Array<Object>,
     interval: PromptInterval,
-    locale: LocaleType,
+    locales: ReadonlyArray<LocaleType>,
 ): string => {
-    let prompt = `You are Kimiqo, a friendly 23 year old K-pop enthusiast who follows the latest updates in K-pop. You are giving an update on the latest happenings in K-pop for a game called KMQ (K-pop Music Quiz). You will be given a string delimited by |, where each column is: the date, the type of post, and the title of the post. The posts are sorted by priority/significance.  Make sure to address the message to KMQ fans/players, and mention who you are. Limit your response to 250 words, even if it means you have to ignore some of the data.
+    const localeList = locales
+        .map((locale) => `${locale} (${localeToLanguageName[locale]})`)
+        .join(", ");
 
-Summarize ${interval} in K-pop in paragraph form (multiple paragraphs if needed), from the POV of an excited and preppy K-pop fan. Add a lot of personality to the summary. Use emojis where appropriate.`;
+    return `You are Kimiqo, a friendly 23 year old K-pop enthusiast who follows the latest updates in K-pop. You are giving an update on the latest happenings in K-pop for a game called KMQ (K-pop Music Quiz). You will be given a string delimited by |, where each column is: the date, the type of post, and the title of the post. The posts are sorted by priority/significance. Make sure to address the message to KMQ fans/players, and mention who you are. Limit each summary to 250 words, even if it means you have to ignore some of the data.
 
-    if (locale !== LocaleType.EN) {
-        prompt += ` Respond in the locale: ${locale}.`;
-    }
+Summarize ${interval} in K-pop in paragraph form (multiple paragraphs if needed), from the POV of an excited and preppy K-pop fan. Add a lot of personality to the summary. Use emojis where appropriate.
 
-    return `${prompt} Data is below:\n${posts.join("\n")}\n`;
+Write the summary in every one of these locales: ${localeList}. Return a JSON array with exactly one object per requested locale; set "locale" to the exact locale code from the list and "summary" to the summary written in that locale's language. Data is below:\n${posts.join("\n")}\n`;
 };
 
 export default class GeminiClient {
@@ -53,40 +89,88 @@ export default class GeminiClient {
         });
     }
 
-    async getPostSummary(
-        locale: LocaleType,
+    /**
+     * Generate news summaries for every requested locale in a single request.
+     * Each locale used to cost its own request, which exhausted the
+     * requests-per-minute quota while barely touching the token allowance;
+     * batching the languages trades many small requests for one large one.
+     * Output is forced to JSON (one entry per locale) so it parses reliably.
+     * @param newsRange - the time range to summarize
+     * @param topPosts - the source posts (shared across locales)
+     * @param locales - the locales to produce summaries for
+     * @returns a map of locale to summary; locales missing from the model's
+     * response are simply absent (callers handle the gaps)
+     */
+    async getPostSummaries(
         newsRange: NewsRange,
         topPosts: Array<KpopNewsRedditPost>,
-    ): Promise<string> {
+        locales: ReadonlyArray<LocaleType>,
+    ): Promise<Map<LocaleType, string>> {
+        const summaries = new Map<LocaleType, string>();
+        if (locales.length === 0) {
+            return summaries;
+        }
+
         try {
             const formattedTopPosts = topPosts.map(
                 (x) =>
                     `${standardDateFormat(x.date)} | ${x.flair} | ${x.title}`,
             );
 
-            const prompt = getNewsPrompt(
+            const prompt = getBatchedNewsPrompt(
                 formattedTopPosts,
                 newsRangeToPromptInterval(newsRange),
-                locale,
+                locales,
             );
 
-            const generatedContent = await this.client.generateContent(prompt);
+            const generatedContent = await this.client.generateContent({
+                contents: [{ role: "user", parts: [{ text: prompt }] }],
+                generationConfig: {
+                    responseMimeType: "application/json",
+                    responseSchema: BATCHED_NEWS_SCHEMA,
+                    maxOutputTokens: NEWS_MAX_OUTPUT_TOKENS,
+                },
+            });
 
             const text = generatedContent.response.text();
             if (text === "") {
                 throw new Error(
-                    `Failed to generate text. generatedContent = ${JSON.stringify(
+                    `Empty response. newsRange = ${newsRange}. generatedContent = ${JSON.stringify(
                         generatedContent,
-                    )}. prompt = ${prompt}`,
+                    )}`,
                 );
             }
 
-            return text;
+            const parsed = JSON.parse(text) as unknown;
+            if (!Array.isArray(parsed)) {
+                throw new Error(
+                    `Expected a JSON array, got ${typeof parsed}. text = ${text}`,
+                );
+            }
+
+            const requested = new Set<string>(locales);
+            for (const entry of parsed as Array<{
+                locale?: unknown;
+                summary?: unknown;
+            } | null>) {
+                if (
+                    entry &&
+                    typeof entry.locale === "string" &&
+                    typeof entry.summary === "string" &&
+                    requested.has(entry.locale)
+                ) {
+                    summaries.set(entry.locale as LocaleType, entry.summary);
+                }
+            }
+
+            return summaries;
         } catch (e) {
             logger.warn(
-                `Failed to fetch getPostSummary(). locale = ${locale}. newsRange = ${newsRange}. e = ${e}`,
+                `Failed to fetch getPostSummaries(). newsRange = ${newsRange}. locales = ${locales.join(
+                    ",",
+                )}. e = ${e}`,
             );
-            return "";
+            return summaries;
         }
     }
 }

--- a/src/kmq_service.ts
+++ b/src/kmq_service.ts
@@ -178,91 +178,116 @@ export default class ServiceWorker extends BaseServiceWorker {
             }),
         );
 
-        for (const locale of Object.values(LocaleType)) {
-            for (const range of Object.values(NewsRange)) {
-                const newsIdentifier = `${locale}-${range}`;
+        const locales = Object.values(LocaleType);
+        const freshnessCutoff = new Date(new Date().getTime() - 60 * 60 * 1000);
+
+        for (const range of Object.values(NewsRange)) {
+            const topPosts = rangeToTopPosts[range];
+            if (!topPosts) {
+                logger.warn(
+                    `Skipping generating news for ${range} because topPosts is null`,
+                );
+                continue;
+            }
+
+            // Skip locales whose entry was generated within the last hour.
+            // eslint-disable-next-line no-await-in-loop
+            const freshEntries = await dbContext.kmq
+                .selectFrom("news")
+                .select("identifier")
+                .where(
+                    "identifier",
+                    "in",
+                    locales.map((locale) => `${locale}-${range}`),
+                )
+                .where("generated_at", ">", freshnessCutoff)
+                .execute();
+
+            const freshIdentifiers = new Set(
+                freshEntries.map((entry) => entry.identifier),
+            );
+
+            const localesToGenerate = locales.filter(
+                (locale) => !freshIdentifiers.has(`${locale}-${range}`),
+            );
+
+            if (localesToGenerate.length === 0) {
+                logger.info(
+                    `Skipping news generation for ${range}, all locale entries too fresh.`,
+                );
+                continue;
+            }
+
+            try {
+                // One request per range covers every locale. A call per locale
+                // exhausted the requests-per-minute quota while barely using
+                // the token allowance, so batch the languages together. Retry
+                // only fires when the whole batch is unusable, keeping us well
+                // under the RPM limit even on partial failures.
                 // eslint-disable-next-line no-await-in-loop
-                const latestEntry = await dbContext.kmq
-                    .selectFrom("news")
-                    .select("generated_at")
-                    .where("identifier", "=", newsIdentifier)
-                    .executeTakeFirst();
+                await retryJob<void | Error>(
+                    async () => {
+                        const summaries = await geminiClient.getPostSummaries(
+                            range as NewsRange,
+                            topPosts,
+                            localesToGenerate,
+                        );
 
-                // skip generation if news was generated in the past hour
-                if (
-                    latestEntry &&
-                    latestEntry.generated_at >
-                        new Date(new Date().getTime() - 60 * 60 * 1000)
-                ) {
-                    logger.info(
-                        `Skipping news generation for ${newsIdentifier}, entry too fresh. ${latestEntry.generated_at.toISOString()}`,
-                    );
-                    continue;
-                }
-
-                try {
-                    // eslint-disable-next-line no-await-in-loop
-                    await retryJob<void | Error>(
-                        async () => {
-                            const topPosts = rangeToTopPosts[range];
-                            if (!topPosts) {
+                        const rows: Array<Insertable<News>> = [];
+                        for (const locale of localesToGenerate) {
+                            const summary = summaries.get(locale);
+                            if (!summary) {
                                 logger.warn(
-                                    `Skipping generating news for ${locale} ${range} because topPosts is null`,
+                                    `Missing news summary for ${locale} ${range}`,
                                 );
-                                return Promise.resolve();
-                            }
-
-                            const summary = await geminiClient.getPostSummary(
-                                locale as LocaleType,
-                                range as NewsRange,
-                                topPosts,
-                            );
-
-                            if (summary === "") {
-                                logger.warn(
-                                    `Error generating news for ${locale} ${range}`,
-                                );
-                                return Promise.reject(
-                                    new Error(
-                                        `Error generating news for ${locale} ${range}`,
-                                    ),
-                                );
+                                continue;
                             }
 
                             if (summary.length < 300 || summary.length > 2500) {
-                                return Promise.reject(
-                                    new Error(
-                                        `Received abnormally sized news entry for ${locale} ${range}. length = ${summary.length}`,
-                                    ),
+                                logger.warn(
+                                    `Received abnormally sized news entry for ${locale} ${range}. length = ${summary.length}`,
                                 );
+                                continue;
                             }
 
-                            const updatePayload: Insertable<News> = {
-                                identifier: newsIdentifier,
+                            rows.push({
+                                identifier: `${locale}-${range}`,
                                 content: summary,
                                 generated_at: new Date(),
-                            };
+                            });
+                        }
 
-                            await dbContext.kmq
-                                .insertInto("news")
-                                .values(updatePayload)
-                                .onDuplicateKeyUpdate(updatePayload)
-                                .execute();
-
-                            logger.info(
-                                `Generated news for ${locale} ${range}`,
+                        if (rows.length === 0) {
+                            return Promise.reject(
+                                new Error(`Error generating news for ${range}`),
                             );
-                            return Promise.resolve();
-                        },
-                        [],
-                        3,
-                        true,
-                        60 * 1000,
-                        false,
-                    );
-                } catch (err) {
-                    logger.warn(`Failed to generate news. err = ${err}`);
-                }
+                        }
+
+                        await Promise.all(
+                            rows.map((row) =>
+                                dbContext.kmq
+                                    .insertInto("news")
+                                    .values(row)
+                                    .onDuplicateKeyUpdate(row)
+                                    .execute(),
+                            ),
+                        );
+
+                        logger.info(
+                            `Generated news for ${range} (${rows.length}/${localesToGenerate.length} locales)`,
+                        );
+                        return Promise.resolve();
+                    },
+                    [],
+                    3,
+                    true,
+                    60 * 1000,
+                    false,
+                );
+            } catch (err) {
+                logger.warn(
+                    `Failed to generate news for ${range}. err = ${err}`,
+                );
             }
         }
     }

--- a/src/test/unit_tests/ci/game_utils.test.ts
+++ b/src/test/unit_tests/ci/game_utils.test.ts
@@ -463,29 +463,40 @@ describe("game utils", () => {
             });
         });
 
-        describe("cleanupInactiveGameSessions", async () => {
+        describe("cleanupInactiveGameSessions", () => {
             const guildId = "123";
-            sandbox
-                .stub(discordUtils, "getCurrentVoiceMembers")
-                .callsFake((_voiceChannelID) => []);
-            guildPreference = await getMockGuildPreference();
-            const gameSession = new GameSession(
-                guildPreference,
-                "id",
-                "id",
-                guildId,
-                new KmqMember("id"),
-                GameType.CLASSIC,
-            );
+            let gameSession: GameSession;
+            let endSessionStub: sinon.SinonStub;
 
-            sandbox.restore();
-            const endSandbox = sinon.createSandbox();
-            const endSessionStub = sandbox.stub(gameSession, "endSession");
+            // Build the stubbed session in a hook rather than in the describe
+            // body. An async describe callback defers the rest of the body
+            // (and the nested suites/stub) into microtasks, which races spec
+            // collection and made this block order-dependent on whatever file
+            // loads next.
+            before(async () => {
+                sandbox
+                    .stub(discordUtils, "getCurrentVoiceMembers")
+                    .callsFake((_voiceChannelID) => []);
+
+                const cleanupGuildPreference = await getMockGuildPreference();
+                gameSession = new GameSession(
+                    cleanupGuildPreference,
+                    "id",
+                    "id",
+                    guildId,
+                    new KmqMember("id"),
+                    GameType.CLASSIC,
+                );
+
+                endSessionStub = sandbox.stub(gameSession, "endSession");
+            });
+
             after(() => {
-                endSandbox.restore();
+                sandbox.restore();
             });
 
             beforeEach(() => {
+                endSessionStub.resetHistory();
                 State.gameSessions = {
                     [guildId]: gameSession,
                 };
@@ -493,6 +504,7 @@ describe("game utils", () => {
 
             describe("no inactive gamesessions", () => {
                 it("should not clean up", async () => {
+                    gameSession.lastActive = Date.now();
                     await cleanupInactiveGameSessions(State.gameSessions);
                     assert.strictEqual(
                         State.gameSessions[guildId],

--- a/src/test/unit_tests/ci/gemini_client.test.ts
+++ b/src/test/unit_tests/ci/gemini_client.test.ts
@@ -1,0 +1,142 @@
+import GeminiClient from "../../../helpers/gemini_client";
+import LocaleType from "../../../enums/locale_type";
+import NewsRange from "../../../enums/news_range";
+import assert from "assert";
+import sinon from "sinon";
+import type { KpopNewsRedditPost } from "../../../helpers/reddit_client";
+
+const topPosts: Array<KpopNewsRedditPost> = [
+    { date: new Date("2026-06-01"), flair: "Comeback", title: "A new MV" },
+] as unknown as Array<KpopNewsRedditPost>;
+
+/**
+ * Stub the underlying Gemini model so getPostSummaries() can be exercised
+ * without a network call.
+ * @param client - the GeminiClient whose model should be stubbed
+ * @param text - the raw response text the stubbed model returns
+ * @returns the sinon stub standing in for generateContent
+ */
+function stubGenerate(client: GeminiClient, text: string): sinon.SinonStub {
+    return sinon
+        .stub((client as any).client, "generateContent")
+        .resolves({ response: { text: () => text } });
+}
+
+describe("GeminiClient.getPostSummaries", () => {
+    let client: GeminiClient;
+
+    before(() => {
+        process.env.GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? "test-key";
+    });
+
+    beforeEach(() => {
+        client = new GeminiClient();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it("returns one entry per requested locale from a JSON array", async () => {
+        const longSummary = "x".repeat(400);
+        stubGenerate(
+            client,
+            JSON.stringify([
+                { locale: LocaleType.EN, summary: longSummary },
+                { locale: LocaleType.KO, summary: longSummary },
+            ]),
+        );
+
+        const summaries = await client.getPostSummaries(
+            NewsRange.DAILY,
+            topPosts,
+            [LocaleType.EN, LocaleType.KO],
+        );
+
+        assert.strictEqual(summaries.size, 2);
+        assert.strictEqual(summaries.get(LocaleType.EN), longSummary);
+        assert.strictEqual(summaries.get(LocaleType.KO), longSummary);
+    });
+
+    it("ignores unrequested locales and malformed entries", async () => {
+        stubGenerate(
+            client,
+            JSON.stringify([
+                { locale: LocaleType.EN, summary: "valid" },
+                { locale: LocaleType.JA, summary: "not requested" },
+                null,
+                { locale: LocaleType.KO },
+                { summary: "no locale" },
+                { locale: LocaleType.KO, summary: 123 },
+            ]),
+        );
+
+        const summaries = await client.getPostSummaries(
+            NewsRange.WEEKLY,
+            topPosts,
+            [LocaleType.EN, LocaleType.KO],
+        );
+
+        assert.deepStrictEqual([...summaries.keys()], [LocaleType.EN]);
+        assert.strictEqual(summaries.get(LocaleType.EN), "valid");
+    });
+
+    it("returns an empty map (no throw) on non-array JSON", async () => {
+        stubGenerate(client, JSON.stringify({ not: "an array" }));
+
+        const summaries = await client.getPostSummaries(
+            NewsRange.MONTHLY,
+            topPosts,
+            [LocaleType.EN],
+        );
+
+        assert.strictEqual(summaries.size, 0);
+    });
+
+    it("returns an empty map (no throw) on invalid JSON", async () => {
+        stubGenerate(client, "this is not json");
+
+        const summaries = await client.getPostSummaries(
+            NewsRange.DAILY,
+            topPosts,
+            [LocaleType.EN],
+        );
+
+        assert.strictEqual(summaries.size, 0);
+    });
+
+    it("makes no request when no locales are requested", async () => {
+        const stub = stubGenerate(client, "[]");
+
+        const summaries = await client.getPostSummaries(
+            NewsRange.DAILY,
+            topPosts,
+            [],
+        );
+
+        assert.strictEqual(summaries.size, 0);
+        assert.ok(stub.notCalled);
+    });
+
+    it("requests JSON output with the batched schema", async () => {
+        const stub = stubGenerate(
+            client,
+            JSON.stringify([
+                { locale: LocaleType.EN, summary: "x".repeat(400) },
+            ]),
+        );
+
+        await client.getPostSummaries(NewsRange.DAILY, topPosts, [
+            LocaleType.EN,
+        ]);
+
+        const request = stub.firstCall.args[0] as {
+            generationConfig?: { responseMimeType?: string };
+        };
+
+        assert.strictEqual(
+            request.generationConfig?.responseMimeType,
+            "application/json",
+        );
+    });
+});


### PR DESCRIPTION
## Problem

News summaries were generated with one Gemini request **per locale per range** — 12 locales × 3 ranges = 36 calls/hour (×3 on retry). This exhausted the Gemini requests-per-minute quota, producing ~3,400 `429 Too Many Requests` failures/day (~11k total warnings/day across the gemini/service/retry layers) while barely touching the much larger token allowance. The feature was effectively non-functional in prod.

## Fix

Generate every locale's summary for a range in a **single request** (3 calls/hour). Per-request:
- Output is forced to `application/json` with a `responseSchema` (array of `{locale, summary}`) so the multi-locale response parses deterministically.
- `maxOutputTokens` is raised so 12 summaries can't truncate the JSON (a truncation would break the whole batch).
- Retries only fire when the **entire** batch is unusable, so partial failures don't reinflate the request count.
- Freshness skipping is now evaluated per range; only locales not already fresh are requested.
- Unparseable / non-array / missing-locale responses degrade gracefully (locales simply absent; caller handles gaps).

### Note on batching dimension
Batched by **language within a range** (3 req/hr), not all 36 into one request, since the source posts differ per range. Easy to collapse ranges too if 1 req/hr is preferred.

## Testing

- New `src/test/unit_tests/ci/gemini_client.test.ts` (6 cases): happy path, filtering malformed/unrequested entries, invalid + non-array JSON, empty-locale short-circuit, and asserting the request sets `responseMimeType: application/json`.
- `tsc --noEmit`: clean
- eslint / prettier: clean
- `mocha gemini_client.test.ts`: 6 passing