### PR TITLE
Fix failed interaction on incorrect multiple-choice button picks

### DIFF
--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -557,15 +557,35 @@ export default class GameSession extends Session {
             }
         }
 
-        // Acknowledge a correct pick before scoring runs: a correct guess can
-        // trigger the multiguess delay + round-end work, which would blow past
-        // Discord's 3s interaction deadline if we acked afterwards.
+        // Acknowledge the pick before the round-end work runs: both a correct
+        // pick AND an incorrect one can trigger that work (in solo MC an
+        // incorrect pick is "everybody guessed, nobody correct", which ends the
+        // round and starts the next one — several seconds of song loading).
+        // Acking afterwards would blow past Discord's 3s interaction deadline
+        // and fail the interaction, so we ack from the callbacks that fire
+        // before the transition: onCorrect for a correct pick, onAccepted's
+        // INCORRECT branch (the "you're out this round" notice) for a wrong one.
         const mcResult = await this.submitMultipleChoiceGuess(
             interaction.member!.id,
             interaction.data.custom_id,
             interaction.createdAt,
             messageContext,
             () => tryInteractionAcknowledge(interaction),
+            (outcome) => {
+                if (outcome === MultipleChoiceGuessResult.INCORRECT) {
+                    // Fire-and-forget so the ack is dispatched before the
+                    // round-end transition rather than awaited after it.
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    tryCreateInteractionErrorAcknowledgement(
+                        interaction,
+                        null,
+                        i18n.translate(
+                            this.guildID,
+                            "misc.failure.interaction.eliminated",
+                        ),
+                    ).catch(() => undefined);
+                }
+            },
         );
 
         if (mcResult === MultipleChoiceGuessResult.INELIGIBLE) {
@@ -580,18 +600,8 @@ export default class GameSession extends Session {
             return true;
         }
 
-        if (mcResult === MultipleChoiceGuessResult.INCORRECT) {
-            await tryCreateInteractionErrorAcknowledgement(
-                interaction,
-                null,
-                i18n.translate(
-                    this.guildID,
-                    "misc.failure.interaction.eliminated",
-                ),
-            );
-            return true;
-        }
-
+        // INCORRECT was acknowledged early in the onAccepted callback above
+        // (before the round-end transition); nothing left to do here.
         return true;
     }
 


### PR DESCRIPTION
## Bug

In the legacy (Discord button) multiple-choice path, guessing **incorrectly** fails the interaction ("This interaction failed"). Guessing correctly works fine.

## Cause

A **correct** pick is acknowledged early via the `onCorrect` callback — *before* the round-end work runs. An **incorrect** pick was only acknowledged *after* `submitMultipleChoiceGuess` returned.

In solo MC, a wrong pick is "everybody guessed, nobody correct" (`getCurrentVoiceMembers` filters out the bot), which ends the round and starts the next one — several seconds of song loading. So for a wrong pick the acknowledgement landed well past Discord's 3s interaction deadline, and the interaction failed. Correct picks acked first, then did the slow work, so they were unaffected.

This is latent since legacy MC shipped (#2358); it's adjacent to but not caused by the recent round-end timing work (#2375 / #2377).

## Fix

Acknowledge the wrong pick from the `onAccepted` callback — which fires *before* the round-end transition — with the same "you're out this round" notice, fire-and-forget, and drop the now-redundant late acknowledgement. This mirrors how a correct pick already acks early. Only the Discord button handler changes; `submitMultipleChoiceGuess` and the Activity path are untouched.

## Relation to #2377

No conflict — complementary. #2377 (merged) reduced perceived lag by not holding the lifecycle mutex for the song-start delay (in `startRoundCore`, ~L1190). This change fixes the failed interaction by moving the ack before the round-end work (in `handleComponentInteraction`, ~L560). Different functions; this branch builds on top of merged #2377.

## Testing

- `tsc`, `lint-ci` (0 warnings), `prettier` all clean.
- Note: this path needs a live game to exercise end-to-end (Discord interaction), which isn't covered by the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
