### PR TITLE
Add Activity social juice: live emotes + post-game recap

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -29,6 +29,7 @@ import {
     openActivityStream,
     preset as apiPreset,
     searchSongs,
+    sendEmote as apiSendEmote,
     setOption as apiSetOption,
     skipVote as apiSkipVote,
     startGame as apiStartGame,
@@ -71,12 +72,14 @@ import type {
     ActivitySongSearchResult,
 } from "./types/activity_song_info";
 import type ActivityEvent from "./types/activity_event";
+import type FloatingEmote from "./types/floating_emote";
 import type ActivityRoundMeta from "./types/activity_round_meta";
 import type { ActivityMultipleChoiceOption } from "./types/activity_round_meta";
 import type ActivityScoreboardSnapshot from "./types/activity_scoreboard_snapshot";
 import type ActivitySnapshot from "./types/activity_snapshot";
 import type GuessRejectReason from "./types/guess_reject_reason";
 import type HintState from "./types/hint_state";
+import type SessionRecap from "./types/session_recap";
 import type SkipState from "./types/skip_state";
 import type UiState from "./types/ui_state";
 
@@ -147,6 +150,8 @@ const initialUi: UiState = {
     hadSession: false,
     options: null,
     roundHistory: [],
+    floatingEmotes: [],
+    recap: null,
 };
 
 function applySnapshot(prev: UiState, snapshot: ActivitySnapshot): UiState {
@@ -1067,6 +1072,140 @@ function SongMontage({ history }: { history: UiState["roundHistory"] }) {
     );
 }
 
+/**
+ * Copies text to the clipboard, working inside the Discord Activity's sandboxed
+ * iframe where `navigator.clipboard.writeText` is often blocked (missing
+ * `clipboard-write` permission, or the document isn't focused). Tries the modern
+ * async API first, then falls back to a hidden-textarea `execCommand("copy")`,
+ * which a sandboxed iframe still honours on a user gesture.
+ * @param text - the text to copy
+ * @returns whether the copy succeeded
+ */
+async function copyToClipboard(text: string): Promise<boolean> {
+    if (navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+            return true;
+        } catch {
+            // Fall through to the legacy path below.
+        }
+    }
+
+    try {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.top = "-9999px";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        textarea.setSelectionRange(0, text.length);
+        const ok = document.execCommand("copy");
+        document.body.removeChild(textarea);
+        return ok;
+    } catch {
+        return false;
+    }
+}
+
+function buildRecapShareText(recap: SessionRecap, t: Translator): string {
+    const lines = [t("recap.shareHeader")];
+    lines.push(
+        t("recap.songs", {
+            correct: String(recap.totalCorrect),
+            rounds: String(recap.totalRounds),
+        }),
+    );
+    if (recap.mvp) {
+        lines.push(
+            t("recap.mvp", {
+                user: recap.mvp.username,
+                score: String(recap.mvp.score),
+            }),
+        );
+    }
+
+    if (recap.fastestGuess) {
+        lines.push(
+            t("recap.fastest", {
+                user: recap.fastestGuess.username,
+                seconds: (recap.fastestGuess.timeMs / 1000).toFixed(1),
+            }),
+        );
+    }
+
+    if (recap.longestStreak) {
+        lines.push(
+            t("recap.streak", {
+                user: recap.longestStreak.username,
+                streak: String(recap.longestStreak.streak),
+            }),
+        );
+    }
+
+    return lines.join("\n");
+}
+
+function RecapCard({ recap, t }: { recap: SessionRecap; t: Translator }) {
+    const [copied, setCopied] = useState(false);
+
+    const onCopy = (): void => {
+        void copyToClipboard(buildRecapShareText(recap, t)).then((ok) => {
+            if (ok) {
+                setCopied(true);
+                window.setTimeout(() => setCopied(false), 2000);
+            }
+
+            return undefined;
+        });
+    };
+
+    return (
+        <div className="recap-card">
+            <div className="recap-title">{t("recap.title")}</div>
+            <dl className="recap-stats">
+                <div>
+                    <dt>{t("recap.songsLabel")}</dt>
+                    <dd>
+                        {recap.totalCorrect}/{recap.totalRounds}
+                    </dd>
+                </div>
+                {recap.mvp && (
+                    <div>
+                        <dt>{t("recap.mvpLabel")}</dt>
+                        <dd>
+                            {recap.mvp.username} ({recap.mvp.score})
+                        </dd>
+                    </div>
+                )}
+                {recap.fastestGuess && (
+                    <div>
+                        <dt>{t("recap.fastestLabel")}</dt>
+                        <dd>
+                            {recap.fastestGuess.username} (
+                            {(recap.fastestGuess.timeMs / 1000).toFixed(1)}s)
+                        </dd>
+                    </div>
+                )}
+                {recap.longestStreak && (
+                    <div>
+                        <dt>{t("recap.streakLabel")}</dt>
+                        <dd>
+                            {recap.longestStreak.username} (×
+                            {recap.longestStreak.streak})
+                        </dd>
+                    </div>
+                )}
+            </dl>
+            <button type="button" className="recap-copy" onClick={onCopy}>
+                {copied ? t("recap.copied") : t("recap.copy")}
+            </button>
+        </div>
+    );
+}
+
 function CurrentRound({
     round,
     reveal,
@@ -1075,6 +1214,7 @@ function CurrentRound({
     viewerWon,
     history,
     guesses,
+    recap,
     t,
 }: {
     round: ActivityRoundMeta | null;
@@ -1090,6 +1230,8 @@ function CurrentRound({
     history: UiState["roundHistory"];
     /** Live guesses, shown in the in-round stage as they come in. */
     guesses: UiState["recentGuesses"];
+    /** End-of-session recap, shown on the game-over screen. */
+    recap: SessionRecap | null;
     t: Translator;
 }) {
     return (
@@ -1273,6 +1415,9 @@ function CurrentRound({
                                 <p className="empty">
                                     {t("waitingForNextRound")}
                                 </p>
+                            )}
+                            {winnerText && recap && (
+                                <RecapCard recap={recap} t={t} />
                             )}
                         </div>
                         {winnerText ? (
@@ -1964,6 +2109,102 @@ function Confetti() {
                             "--drift": `${p.drift}px`,
                         } as React.CSSProperties
                     }
+                />
+            ))}
+        </div>
+    );
+}
+
+// Mirror of ACTIVITY_EMOTES (server constants). Kept in sync manually; the
+// server re-validates, so an out-of-date client can only fail closed.
+const EMOTES = ["🔥", "😂", "👏", "😱", "❤️", "🎉"] as const;
+const FLOATING_EMOTE_LIMIT = 30;
+const EMOTE_FLOAT_MS = 2600;
+const EMOTE_CLIENT_COOLDOWN_MS = 500;
+
+function EmoteBar({
+    accessToken,
+    instanceId,
+    enabled,
+    t,
+}: {
+    accessToken: string;
+    instanceId: string;
+    enabled: boolean;
+    t: Translator;
+}) {
+    const lastSentRef = useRef(0);
+
+    const send = (emote: string): void => {
+        const now = Date.now();
+        if (now - lastSentRef.current < EMOTE_CLIENT_COOLDOWN_MS) return;
+        lastSentRef.current = now;
+        // Fire-and-forget: the broadcast drives the floating animation, so a
+        // failed send just means no emote appears — nothing to roll back.
+        void apiSendEmote(accessToken, instanceId, emote);
+    };
+
+    return (
+        <div className="emote-bar" role="group" aria-label={t("emoteBarLabel")}>
+            {EMOTES.map((emote) => (
+                <button
+                    key={emote}
+                    type="button"
+                    className="emote-button"
+                    disabled={!enabled}
+                    onClick={() => send(emote)}
+                >
+                    {emote}
+                </button>
+            ))}
+        </div>
+    );
+}
+
+function FloatingEmoteItem({
+    emote,
+    onDismiss,
+}: {
+    emote: FloatingEmote;
+    onDismiss: (id: string) => void;
+}) {
+    useEffect(() => {
+        const timer = window.setTimeout(
+            () => onDismiss(emote.id),
+            EMOTE_FLOAT_MS,
+        );
+        return () => window.clearTimeout(timer);
+    }, [emote.id, onDismiss]);
+
+    return (
+        <span
+            className="floating-emote"
+            style={{ left: `${emote.left}%` }}
+            aria-hidden
+        >
+            {emote.emote}
+        </span>
+    );
+}
+
+function FloatingEmotes({
+    emotes,
+    onDismiss,
+}: {
+    emotes: FloatingEmote[];
+    onDismiss: (id: string) => void;
+}) {
+    if (emotes.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="floating-emotes" aria-hidden>
+            {emotes.map((emote) => (
+                <FloatingEmoteItem
+                    key={emote.id}
+                    emote={emote}
+                    onDismiss={onDismiss}
                 />
             ))}
         </div>
@@ -3864,6 +4105,13 @@ export default function App() {
     const [error, setError] = useState<ConnectionError | null>(null);
     const [ready, setReady] = useState(false);
     const [ui, setUi] = useState<UiState>(initialUi);
+    // Stable so each floating emote's dismissal timer effect isn't re-armed.
+    const dismissFloatingEmote = useCallback((id: string) => {
+        setUi((prev) => ({
+            ...prev,
+            floatingEmotes: prev.floatingEmotes.filter((e) => e.id !== id),
+        }));
+    }, []);
     const [authState, setAuthState] = useState<{
         accessToken: string;
         instanceId: string;
@@ -4503,6 +4751,7 @@ export default function App() {
                             reveal={ui.lastReveal}
                             history={ui.roundHistory}
                             guesses={ui.recentGuesses}
+                            recap={ui.recap}
                             t={t}
                             winnerText={
                                 ui.sessionEnded &&
@@ -4680,6 +4929,15 @@ export default function App() {
                             </div>
                         )}
 
+                        {authState && (
+                            <EmoteBar
+                                accessToken={authState.accessToken}
+                                instanceId={authState.instanceId}
+                                enabled={!ui.sessionEnded}
+                                t={t}
+                            />
+                        )}
+
                         {authState && ui.options && (
                             <div className="options-section">
                                 <button
@@ -4765,6 +5023,11 @@ export default function App() {
                     </div>
                 </aside>
             </div>
+
+            <FloatingEmotes
+                emotes={ui.floatingEmotes}
+                onDismiss={dismissFloatingEmote}
+            />
         </>
     );
 }
@@ -4797,6 +5060,8 @@ function reduce(
                 currentRoundBookmarked: false,
                 hadSession: true,
                 roundHistory: [],
+                floatingEmotes: [],
+                recap: null,
             };
         case "roundStart":
             return {
@@ -4908,6 +5173,29 @@ function reduce(
                 lastReveal: null,
                 hint: initialHint,
                 skip: initialSkip,
+            };
+        case "recap":
+            return {
+                ...prev,
+                recap: {
+                    mvp: msg.mvp,
+                    fastestGuess: msg.fastestGuess,
+                    longestStreak: msg.longestStreak,
+                    totalCorrect: msg.totalCorrect,
+                    totalRounds: msg.totalRounds,
+                },
+            };
+        case "emote":
+            return {
+                ...prev,
+                floatingEmotes: [
+                    ...prev.floatingEmotes.slice(-FLOATING_EMOTE_LIMIT),
+                    {
+                        id: `${msg.userID}-${Date.now()}-${Math.random()}`,
+                        emote: msg.emote,
+                        left: 8 + Math.random() * 84,
+                    },
+                ],
             };
         case "optionsChanged":
             return { ...prev, options: msg.options };

--- a/activity/src/api.ts
+++ b/activity/src/api.ts
@@ -122,7 +122,7 @@ export async function fetchSnapshot(
 async function postAction(
     accessToken: string,
     instanceId: string,
-    path: "start" | "skip" | "end" | "hint",
+    path: "start" | "skip" | "end" | "hint" | "emote",
     extra?: Record<string, unknown>,
 ): Promise<GuessResult> {
     const resp = await fetch(`${ACTIVITY_PROXY_BASE}/${path}`, {
@@ -179,6 +179,12 @@ export const endGame = (accessToken: string, instanceId: string) =>
 
 export const hintVote = (accessToken: string, instanceId: string) =>
     postAction(accessToken, instanceId, "hint");
+
+export const sendEmote = (
+    accessToken: string,
+    instanceId: string,
+    emote: string,
+) => postAction(accessToken, instanceId, "emote", { emote });
 
 /**
  * Submit a GuildPreference change. Server validates the shape and accepts

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -1204,6 +1204,141 @@ body::before {
     gap: 8px;
 }
 
+/* ---- EMOTE BAR + FLOATING EMOTES ---- */
+.emote-bar {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.emote-button {
+    font-size: 1.15rem;
+    line-height: 1;
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: var(--bg-elevated);
+    cursor: pointer;
+    transition:
+        transform 0.1s ease,
+        background 0.15s ease;
+}
+
+.emote-button:hover:not(:disabled) {
+    background: var(--bg-hover);
+    transform: translateY(-1px) scale(1.08);
+}
+
+.emote-button:active:not(:disabled) {
+    transform: scale(0.92);
+}
+
+.emote-button:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.floating-emotes {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 40;
+}
+
+.floating-emote {
+    position: absolute;
+    bottom: 96px;
+    font-size: 2rem;
+    opacity: 0;
+    animation: emote-float 2.6s ease-out forwards;
+}
+
+@keyframes emote-float {
+    0% {
+        opacity: 0;
+        transform: translateY(0) scale(0.6);
+    }
+    15% {
+        opacity: 1;
+        transform: translateY(-20px) scale(1.1);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(-220px) scale(1);
+    }
+}
+
+.recap-card {
+    margin: 12px auto 0;
+    max-width: 320px;
+    padding: 14px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.recap-title {
+    font-weight: 700;
+    font-size: 0.95rem;
+    text-align: center;
+}
+
+.recap-stats {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.recap-stats > div {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.recap-stats dt {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.recap-stats dd {
+    margin: 0;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-align: right;
+}
+
+.recap-copy {
+    align-self: center;
+    padding: 8px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition:
+        transform 0.1s ease,
+        background 0.15s ease;
+}
+
+.recap-copy:hover {
+    background: var(--bg-hover);
+    transform: translateY(-1px);
+}
+
+.recap-copy:active {
+    transform: scale(0.96);
+}
+
 .vote-row .hint-control {
     margin: 0;
 }

--- a/activity/src/types/activity_event.ts
+++ b/activity/src/types/activity_event.ts
@@ -34,6 +34,29 @@ type ActivityEvent =
           ts: number;
       }
     | { type: "sessionEnd"; reason: string }
+    | {
+          type: "recap";
+          mvp: { userID: string; username: string; score: number } | null;
+          fastestGuess: {
+              userID: string;
+              username: string;
+              timeMs: number;
+          } | null;
+          longestStreak: {
+              userID: string;
+              username: string;
+              streak: number;
+          } | null;
+          totalCorrect: number;
+          totalRounds: number;
+      }
+    | {
+          type: "emote";
+          userID: string;
+          username: string;
+          avatarUrl: string | null;
+          emote: string;
+      }
     | { type: "hintProgress"; requesters: number; threshold: number }
     | { type: "hintRevealed"; text: string }
     | { type: "skipProgress"; requesters: number; threshold: number }

--- a/activity/src/types/floating_emote.ts
+++ b/activity/src/types/floating_emote.ts
@@ -1,0 +1,8 @@
+// A transient emote drifting up the screen after a player flung it.
+export default interface FloatingEmote {
+    /** Unique key for React + dismissal. */
+    id: string;
+    emote: string;
+    /** Horizontal anchor as a viewport percentage (0–100). */
+    left: number;
+}

--- a/activity/src/types/session_recap.ts
+++ b/activity/src/types/session_recap.ts
@@ -1,0 +1,16 @@
+// Mirror of the "recap" ActivityEvent payload (names resolved server-side).
+export default interface SessionRecap {
+    mvp: { userID: string; username: string; score: number } | null;
+    fastestGuess: {
+        userID: string;
+        username: string;
+        timeMs: number;
+    } | null;
+    longestStreak: {
+        userID: string;
+        username: string;
+        streak: number;
+    } | null;
+    totalCorrect: number;
+    totalRounds: number;
+}

--- a/activity/src/types/ui_state.ts
+++ b/activity/src/types/ui_state.ts
@@ -5,8 +5,10 @@ import type ActivityRoundMeta from "./activity_round_meta";
 import type ActivityRoundReveal from "./activity_round_reveal";
 import type ActivityScoreboardSnapshot from "./activity_scoreboard_snapshot";
 import type ActivitySessionMeta from "./activity_session_meta";
+import type FloatingEmote from "./floating_emote";
 import type HintState from "./hint_state";
 import type RecentGuess from "./recent_guess";
+import type SessionRecap from "./session_recap";
 import type SkipState from "./skip_state";
 
 export default interface UiState {
@@ -36,4 +38,8 @@ export default interface UiState {
     /** Rounds revealed so far in the current session, oldest-first. Populated
      *  on roundEnd and reset on sessionStart. */
     roundHistory: ActivityRoundReveal[];
+    /** In-flight floating emotes, removed on a timer once their animation ends. */
+    floatingEmotes: FloatingEmote[];
+    /** End-of-session recap, shown on the game-over screen. Null until received. */
+    recap: SessionRecap | null;
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Diesen Song als Lesezeichen speichern",
         "bookmarkTitleDone": "Gespeichert — per DM am Ende der Sitzung",
         "connectFailed": "Konnte keine Verbindung zu KMQ herstellen. Bitte versuche es erneut.",
+        "emoteBarLabel": "Eine Reaktion senden",
         "endGameBusy": "Wird beendet…",
         "endGameButton": "Spiel beenden",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Abgegebene Stimmen",
             "voteCta": "Stimme für 2x EXP",
             "voteExpires": "Läuft ab in {{time}}"
+        },
+        "recap": {
+            "copied": "Kopiert!",
+            "copy": "Ergebnis kopieren",
+            "fastest": "⚡ Schnellste: {{user}} ({{seconds}}s)",
+            "fastestLabel": "Schnellste Vermutung",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 KMQ-Zusammenfassung",
+            "songs": "✅ {{correct}}/{{rounds}} Lieder erraten",
+            "songsLabel": "Erratene Lieder",
+            "streak": "🔥 Längste Serie: {{user}} (×{{streak}})",
+            "streakLabel": "Längste Serie",
+            "title": "Spielzusammenfassung"
         },
         "reconnectButton": "Erneut verbinden",
         "reconnecting": "Erneute Verbindung wird hergestellt...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "Du kannst diese Option nicht ändern, wenn du von einer Wiedergabeliste aus spielst. Verwende {{playlistResetCommand}}, bevor du diese Option änderst.",
             "notSuddenDeath": "Das kannst du während des Modus - plötzlicher Tod nicht machen.",
             "title": "Warten..."
+        },
+        "recap": {
+            "fastest": "⚡ Schnellste Vermutung: {{user}} ({{seconds}}s)",
+            "mvp": "👑 MVP: {{user}} ({{score}} Pkt)",
+            "streak": "🔥 Längste Serie: {{user}} (×{{streak}})",
+            "title": "Spielzusammenfassung"
         },
         "releaseDate": "Erscheinungsdatum",
         "restart": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Bookmark this song",
         "bookmarkTitleDone": "Bookmarked — DM'd at end of session",
         "connectFailed": "Couldn't connect to KMQ. Please try again.",
+        "emoteBarLabel": "Send a reaction",
         "endGameBusy": "Ending...",
         "endGameButton": "End game",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Times Voted",
             "voteCta": "Vote for 2x EXP",
             "voteExpires": "Expires in {{time}}"
+        },
+        "recap": {
+            "copied": "Copied!",
+            "copy": "Copy result",
+            "fastest": "⚡ Fastest: {{user}} ({{seconds}}s)",
+            "fastestLabel": "Fastest guess",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 KMQ Recap",
+            "songs": "✅ {{correct}}/{{rounds}} songs guessed",
+            "songsLabel": "Songs guessed",
+            "streak": "🔥 Longest streak: {{user}} (×{{streak}})",
+            "streakLabel": "Longest streak",
+            "title": "Game Recap"
         },
         "reconnectButton": "Reconnect",
         "reconnecting": "Reconnecting...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "You can't change that option when playing from a playlist. Use {{playlistResetCommand}} before changing this option.",
             "notSuddenDeath": "You can't do that during sudden death.",
             "title": "Wait..."
+        },
+        "recap": {
+            "fastest": "⚡ Fastest guess: {{user}} ({{seconds}}s)",
+            "mvp": "👑 MVP: {{user}} ({{score}} pts)",
+            "streak": "🔥 Longest streak: {{user}} (×{{streak}})",
+            "title": "Game Recap"
         },
         "releaseDate": "Release Date",
         "restart": {

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Marcar esta canción",
         "bookmarkTitleDone": "Marcada — se enviará por MD al final de la sesión",
         "connectFailed": "No se pudo conectar a KMQ. Por favor, inténtalo de nuevo.",
+        "emoteBarLabel": "Envía una reacción",
         "endGameBusy": "Finalizando…",
         "endGameButton": "Finalizar partida",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Veces votado",
             "voteCta": "Vota por 2x EXP",
             "voteExpires": "Expira en {{time}}"
+        },
+        "recap": {
+            "copied": "¡Copiado!",
+            "copy": "Copiar resultado",
+            "fastest": "⚡ Más rápido: {{user}} ({{seconds}}s)",
+            "fastestLabel": "Adivinanza más rápida",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 Resumen de KMQ",
+            "songs": "✅ {{correct}}/{{rounds}} canciones adivinadas",
+            "songsLabel": "Canciones adivinadas",
+            "streak": "🔥 Racha más larga: {{user}} (×{{streak}})",
+            "streakLabel": "Racha más larga",
+            "title": "Resumen del juego"
         },
         "reconnectButton": "Volver a conectar",
         "reconnecting": "Reconectando...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "No puedes cambiar esa opción cuando reproduces desde una lista de reproducción. Usa {{playlistResetCommand}} antes de cambiar esta opción.",
             "notSuddenDeath": "No puedes hacer eso durante la muerte súbita.",
             "title": "Espera..."
+        },
+        "recap": {
+            "fastest": "⚡ Adivinanza más rápida: {{user}} ({{seconds}}s)",
+            "mvp": "👑 MVP: {{user}} ({{score}} pts)",
+            "streak": "🔥 Racha más larga: {{user}} (×{{streak}})",
+            "title": "Resumen del juego"
         },
         "releaseDate": "Fecha de lanzamiento",
         "restart": {

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Mettre cette chanson en favori",
         "bookmarkTitleDone": "Mise en favori — envoyée en MP en fin de session",
         "connectFailed": "Impossible de se connecter à KMQ. Veuillez réessayer.",
+        "emoteBarLabel": "Envoyez une réaction",
         "endGameBusy": "Fin en cours…",
         "endGameButton": "Terminer la partie",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Fois voté",
             "voteCta": "Votez pour 2x EXP",
             "voteExpires": "Expire dans {{time}}"
+        },
+        "recap": {
+            "copied": "Copié !",
+            "copy": "Copier le résultat",
+            "fastest": "⚡ Le plus rapide : {{user}} ({{seconds}}s)",
+            "fastestLabel": "Réponse la plus rapide",
+            "mvp": "👑 MVP : {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 Récapitulatif KMQ",
+            "songs": "✅ {{correct}}/{{rounds}} chansons devinées",
+            "songsLabel": "Chansons devinées",
+            "streak": "🔥 Plus longue série : {{user}} (×{{streak}})",
+            "streakLabel": "Plus longue série",
+            "title": "Récapitulatif du jeu"
         },
         "reconnectButton": "Reconnecter",
         "reconnecting": "Reconnexion...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "Vous ne pouvez pas modifier cette option lors de la lecture à partir d'une playlist. Utilisez {{playlistResetCommand}} avant de modifier cette option.",
             "notSuddenDeath": "Vous ne pouvez pas faire ça pendant la mort subite.",
             "title": "Attendez..."
+        },
+        "recap": {
+            "fastest": "⚡ La réponse la plus rapide : {{user}} ({{seconds}}s)",
+            "mvp": "👑 MVP : {{user}} ({{score}} pts)",
+            "streak": "🔥 Plus longue série : {{user}} (×{{streak}})",
+            "title": "Récapitulatif du jeu"
         },
         "releaseDate": "Date de sortie",
         "restart": {

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "इस गाने को बुकमार्क करें",
         "bookmarkTitleDone": "बुकमार्क किया गया — सत्र के अंत में DM किया जाएगा",
         "connectFailed": "KMQ से कनेक्ट नहीं हो सका। कृपया फिर से प्रयास करें।",
+        "emoteBarLabel": "प्रतिक्रिया भेजें",
         "endGameBusy": "समाप्त हो रहा है…",
         "endGameButton": "खेल समाप्त करें",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "वोट किए गए समय",
             "voteCta": "2x EXP के लिए वोट करें",
             "voteExpires": "{{time}} में समाप्त होता है"
+        },
+        "recap": {
+            "copied": "कॉपी किया गया!",
+            "copy": "परिणाम कॉपी करें",
+            "fastest": "⚡ सबसे तेज़: {{user}} ({{seconds}}s)",
+            "fastestLabel": "सबसे तेज़ सही अनुमान",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 KMQ सारांश",
+            "songs": "✅ {{correct}}/{{rounds}} गाने का सही अनुमान लगाया",
+            "songsLabel": "गाने पहचाने गए",
+            "streak": "🔥 सबसे लंबी स्ट्रीक: {{user}} (×{{streak}})",
+            "streakLabel": "सबसे लंबी शृंखला",
+            "title": "खेल सारांश"
         },
         "reconnectButton": "पुनः कनेक्ट करें",
         "reconnecting": "पुन: कनेक्ट किया जा रहा है...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "आप किसी प्लेलिस्ट से खेलते समय उस विकल्प को नहीं बदल सकते। इस विकल्प को बदलने से पहले {{playlistResetCommand}} का उपयोग करें।",
             "notSuddenDeath": "आप अचानक मौत के दौरान ऐसा नहीं कर सकते।",
             "title": "प्रतीक्षा करें..."
+        },
+        "recap": {
+            "fastest": "⚡ सबसे तेज़ अनुमान: {{user}} ({{seconds}}s)",
+            "mvp": "👑 MVP: {{user}} ({{score}} अंक)",
+            "streak": "🔥 सबसे लंबी स्ट्रीक: {{user}} (×{{streak}})",
+            "title": "खेल सारांश"
         },
         "releaseDate": "रिलीज़ तिथि",
         "restart": {

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Bookmark lagu ini",
         "bookmarkTitleDone": "Di-bookmark — akan di-DM di akhir sesi",
         "connectFailed": "Tidak dapat terhubung ke KMQ. Silakan coba lagi.",
+        "emoteBarLabel": "Kirim reaksi",
         "endGameBusy": "Mengakhiri…",
         "endGameButton": "Akhiri permainan",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Jumlah Suara",
             "voteCta": "Pilih untuk 2x EXP",
             "voteExpires": "Kadaluwarsa dalam {{time}}"
+        },
+        "recap": {
+            "copied": "Disalin!",
+            "copy": "Salin hasil",
+            "fastest": "⚡ Tercepat: {{user}} ({{seconds}}d)",
+            "fastestLabel": "Tebakan tercepat",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 Rekap KMQ",
+            "songs": "✅ {{correct}}/{{rounds}} lagu ditebak",
+            "songsLabel": "Lagu yang ditebak",
+            "streak": "🔥 Rentetan terpanjang: {{user}} (×{{streak}})",
+            "streakLabel": "Rentetan terpanjang",
+            "title": "Rekap Permainan"
         },
         "reconnectButton": "Sambungkan kembali",
         "reconnecting": "Menyambungkan kembali...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "Anda tidak dapat mengubah opsi itu saat memutar dari daftar putar. Gunakan {{playlistResetCommand}} sebelum mengubah opsi ini.",
             "notSuddenDeath": "Kamu tidak boleh melakukan itu selama tiba-tiba",
             "title": "Tunggu dulu..."
+        },
+        "recap": {
+            "fastest": "⚡ Tebakan tercepat: {{user}} ({{seconds}}d)",
+            "mvp": "👑 MVP: {{user}} ({{score}} pts)",
+            "streak": "🔥 Rentetan terpanjang: {{user}} (×{{streak}})",
+            "title": "Rekap Permainan"
         },
         "releaseDate": "Tanggal Rilis",
         "restart": {

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "この曲をブックマーク",
         "bookmarkTitleDone": "ブックマーク済み — セッション終了時にDM送信",
         "connectFailed": "KMQに接続できませんでした。もう一度お試しください。",
+        "emoteBarLabel": "リアクションを送る",
         "endGameBusy": "終了中…",
         "endGameButton": "ゲーム終了",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "投票回数",
             "voteCta": "2倍EXPのために投票",
             "voteExpires": "{{time}}で期限切れ"
+        },
+        "recap": {
+            "copied": "コピーされました！",
+            "copy": "結果をコピー",
+            "fastest": "⚡ 最速: {{user}} ({{seconds}}秒)",
+            "fastestLabel": "最速の推測",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 KMQ リキャップ",
+            "songs": "✅ {{correct}}/{{rounds}} 曲 推測済み",
+            "songsLabel": "曲の推測",
+            "streak": "🔥 最長連勝記録: {{user}} (×{{streak}})",
+            "streakLabel": "最長連勝",
+            "title": "ゲーム概要"
         },
         "reconnectButton": "再接続",
         "reconnecting": "再接続中...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "プレイリストから再生しているときは、そのオプションを変更することはできません。このオプションを変更する前に{{playlistResetCommand}}を使用してください。",
             "notSuddenDeath": "サドンデス中はそれを実施できません。",
             "title": "お待ちください..."
+        },
+        "recap": {
+            "fastest": "⚡ 最速の推測: {{user}} ({{seconds}}秒)",
+            "mvp": "👑 MVP: {{user}} ({{score}} 点)",
+            "streak": "🔥 最長連勝記録: {{user}} (×{{streak}})",
+            "title": "ゲーム概要"
         },
         "releaseDate": "リリース日",
         "restart": {

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "이 곡을 북마크",
         "bookmarkTitleDone": "북마크됨 — 세션 종료 시 DM 발송",
         "connectFailed": "KMQ에 연결할 수 없습니다. 다시 시도해 주세요.",
+        "emoteBarLabel": "반응 표시 보내기",
         "endGameBusy": "종료 중…",
         "endGameButton": "게임 종료",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "투표 횟수",
             "voteCta": "2배 EXP 투표하기",
             "voteExpires": "{{time}} 후 만료됨"
+        },
+        "recap": {
+            "copied": "복사 완료!",
+            "copy": "결과 복사",
+            "fastest": "⚡ 가장 빠름: {{user}} ({{seconds}}초)",
+            "fastestLabel": "가장 빠른 추측",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 KMQ 요약",
+            "songs": "✅ {{rounds}}곡 중 {{correct}}곡 맞춤",
+            "songsLabel": "맞힌 노래",
+            "streak": "🔥 최장 연승: {{user}} (×{{streak}})",
+            "streakLabel": "최장 연승",
+            "title": "게임 요약"
         },
         "reconnectButton": "다시 연결",
         "reconnecting": "다시 연결 중...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "재생 목록에서 재생할 때 해당 옵션을 변경할 수 없습니다. 이 옵션을 변경하기 전에 {{playlistResetCommand}}를 사용하세요.",
             "notSuddenDeath": "폭사 게임 중에는 그렇게 할 수 없습니다.",
             "title": "잠시만 기다려주십시오..."
+        },
+        "recap": {
+            "fastest": "⚡ 가장 빠른 추측: {{user}} ({{seconds}}초)",
+            "mvp": "👑 MVP: {{user}} ({{score}} pts)",
+            "streak": "🔥 최장 연승: {{user}} (×{{streak}})",
+            "title": "게임 요약"
         },
         "releaseDate": "발매 날짜",
         "restart": {

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Dit nummer bladwijzeren",
         "bookmarkTitleDone": "Bladwijzer gezet — wordt aan het eind van de sessie ge-DM'd",
         "connectFailed": "Kon geen verbinding maken met KMQ. Probeer het opnieuw.",
+        "emoteBarLabel": "Stuur een reactie",
         "endGameBusy": "Beëindigen…",
         "endGameButton": "Spel beëindigen",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Aantal keer gestemd",
             "voteCta": "Stem voor 2x EXP",
             "voteExpires": "Verloopt in {{time}}"
+        },
+        "recap": {
+            "copied": "Gekopieerd!",
+            "copy": "Kopieer resultaat",
+            "fastest": "⚡ Snelste: {{user}} ({{seconds}}s)",
+            "fastestLabel": "Snelste gok",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 KMQ Overzicht",
+            "songs": "✅ {{correct}}/{{rounds}} liedjes geraden",
+            "songsLabel": "Geraden liedjes",
+            "streak": "🔥 Langste reeks: {{user}} (×{{streak}})",
+            "streakLabel": "Langste reeks",
+            "title": "Speloverzicht"
         },
         "reconnectButton": "Opnieuw verbinden",
         "reconnecting": "Opnieuw verbinden...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "Je kunt die optie niet wijzigen wanneer je vanaf een afspeellijst afspeelt. Gebruik {{playlistResetCommand}} voordat je deze optie wijzigt.",
             "notSuddenDeath": "Dat kan niet tijdens een plotselinge dood.",
             "title": "Wachten..."
+        },
+        "recap": {
+            "fastest": "⚡ Snelste gok: {{user}} ({{seconds}}s)",
+            "mvp": "👑 MVP: {{user}} ({{score}} pts)",
+            "streak": "🔥 Langste reeks: {{user}} (×{{streak}})",
+            "title": "Speloverzicht"
         },
         "releaseDate": "Uitgavedatum",
         "restart": {

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Favoritar esta música",
         "bookmarkTitleDone": "Favoritada — enviada por DM no fim da sessão",
         "connectFailed": "Não foi possível conectar ao KMQ. Por favor, tente novamente.",
+        "emoteBarLabel": "Envie uma reação",
         "endGameBusy": "Encerrando…",
         "endGameButton": "Encerrar jogo",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Vezes Votadas",
             "voteCta": "Vote por 2x EXP",
             "voteExpires": "Expira em {{time}}"
+        },
+        "recap": {
+            "copied": "Copiado!",
+            "copy": "Copiar resultado",
+            "fastest": "⚡ Mais rápido: {{user}} ({{seconds}}s)",
+            "fastestLabel": "Adivinhação mais rápida",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 Recapitulação KMQ",
+            "songs": "✅ {{correct}}/{{rounds}} músicas adivinhadas",
+            "songsLabel": "Músicas adivinhadas",
+            "streak": "🔥 Maior sequência: {{user}} (×{{streak}})",
+            "streakLabel": "Maior sequência",
+            "title": "Recapitulação do Jogo"
         },
         "reconnectButton": "Reconectar",
         "reconnecting": "Reconectando...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "Você não pode alterar essa opção ao tocar a partir de uma lista de reprodução. Use {{playlistResetCommand}} antes de alterar esta opção.",
             "notSuddenDeath": "Você não pode fazer isso durante morte súbita.",
             "title": "Espere..."
+        },
+        "recap": {
+            "fastest": "⚡ Adivinhação mais rápida: {{user}} ({{seconds}}s)",
+            "mvp": "👑 MVP: {{user}} ({{score}} pts)",
+            "streak": "🔥 Maior sequência: {{user}} (×{{streak}})",
+            "title": "Recapitulação do Jogo"
         },
         "releaseDate": "Data de Lançamento",
         "restart": {

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "Сохранить песню в закладки",
         "bookmarkTitleDone": "В закладках — будет отправлено в ЛС в конце сессии",
         "connectFailed": "Не удалось подключиться к KMQ. Пожалуйста, попробуйте снова.",
+        "emoteBarLabel": "Отправьте реакцию",
         "endGameBusy": "Завершение…",
         "endGameButton": "Завершить игру",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "Кол-во голосов",
             "voteCta": "Голосуйте за 2x EXP",
             "voteExpires": "Истекает через {{time}}"
+        },
+        "recap": {
+            "copied": "Скопировано!",
+            "copy": "Скопировать результат",
+            "fastest": "⚡ Быстрее всех: {{user}} ({{seconds}}с)",
+            "fastestLabel": "Самая быстрая догадка",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 Обзор KMQ",
+            "songs": "✅ {{correct}}/{{rounds}} угаданных песен",
+            "songsLabel": "Песни угадали",
+            "streak": "🔥 Самая длинная серия: {{user}} (×{{streak}})",
+            "streakLabel": "Самая длинная серия",
+            "title": "Итоги игры"
         },
         "reconnectButton": "Переподключиться",
         "reconnecting": "Переподключение...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "Вы не можете изменить этот параметр при игре из плейлиста. Используйте {{playlistResetCommand}} перед изменением этого параметра.",
             "notSuddenDeath": "Во время внезапной смерти такого делать нельзя.",
             "title": "Подождите..."
+        },
+        "recap": {
+            "fastest": "⚡ Самая быстрая догадка: {{user}} ({{seconds}}с)",
+            "mvp": "👑 MVP: {{user}} ({{score}} pts)",
+            "streak": "🔥 Самая длинная серия: {{user}} (×{{streak}})",
+            "title": "Итоги игры"
         },
         "releaseDate": "Дата выпуска",
         "restart": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -29,6 +29,7 @@
         "bookmarkTitleActive": "收藏这首歌",
         "bookmarkTitleDone": "已收藏 — 会在会话结束时私信发送",
         "connectFailed": "无法连接到KMQ。请再试一次。",
+        "emoteBarLabel": "发送反应",
         "endGameBusy": "正在结束…",
         "endGameButton": "结束游戏",
         "gameType": {
@@ -206,6 +207,20 @@
             "timesVoted": "投票次数",
             "voteCta": "投票以获取 2x 经验",
             "voteExpires": "{{time}} 后到期"
+        },
+        "recap": {
+            "copied": "已复制!",
+            "copy": "复制结果",
+            "fastest": "⚡ 最快: {{user}} ({{seconds}}秒)",
+            "fastestLabel": "最快猜测",
+            "mvp": "👑 MVP: {{user}} ({{score}})",
+            "mvpLabel": "MVP",
+            "shareHeader": "🎵 KMQ 总结",
+            "songs": "✅ {{correct}}/{{rounds}} 首歌曲猜对",
+            "songsLabel": "猜对的歌曲",
+            "streak": "🔥 最长连胜: {{user}} (×{{streak}})",
+            "streakLabel": "最长连胜",
+            "title": "游戏总结"
         },
         "reconnectButton": "重新连接",
         "reconnecting": "重新连接中...",
@@ -1935,6 +1950,12 @@
             "notPlaylist": "从播放列表播放时，您不能更改该选项。更改此选项之前，请使用{{playlistResetCommand}}。",
             "notSuddenDeath": "你无法在突然死亡比赛中这样做。",
             "title": "请稍等..."
+        },
+        "recap": {
+            "fastest": "⚡ 最快猜测: {{user}} ({{seconds}}秒)",
+            "mvp": "👑 MVP: {{user}} ({{score}} 分)",
+            "streak": "🔥 最长连胜: {{user}} (×{{streak}})",
+            "title": "游戏总结"
         },
         "releaseDate": "发布日期",
         "restart": {

--- a/src/activity_hub.ts
+++ b/src/activity_hub.ts
@@ -11,6 +11,7 @@ import type ActivityAutocompleteArtistsArgs from "./interfaces/activity_autocomp
 import type ActivityAutocompleteArtistsResponse from "./interfaces/activity_autocomplete_artists_response";
 import type ActivityBookmarkArgs from "./interfaces/activity_bookmark_args";
 import type ActivityBookmarkResponse from "./interfaces/activity_bookmark_response";
+import type ActivityEmoteArgs from "./interfaces/activity_emote_args";
 import type ActivityGuessArgs from "./interfaces/activity_guess_args";
 import type ActivityGuessResponse from "./interfaces/activity_guess_response";
 import type ActivityMcGuessArgs from "./interfaces/activity_mc_guess_args";
@@ -221,6 +222,17 @@ export default class ActivityHub {
     async hint(args: ActivityUserActionArgs): Promise<ActivityGuessResponse> {
         const target = await this.resolveCluster(args.guildID);
         return this.sendRequest<ActivityGuessResponse>(target, "hint", args);
+    }
+
+    /**
+     * Flings an emote into the round; the worker re-broadcasts it to all
+     * viewers of the guild.
+     * @param args - guildID/userID/emote
+     * @returns the worker's accept/reject response
+     */
+    async emote(args: ActivityEmoteArgs): Promise<ActivityGuessResponse> {
+        const target = await this.resolveCluster(args.guildID);
+        return this.sendRequest<ActivityGuessResponse>(target, "emote", args);
     }
 
     /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -390,6 +390,13 @@ export const ACTIVITY_RATE_LIMIT_READ = 60;
 export const ACTIVITY_RATE_LIMIT_ACTION = 60;
 export const ACTIVITY_RATE_LIMIT_GUESS = 120;
 
+// Fixed set of emotes a player can fling during an Activity round. Server-side
+// allow-list so the broadcast can't be used to inject arbitrary content.
+export const ACTIVITY_EMOTES = ["🔥", "😂", "👏", "😱", "❤️", "🎉"] as const;
+
+// Per-user cooldown between accepted emotes, to curb spam (ms).
+export const ACTIVITY_EMOTE_COOLDOWN_MS = 600;
+
 // Discord OAuth + activity REST endpoints used by the admiral.
 const DISCORD_API_BASE = "https://discord.com/api";
 export const DISCORD_OAUTH_TOKEN_URL = `${DISCORD_API_BASE}/oauth2/token`;

--- a/src/enums/activity_request_op.ts
+++ b/src/enums/activity_request_op.ts
@@ -6,6 +6,7 @@ type ActivityRequestOp =
     | "skipVote"
     | "endGame"
     | "hint"
+    | "emote"
     | "bookmark"
     | "setOption"
     | "autocompleteArtists"

--- a/src/enums/activity_request_rejection.ts
+++ b/src/enums/activity_request_rejection.ts
@@ -9,6 +9,7 @@ type ActivityRequestRejection =
     | "session_already_running"
     | "no_round"
     | "hint_unavailable"
+    | "invalid_emote"
     | "song_not_found"
     // Playlist set failures (POST /api/activity/option, kind="playlist").
     | "playlist_invalid_url"

--- a/src/interfaces/activity_emote_args.ts
+++ b/src/interfaces/activity_emote_args.ts
@@ -1,0 +1,6 @@
+export default interface ActivityEmoteArgs {
+    guildID: string;
+    userID: string;
+    /** One of ACTIVITY_EMOTES; validated server-side before broadcast. */
+    emote: string;
+}

--- a/src/interfaces/activity_event.ts
+++ b/src/interfaces/activity_event.ts
@@ -38,6 +38,33 @@ type ActivityEvent =
           ts: number;
       }
     | { type: "sessionEnd"; reason: string }
+    | {
+          // Pushed once at session end with the standout stats, for the recap
+          // card on the game-over screen. Names resolved server-side.
+          type: "recap";
+          mvp: { userID: string; username: string; score: number } | null;
+          fastestGuess: {
+              userID: string;
+              username: string;
+              timeMs: number;
+          } | null;
+          longestStreak: {
+              userID: string;
+              username: string;
+              streak: number;
+          } | null;
+          totalCorrect: number;
+          totalRounds: number;
+      }
+    | {
+          // Broadcast to every viewer when a player flings an emote, for a
+          // transient floating-emote animation. Not persisted.
+          type: "emote";
+          userID: string;
+          username: string;
+          avatarUrl: string | null;
+          emote: string;
+      }
     | { type: "hintProgress"; requesters: number; threshold: number }
     | { type: "hintRevealed"; text: string }
     | { type: "skipProgress"; requesters: number; threshold: number }

--- a/src/interfaces/activity_request_message.ts
+++ b/src/interfaces/activity_request_message.ts
@@ -1,5 +1,6 @@
 import type ActivityAutocompleteArtistsArgs from "./activity_autocomplete_artists_args";
 import type ActivityBookmarkArgs from "./activity_bookmark_args";
+import type ActivityEmoteArgs from "./activity_emote_args";
 import type ActivityGuessArgs from "./activity_guess_args";
 import type ActivityProfileArgs from "./activity_profile_args";
 import type ActivityRequestOp from "../enums/activity_request_op";
@@ -17,5 +18,6 @@ export default interface ActivityRequestMessage {
         | ActivityUserActionArgs
         | ActivityBookmarkArgs
         | ActivityAutocompleteArtistsArgs
+        | ActivityEmoteArgs
         | ActivityProfileArgs;
 }

--- a/src/interfaces/game_session_recap.ts
+++ b/src/interfaces/game_session_recap.ts
@@ -1,0 +1,17 @@
+/**
+ * End-of-session summary, computed from accumulated session state (no DB).
+ * userIDs are resolved to names by the consumer (the legacy embed via the
+ * scoreboard; the Activity via the bridge's name lookup).
+ */
+export default interface GameSessionRecap {
+    /** Top scorer (sole/shared first place), or null if nobody scored. */
+    mvp: { userID: string; score: number } | null;
+    /** Fastest correct guess, or null if there were none. */
+    fastestGuess: { userID: string; timeMs: number } | null;
+    /** Longest guess streak reached, or null if there were none. */
+    longestStreak: { userID: string; streak: number } | null;
+    /** Songs correctly guessed this session. */
+    totalCorrect: number;
+    /** Rounds played this session. */
+    totalRounds: number;
+}

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -1282,6 +1282,41 @@ export default class KmqWebServer {
             },
         );
 
+        httpServer.post(
+            "/api/activity/emote",
+            limit(ACTIVITY_RATE_LIMIT_ACTION),
+            async (request, reply) => {
+                const ctx = await requireAuthedInstance(request, reply);
+                if (!ctx) return;
+
+                const body = (request.body ?? {}) as { emote?: string };
+                if (typeof body.emote !== "string") {
+                    await reply.code(400).send({ error: "Missing emote" });
+                    return;
+                }
+
+                try {
+                    const result = await this.activityHub!.emote({
+                        guildID: ctx.instance.guildID,
+                        userID: ctx.user.id,
+                        emote: body.emote,
+                    });
+
+                    if (!result.ok) {
+                        await reply.code(409).send({ error: result.reason });
+                        return;
+                    }
+
+                    await reply.code(200).send({ ok: true });
+                } catch (e) {
+                    logger.warn(
+                        `Activity emote failed. gid=${ctx.instance.guildID}, err=${(e as Error).message}`,
+                    );
+                    await reply.code(500).send({ error: "Internal" });
+                }
+            },
+        );
+
         httpServer.get(
             "/api/activity/artist-autocomplete",
             limit(ACTIVITY_RATE_LIMIT_READ),

--- a/src/structures/activity_bridge.ts
+++ b/src/structures/activity_bridge.ts
@@ -1,5 +1,7 @@
 import {
     ACTIVITY_AUTOCOMPLETE_LIMIT,
+    ACTIVITY_EMOTES,
+    ACTIVITY_EMOTE_COOLDOWN_MS,
     ACTIVITY_IPC_EVENT,
     ACTIVITY_IPC_REPLY,
     ACTIVITY_IPC_REQUEST,
@@ -50,6 +52,7 @@ import type ActivityAutocompleteArtistsResponse from "../interfaces/activity_aut
 import type ActivityBookmarkArgs from "../interfaces/activity_bookmark_args";
 import type ActivityBookmarkResponse from "../interfaces/activity_bookmark_response";
 import type ActivityCorrectGuesser from "../interfaces/activity_correct_guesser";
+import type ActivityEmoteArgs from "../interfaces/activity_emote_args";
 import type ActivityEvent from "../interfaces/activity_event";
 import type ActivityGuessArgs from "../interfaces/activity_guess_args";
 import type ActivityGuessResponse from "../interfaces/activity_guess_response";
@@ -72,6 +75,7 @@ import type ActivitySongInfoArgs from "../interfaces/activity_song_info_args";
 import type ActivitySongInfoResponse from "../interfaces/activity_song_info_response";
 import type ActivityStartGameArgs from "../interfaces/activity_start_game_args";
 import type ActivityUserActionArgs from "../interfaces/activity_user_action_args";
+import type GameSessionRecap from "../interfaces/game_session_recap";
 import type MatchedArtist from "../interfaces/matched_artist";
 import type Player from "./player";
 import type PlayerRoundResult from "../interfaces/player_round_result";
@@ -304,6 +308,11 @@ function userInVoiceChannel(
 ): boolean {
     return getUserVoiceChannelID(guildID, userID) === voiceChannelID;
 }
+
+// Per-user emote cooldown, keyed by `${guildID}:${userID}`. Module-scoped so it
+// persists across requests within the worker; bounded by natural churn (one
+// entry per recently-active emoter).
+const emoteCooldowns = new Map<string, number>();
 
 function pushEvent(guildID: string, event: ActivityEvent): void {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -929,6 +938,65 @@ function ensureWorkerHandlerRegistered(): void {
                             reply({ ok: false, reason: "internal" });
                         }
                     });
+                    return;
+                }
+
+                case "emote": {
+                    const emoteArgs = args as ActivityEmoteArgs;
+                    const reply = (payload: ActivityGuessResponse): void => {
+                        State.ipc.sendToAdmiral(ACTIVITY_IPC_REPLY, {
+                            cid,
+                            payload,
+                        });
+                    };
+
+                    if (
+                        !(ACTIVITY_EMOTES as readonly string[]).includes(
+                            emoteArgs.emote,
+                        )
+                    ) {
+                        reply({ ok: false, reason: "invalid_emote" });
+                        return;
+                    }
+
+                    const session = Session.getSession(emoteArgs.guildID);
+                    if (!session) {
+                        reply({ ok: false, reason: "no_session" });
+                        return;
+                    }
+
+                    if (
+                        !userInVoiceChannel(
+                            emoteArgs.guildID,
+                            emoteArgs.userID,
+                            session.voiceChannelID,
+                        )
+                    ) {
+                        reply({ ok: false, reason: "not_in_vc" });
+                        return;
+                    }
+
+                    // Per-user cooldown to curb spam.
+                    const cooldownKey = `${emoteArgs.guildID}:${emoteArgs.userID}`;
+                    const now = Date.now();
+                    const last = emoteCooldowns.get(cooldownKey) ?? 0;
+                    if (now - last < ACTIVITY_EMOTE_COOLDOWN_MS) {
+                        reply({ ok: false, reason: "rate_limit" });
+                        return;
+                    }
+
+                    emoteCooldowns.set(cooldownKey, now);
+
+                    const cachedUser = State.client.users.get(emoteArgs.userID);
+                    pushEvent(emoteArgs.guildID, {
+                        type: "emote",
+                        userID: emoteArgs.userID,
+                        username: cachedUser?.username || emoteArgs.userID,
+                        avatarUrl: cachedUser?.avatarURL || null,
+                        emote: emoteArgs.emote,
+                    });
+
+                    reply({ ok: true });
                     return;
                 }
 
@@ -1905,6 +1973,35 @@ export function attachActivityBridge(session: GameSession): void {
             avatarUrl,
             isCorrect: payload.isCorrect,
             ts: payload.ts,
+        });
+    });
+
+    session.on("recap", (recap: GameSessionRecap) => {
+        pushEvent(guildID, {
+            type: "recap",
+            mvp: recap.mvp
+                ? {
+                      userID: recap.mvp.userID,
+                      username: lookupName(recap.mvp.userID).username,
+                      score: recap.mvp.score,
+                  }
+                : null,
+            fastestGuess: recap.fastestGuess
+                ? {
+                      userID: recap.fastestGuess.userID,
+                      username: lookupName(recap.fastestGuess.userID).username,
+                      timeMs: recap.fastestGuess.timeMs,
+                  }
+                : null,
+            longestStreak: recap.longestStreak
+                ? {
+                      userID: recap.longestStreak.userID,
+                      username: lookupName(recap.longestStreak.userID).username,
+                      streak: recap.longestStreak.streak,
+                  }
+                : null,
+            totalCorrect: recap.totalCorrect,
+            totalRounds: recap.totalRounds,
         });
     });
 

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -9,6 +9,7 @@ import {
     chunkArray,
     codeLine,
     delay,
+    friendlyFormattedNumber,
     getMention,
     getOrdinalNum,
     setDifference,
@@ -77,6 +78,7 @@ import TeamScoreboard from "./team_scoreboard";
 import i18n from "../helpers/localization_manager";
 import type { ButtonActionRow, GuildTextableMessage } from "../types";
 import type { CommandInteraction } from "eris";
+import type GameSessionRecap from "../interfaces/game_session_recap";
 import type GuildPreference from "./guild_preference";
 import type PlayerRoundResult from "../interfaces/player_round_result";
 import type QueriedSong from "./queried_song";
@@ -135,6 +137,12 @@ export default class GameSession extends Session {
     /** The most recent Guesser, including their current streak */
     private lastGuesser: LastGuesser | null;
 
+    /** Fastest correct guess this session (for the end-game recap). */
+    private fastestGuess: { userID: string; timeMs: number } | null;
+
+    /** Longest guess streak reached this session (for the end-game recap). */
+    private longestStreak: { userID: string; streak: number } | null;
+
     /** Manages updating a message with current guessers with hidden enabled */
     private hiddenUpdateTimer: NodeJS.Timeout | null;
 
@@ -168,6 +176,8 @@ export default class GameSession extends Session {
         this.round = null;
         this.songStats = {};
         this.lastGuesser = null;
+        this.fastestGuess = null;
+        this.longestStreak = null;
         this.hiddenUpdateTimer = null;
         this.clipDurationLength = clipDurationLength || null;
         this.clipPlayNewClip = clipPlayNewClip || null;
@@ -453,6 +463,26 @@ export default class GameSession extends Session {
 
     getCorrectGuesses(): number {
         return this.correctGuesses;
+    }
+
+    /**
+     * Builds the end-of-session recap from accumulated session state. userIDs
+     * stay raw; consumers resolve names.
+     * @returns the recap summary
+     */
+    buildRecap(): GameSessionRecap {
+        const winners = this.scoreboard.getWinners();
+        const topWinner = winners[0];
+        return {
+            mvp:
+                topWinner && topWinner.getScore() > 0
+                    ? { userID: topWinner.id, score: topWinner.getScore() }
+                    : null,
+            fastestGuess: this.fastestGuess,
+            longestStreak: this.longestStreak,
+            totalCorrect: this.correctGuesses,
+            totalRounds: this.roundsPlayed,
+        };
     }
 
     isGameSession(): this is GameSession {
@@ -884,6 +914,11 @@ export default class GameSession extends Session {
                 this.guildID,
             );
 
+            const recapField = this.buildRecapEmbedField();
+            if (recapField) {
+                fields.push(recapField);
+            }
+
             const endGameMessage = await getGameInfoMessage(this.guildID);
 
             if (
@@ -1074,6 +1109,63 @@ export default class GameSession extends Session {
         messageContext: MessageContext,
     ): Promise<Round | null> {
         return this.startRoundCore(messageContext);
+    }
+
+    /**
+     * Formats the recap as an embed field for the legacy end-game message, or
+     * null when there's nothing noteworthy to show.
+     * @returns the recap field, or null
+     */
+    private buildRecapEmbedField(): {
+        name: string;
+        value: string;
+        inline: boolean;
+    } | null {
+        const recap = this.buildRecap();
+        const lines: string[] = [];
+
+        if (recap.mvp) {
+            lines.push(
+                i18n.translate(this.guildID, "misc.recap.mvp", {
+                    user: this.scoreboard.getPlayerDisplayedName(
+                        recap.mvp.userID,
+                    ),
+                    score: friendlyFormattedNumber(recap.mvp.score),
+                }),
+            );
+        }
+
+        if (recap.fastestGuess) {
+            lines.push(
+                i18n.translate(this.guildID, "misc.recap.fastest", {
+                    user: this.scoreboard.getPlayerDisplayedName(
+                        recap.fastestGuess.userID,
+                    ),
+                    seconds: (recap.fastestGuess.timeMs / 1000).toFixed(1),
+                }),
+            );
+        }
+
+        if (recap.longestStreak) {
+            lines.push(
+                i18n.translate(this.guildID, "misc.recap.streak", {
+                    user: this.scoreboard.getPlayerDisplayedName(
+                        recap.longestStreak.userID,
+                    ),
+                    streak: friendlyFormattedNumber(recap.longestStreak.streak),
+                }),
+            );
+        }
+
+        if (lines.length === 0) {
+            return null;
+        }
+
+        return {
+            name: i18n.translate(this.guildID, "misc.recap.title"),
+            value: lines.join("\n"),
+            inline: false,
+        };
     }
 
     /**
@@ -1305,6 +1397,27 @@ export default class GameSession extends Session {
                 this.lastGuesser.streak++;
             }
 
+            // Track session-best stats for the end-game recap.
+            if (
+                this.longestStreak === null ||
+                this.lastGuesser.streak > this.longestStreak.streak
+            ) {
+                this.longestStreak = {
+                    userID: this.lastGuesser.userID,
+                    streak: this.lastGuesser.streak,
+                };
+            }
+
+            if (
+                this.fastestGuess === null ||
+                timePlayed < this.fastestGuess.timeMs
+            ) {
+                this.fastestGuess = {
+                    userID: correctGuessers[0]!.id,
+                    timeMs: timePlayed,
+                };
+            }
+
             this.guessTimes.push(timePlayed);
             await this.updateScoreboard(
                 round,
@@ -1460,6 +1573,10 @@ export default class GameSession extends Session {
         }
 
         this.finished = true;
+        // Emit recap before sessionEnd: both are synchronous, so the Activity
+        // bridge handles them before its sessionEnd teardown (scheduled via
+        // setImmediate) runs.
+        this.emit("recap", this.buildRecap());
         this.emit("sessionEnd", { reason });
         if (this.gameType === GameType.COMPETITION) {
             // log scoreboard

--- a/src/test/unit_tests/ci/activity_hub.test.ts
+++ b/src/test/unit_tests/ci/activity_hub.test.ts
@@ -650,6 +650,18 @@ describe("ActivityHub", () => {
             assert.deepStrictEqual(sent.payload.args, args);
         });
 
+        it("emote → emote", async () => {
+            const args = {
+                guildID: "0",
+                userID: "user1",
+                emote: "🔥",
+            };
+
+            const sent = await dispatch((hub) => hub.emote(args));
+            assert.strictEqual(sent.payload.op, "emote");
+            assert.deepStrictEqual(sent.payload.args, args);
+        });
+
         it("routes to the cluster owning the guild, not always cluster 0", async () => {
             // guild 2^23 → shard 2 → cluster 1
             const guildID = String(2 ** 23);


### PR DESCRIPTION
## What

Adds two "social juice" features to the Activity (and surfaces the recap in the legacy text path too):

### Live emotes
A new client→bot `emote` op lets players fling a small fixed set of reactions (🔥😂👏😱❤️🎉). The worker rate-limits per user (`ACTIVITY_EMOTE_COOLDOWN_MS`) and re-broadcasts the emote to all of the guild's subscribers as an `emote` event — pure fan-out, no persistence. The client renders incoming emotes as floating animations (`@keyframes emote-float`).

### Post-game recap
`GameSession` tracks the session's fastest correct guess and longest streak and builds a mode-agnostic recap (MVP, fastest, longest streak, songs guessed) at session end. It's surfaced in **both** modes:
- **Legacy**: a recap field on the end-game embed.
- **Activity**: a shareable, copy-to-clipboard recap card on the game-over screen.

## How
- Bot→client: new `emote` + `recap` discriminants on the `ActivityEvent` union, emitted via the bridge.
- Client→bot: new `emote` op → `ActivityHub.emote()` → `/api/activity/emote` → worker case (validates the emote, checks VC, applies the per-user cooldown, fans out).
- Recap is emitted synchronously *before* `sessionEnd` so the bridge handles it before its teardown.
- Clipboard copy uses a helper that falls back to `execCommand("copy")` for the sandboxed Activity iframe (where `navigator.clipboard` is often blocked).

## Testing
- `tsc` (backend + activity), `lint-ci` (0 warnings), `prettier`, `lint-i18n` (0 warnings; new keys propagated to all 12 locales).
- Unit tests: `activity_hub.test.ts` pins the new `emote` op routing (36 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
