### PR TITLE
Clamp the Activity limit input to the matched-song upper bound

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -3006,6 +3006,7 @@ function OptionsPanel({
                         endMin={1}
                         endMax={100000}
                         onCommit={submitLimit}
+                        clampEndTo={options.matchedSongCount}
                         note={
                             options.matchedSongCount === null
                                 ? undefined
@@ -3387,6 +3388,7 @@ function NumberRangeGroup({
     endMax,
     onCommit,
     note,
+    clampEndTo,
 }: {
     label: string;
     help?: string;
@@ -3398,6 +3400,7 @@ function NumberRangeGroup({
     endMax: number;
     onCommit: (start: number, end: number) => void;
     note?: string;
+    clampEndTo?: number | null;
 }) {
     const [start, setStart] = useState(String(startValue));
     const [end, setEnd] = useState(String(endValue));
@@ -3407,11 +3410,19 @@ function NumberRangeGroup({
 
     const commit = (): void => {
         const s = parseInt(start, 10);
-        const e = parseInt(end, 10);
+        let e = parseInt(end, 10);
         if (!Number.isInteger(s) || !Number.isInteger(e)) {
             setStart(String(startValue));
             setEnd(String(endValue));
             return;
+        }
+        // Snap the end of the range down to the matched-song upper bound:
+        // entering a limit above the number of songs that actually match
+        // (e.g. 10000 when 3000 match) clamps to that bound rather than
+        // silently overshooting. Skip when the bound is unknown or zero.
+        if (clampEndTo != null && clampEndTo > 0 && e > clampEndTo) {
+            e = clampEndTo;
+            setEnd(String(e));
         }
         if (s === startValue && e === endValue) return;
         onCommit(s, e);


### PR DESCRIPTION
## Summary
Builds on the matched-song count (#2382): when a player types a `limitEnd` above the number of songs that actually match the current filters, snap it down to that upper bound on commit instead of letting them set an unreachable cap.

- `NumberRangeGroup` gains a `clampEndTo` prop; on commit, if the entered end exceeds `clampEndTo` (the matched-song count), it's clamped down and the input reflects the corrected value.
- Wired the limit range's `clampEndTo` to `options.matchedSongCount`. No-op when the count is null (couldn't be computed).

## Test plan
- Open the Activity options panel, note the "N songs match your filters" note under the limit range.
- Type a limit end greater than N and commit; confirm it snaps down to N.
- Type a value at or below N; confirm it's left unchanged.