### PR TITLE
Fix ~songStartDelay stall between guessing and round end

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -1178,7 +1178,20 @@ export default class GameSession extends Session {
             ? 0
             : this.guildPreference.getSongStartDelay() * 1000;
 
-        if (this.sessionInitialized) {
+        // Only wait out the song-start delay when we're actually going to start
+        // a round. endRoundCore() already chains startRoundCore() to begin the
+        // next round, so guessSong's explicit startRound() in the "everybody
+        // guessed, nobody correct" path is usually redundant — a round already
+        // exists. Without skipping the delay here, that redundant call would
+        // hold the lifecycleMutex for the full song-start delay before the guard
+        // below bails, blocking the next round's endRound() (i.e. the next
+        // guess) for ~songStartDelay seconds.
+        if (
+            this.sessionInitialized &&
+            !this.finished &&
+            !this.round &&
+            !this.pendingEndSession
+        ) {
             // Only add a delay if the game has already started
             await delay(
                 this.multiguessDelayIsActive(this.guildPreference)


### PR DESCRIPTION
## Symptom

Solo players (observed on canary, in the Activity) feel a delay — often +1s or longer — between guessing and the round ending. Disabling multiguess did not help.

## Root cause

`endRoundCore()` already chains into `startRoundCore()` (game_session.ts:1421) to begin the next round. But `guessSong`'s **"everybody guessed, nobody correct"** branch *also* calls `startRound()` explicitly afterward — a redundant second start, since a round is already active.

In `startRoundCore()`, the `songStartDelay` wait (default **3s**) ran *before* the `if (this.finished || this.round || this.pendingEndSession) return null` guard. So the redundant call acquired the `lifecycleMutex`, slept for the full song-start delay, and only then discovered a round already existed and bailed. While it held the mutex, the **next** round's `endRound()` — triggered by the player's guess — was blocked for up to ~`songStartDelay` seconds.

### Why it matched the observations
- The stall appears only when the **previous** round ended via "everybody guessed, nobody correct" (the path with the redundant `startRound`). Rounds following a correct guess were instant.
- Not multiguess: solo players skip the multiguess delay entirely (`playerIsAlone`), and it reproduced with multiguess off.
- No mutex-wait log: the wait (~3s) is under the 5s logging threshold in `endRound()`.
- The faster you guess, the longer the wait — you're waiting out the remainder of the redundant 3s delay.

Verified pattern from canary logs (guess → "Round ending"):

| Round | Previous round outcome | gap |
|---|---|---|
| A | everybody guessed | 2.46s |
| B | correct guess | 0.002s |
| C | everybody guessed | 2.66s |
| D | everybody guessed | 2.72s |

## Fix

Skip the song-start delay in `startRoundCore()` when a round is already active (or the session is ending), so the redundant `startRound()` bails immediately instead of holding the mutex for the full delay. Legitimate next-round starts (where `this.round` is null) are unaffected — the between-rounds delay is preserved. The explicit `startRound()` is kept as a safety net for the case where `endRoundCore()` early-returns (e.g. `songStartedAt === null`) and doesn't reach its `startRoundCore()` chain.

## Testing

- `tsc --noEmit`: clean
- eslint / prettier: clean
- `mocha game_round.test.ts`: 35 passing

Note: a full end-to-end round-timing check requires the test DB + a live voice session, which isn't reproducible locally; the diagnosis is grounded in the production canary log timing pattern above.