### PR TITLE
Replace inert idle scaffold with a real empty state in the Activity

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -1215,6 +1215,7 @@ function CurrentRound({
     history,
     guesses,
     recap,
+    noActiveGame,
     t,
 }: {
     round: ActivityRoundMeta | null;
@@ -1223,6 +1224,10 @@ function CurrentRound({
     /** If non-null, the round-area idle state renders the session-end winner
      *  line in place of "Waiting for next round". */
     winnerText: string | null;
+    /** True when there is no active game. Distinguishes a genuine empty state
+     *  ("no game running") from the between-rounds pause of a live game (which
+     *  legitimately shows a "Waiting for the next round..." loading placeholder). */
+    noActiveGame: boolean;
     /** Whether the viewer won the just-ended game — triggers the confetti +
      *  celebratory styling on the winner line. */
     viewerWon: boolean;
@@ -1411,6 +1416,12 @@ function CurrentRound({
                                 >
                                     {winnerText}
                                 </p>
+                            ) : noActiveGame ? (
+                                <p className="empty">
+                                    {t("sessionEndedBanner", {
+                                        playSlash: "/play",
+                                    })}
+                                </p>
                             ) : (
                                 <p className="empty">
                                     {t("waitingForNextRound")}
@@ -1430,6 +1441,16 @@ function CurrentRound({
                                     <img src={thumbsUpUrl} alt="" />
                                 </div>
                             )
+                        ) : noActiveGame ? (
+                            // No game running: a calm, static music glyph — not the
+                            // pulsing "waiting..." placeholder, which implies a round
+                            // is loading when nothing is actually happening.
+                            <div
+                                className="thumbnail-slot placeholder idle-empty"
+                                aria-hidden
+                            >
+                                <span className="note-main">🎵</span>
+                            </div>
                         ) : (
                             <div
                                 className="thumbnail-slot placeholder"
@@ -4761,20 +4782,13 @@ export default function App() {
                             </div>
                         )}
 
-                        {ui.sessionEnded && (
-                            <div className="banner">
-                                {t("sessionEndedBanner", {
-                                    playSlash: "/play",
-                                })}
-                            </div>
-                        )}
-
                         <CurrentRound
                             round={ui.currentRound}
                             reveal={ui.lastReveal}
                             history={ui.roundHistory}
                             guesses={ui.recentGuesses}
                             recap={ui.recap}
+                            noActiveGame={ui.sessionEnded}
                             t={t}
                             winnerText={
                                 ui.sessionEnded &&
@@ -4839,6 +4853,7 @@ export default function App() {
                         />
 
                         {authState &&
+                            !ui.sessionEnded &&
                             (ui.options &&
                             MC_ANSWER_TYPES.has(ui.options.answerType) ? (
                                 <MultipleChoiceInput
@@ -4866,7 +4881,7 @@ export default function App() {
                                 />
                             ))}
 
-                        {authState && (
+                        {authState && !ui.sessionEnded && (
                             <div className="vote-row">
                                 {/* Hints are disabled server-side in multiple
                                     choice mode, so hide the control rather than
@@ -4952,7 +4967,7 @@ export default function App() {
                             </div>
                         )}
 
-                        {authState && (
+                        {authState && !ui.sessionEnded && (
                             <EmoteBar
                                 accessToken={authState.accessToken}
                                 instanceId={authState.instanceId}

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -876,6 +876,18 @@ body::before {
     z-index: 1;
 }
 
+/* No active game: a calm, neutral glyph rather than the pink pulsing "waiting"
+   placeholder — nothing is loading, so nothing should animate or read as busy. */
+.thumbnail-slot.placeholder.idle-empty {
+    background: var(--bg-surface);
+    border-color: var(--border);
+}
+
+.idle-empty .note-main {
+    animation: none;
+    opacity: 0.35;
+}
+
 .thumbnail-slot.session-winner-art img {
     width: 100%;
     height: 100%;

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -1231,6 +1231,42 @@ body::before {
     gap: 8px;
 }
 
+/* Game-start entrance: these controls only mount once a game is active, so they
+   otherwise pop in instantly. Fade + slide them up, staggered top-to-bottom
+   (guess input → votes → emotes) to match the reveal-line-in cascade elsewhere.
+   Runs once on mount and stays put across rounds since the elements persist.
+   Neutralised by the global prefers-reduced-motion guard. */
+.guess-input,
+.mc-input,
+.vote-row,
+.emote-bar {
+    animation: control-enter 0.32s cubic-bezier(0.2, 0.8, 0.3, 1) both;
+}
+
+.guess-input,
+.mc-input {
+    animation-delay: 0.04s;
+}
+
+.vote-row {
+    animation-delay: 0.11s;
+}
+
+.emote-bar {
+    animation-delay: 0.18s;
+}
+
+@keyframes control-enter {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 /* ---- EMOTE BAR + FLOATING EMOTES ---- */
 .emote-bar {
     display: flex;


### PR DESCRIPTION
## Summary

When no game is running, the Activity panel rendered the full live-game scaffold — a "Waiting for the next round…" round card with a pulsing loader, a disabled guess input, Hint/Skip vote buttons, and the emote bar — all inert. It read as the busiest part of the screen while doing nothing, and the red-bordered "No active game" banner used error styling for what is just an informational state.

This came out of a live UI/UX audit of the idle state.

## Changes

- **Hide dead controls when idle** — the guess input, vote row, and emote bar now only mount while a game is active (`!sessionEnded`), so no inert controls render on an empty screen.
- **Real empty state** — `CurrentRound` takes a `noActiveGame` flag; the idle branch now shows a calm, static neutral glyph plus the start / `/play` hint (reusing the existing `sessionEndedBanner` string) instead of the pulsing "waiting…" loader, which falsely implied a round was loading. The between-rounds pause of a *live* game still shows the loading placeholder.
- **De-error the banner** — dropped the separate red error-styled banner; its message now lives in the empty state, so idle no longer looks like something went wrong.

No new i18n keys (reuses `sessionEndedBanner`). `tsc` clean, prod build passes.

## Testing

Needs a deploy to verify visually in the live Activity (fresh idle + end-of-game states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)