### PR TITLE
Add Activity game feel: end-of-game level-up celebration + combo/near-miss juice

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -79,6 +79,7 @@ import type ActivityScoreboardSnapshot from "./types/activity_scoreboard_snapsho
 import type ActivitySnapshot from "./types/activity_snapshot";
 import type GuessRejectReason from "./types/guess_reject_reason";
 import type HintState from "./types/hint_state";
+import type LevelUp from "./types/level_up";
 import type SessionRecap from "./types/session_recap";
 import type SkipState from "./types/skip_state";
 import type UiState from "./types/ui_state";
@@ -111,8 +112,57 @@ const THEME_STORAGE_KEY = "kmq:theme";
 // Mirrors the bot's QUICK_GUESS_MS (src/constants.ts) — guesses at or under
 // this get a ⚡ in the round-end reveal, matching the legacy text-chat look.
 const QUICK_GUESS_MS = 3500;
+// A blazing-fast guess gets an extra-emphatic ⚡⚡ flourish.
+const VERY_QUICK_GUESS_MS = 1500;
 // Legacy shows the 🔥 streak flair starting at 5 in a row.
 const STREAK_DISPLAY_THRESHOLD = 5;
+
+/** Strips casing/punctuation/whitespace so near-miss comparison is forgiving. */
+function normalizeForCompare(s: string): string {
+    return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Levenshtein edit distance between two short strings. */
+function editDistance(a: string, b: string): number {
+    const m = a.length;
+    const n = b.length;
+    if (m === 0) return n;
+    if (n === 0) return m;
+    let prev = Array.from({ length: n + 1 }, (_, i) => i);
+    let curr = new Array<number>(n + 1);
+    for (let i = 1; i <= m; i++) {
+        curr[0] = i;
+        for (let j = 1; j <= n; j++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            curr[j] = Math.min(
+                prev[j]! + 1,
+                curr[j - 1]! + 1,
+                prev[j - 1]! + cost,
+            );
+        }
+
+        [prev, curr] = [curr, prev];
+    }
+
+    return prev[n]!;
+}
+
+/** True when an *incorrect* guess is within a small edit distance of one of the
+ *  answers (song or artist) — a "so close!" near-miss. Purely client-side. */
+function isNearMiss(guess: string, targets: string[]): boolean {
+    const g = normalizeForCompare(guess);
+    if (g.length < 2) return false;
+    return targets.some((target) => {
+        const t = normalizeForCompare(target);
+        if (t.length === 0 || g === t) return false;
+        const tol = Math.min(
+            3,
+            Math.max(1, Math.floor(Math.max(g.length, t.length) * 0.2)),
+        );
+
+        return editDistance(g, t) <= tol;
+    });
+}
 
 function readInitialTheme(): Theme {
     // localStorage can throw in sandboxed contexts (rare inside Discord's
@@ -152,6 +202,7 @@ const initialUi: UiState = {
     roundHistory: [],
     floatingEmotes: [],
     recap: null,
+    levelUps: [],
 };
 
 function applySnapshot(prev: UiState, snapshot: ActivitySnapshot): UiState {
@@ -1206,6 +1257,70 @@ function RecapCard({ recap, t }: { recap: SessionRecap; t: Translator }) {
     );
 }
 
+/** Game-over level-up flourish: the viewer's own level-up (if any) leads, with
+ *  confetti, and rank-ups get extra emphasis. Other players' level-ups follow. */
+function LevelUpCelebration({
+    levelUps,
+    viewerID,
+    t,
+}: {
+    levelUps: LevelUp[];
+    viewerID: string | null;
+    t: Translator;
+}) {
+    // Viewer's level-up first, then most levels gained; cap the visible rows so
+    // a large lobby can't overflow the game-over card.
+    const ordered = [...levelUps].sort((a, b) => {
+        if (a.userID === viewerID) return -1;
+        if (b.userID === viewerID) return 1;
+        return b.endLevel - b.startLevel - (a.endLevel - a.startLevel);
+    });
+
+    const shown = ordered.slice(0, 6);
+    const viewerLeveled =
+        viewerID !== null && levelUps.some((l) => l.userID === viewerID);
+    const viewerRankUp = levelUps.some(
+        (l) => l.userID === viewerID && l.isRankUp,
+    );
+
+    return (
+        <div className="level-up-celebration">
+            {viewerLeveled && <Confetti />}
+            <div className={`level-up-title${viewerRankUp ? " rank-up" : ""}`}>
+                {viewerRankUp ? t("levelUp.rankUpTitle") : t("levelUp.title")}
+            </div>
+            <ul className="level-up-list">
+                {shown.map((l) => (
+                    <li
+                        key={l.userID}
+                        className={`level-up-row${
+                            l.userID === viewerID ? " viewer" : ""
+                        }${l.isRankUp ? " rank-up" : ""}`}
+                    >
+                        <span className="level-up-user">{l.username}</span>
+                        <span className="level-up-levels">
+                            {t("levelUp.levels", {
+                                start: String(l.startLevel),
+                                end: String(l.endLevel),
+                            })}
+                        </span>
+                        {l.isRankUp && (
+                            <span className="level-up-rank">⭐ {l.rank}</span>
+                        )}
+                    </li>
+                ))}
+                {ordered.length > shown.length && (
+                    <li className="level-up-more">
+                        {t("levelUp.more", {
+                            count: String(ordered.length - shown.length),
+                        })}
+                    </li>
+                )}
+            </ul>
+        </div>
+    );
+}
+
 function CurrentRound({
     round,
     reveal,
@@ -1216,6 +1331,8 @@ function CurrentRound({
     guesses,
     recap,
     noActiveGame,
+    levelUps,
+    viewerID,
     t,
 }: {
     round: ActivityRoundMeta | null;
@@ -1237,6 +1354,10 @@ function CurrentRound({
     guesses: UiState["recentGuesses"];
     /** End-of-session recap, shown on the game-over screen. */
     recap: SessionRecap | null;
+    /** Per-player level-ups from the just-ended session (game-over screen). */
+    levelUps: UiState["levelUps"];
+    /** The viewer's Discord ID, to highlight their own level-up. */
+    viewerID: string | null;
     t: Translator;
 }) {
     return (
@@ -1299,6 +1420,17 @@ function CurrentRound({
                                     const quick =
                                         g.timeToGuessMs !== null &&
                                         g.timeToGuessMs <= QUICK_GUESS_MS;
+                                    const veryQuick =
+                                        g.timeToGuessMs !== null &&
+                                        g.timeToGuessMs <= VERY_QUICK_GUESS_MS;
+                                    // Escalate the streak flair: tier 1 at 5+,
+                                    // tier 2 at 10+, tier 3 at 15+.
+                                    const streakTier =
+                                        g.streak >= 15
+                                            ? 3
+                                            : g.streak >= 10
+                                              ? 2
+                                              : 1;
                                     return (
                                         <li key={g.id}>
                                             {t("revealWinners", {
@@ -1309,7 +1441,7 @@ function CurrentRound({
                                             {g.streak >=
                                                 STREAK_DISPLAY_THRESHOLD && (
                                                 <span
-                                                    className="winner-streak"
+                                                    className={`winner-streak streak-tier-${streakTier}`}
                                                     title={t("streakTitle", {
                                                         streak: g.streak,
                                                     })}
@@ -1321,9 +1453,17 @@ function CurrentRound({
                                                 <span
                                                     className={`winner-time ${
                                                         quick ? "quick" : ""
+                                                    }${
+                                                        veryQuick
+                                                            ? " very-quick"
+                                                            : ""
                                                     }`}
                                                 >
-                                                    {quick ? "⚡" : ""}
+                                                    {veryQuick
+                                                        ? "⚡⚡"
+                                                        : quick
+                                                          ? "⚡"
+                                                          : ""}
                                                     {(
                                                         g.timeToGuessMs / 1000
                                                     ).toFixed(1)}
@@ -1352,28 +1492,45 @@ function CurrentRound({
                                         {reveal.allGuesses
                                             .slice()
                                             .sort((a, b) => a.ts - b.ts)
-                                            .map((g) => (
-                                                <li
-                                                    key={g.userID}
-                                                    className={
-                                                        g.isCorrect
-                                                            ? "correct"
-                                                            : ""
-                                                    }
-                                                >
-                                                    <span className="g-name">
-                                                        {g.username}
-                                                    </span>
-                                                    <span className="g-text">
-                                                        {g.guess || "—"}
-                                                    </span>
-                                                    {g.isCorrect && (
-                                                        <span className="g-mark">
-                                                            ✓
+                                            .map((g) => {
+                                                const nearMiss =
+                                                    !g.isCorrect &&
+                                                    isNearMiss(g.guess, [
+                                                        reveal.song.songName,
+                                                        reveal.song.artistName,
+                                                    ]);
+                                                return (
+                                                    <li
+                                                        key={g.userID}
+                                                        className={`${
+                                                            g.isCorrect
+                                                                ? "correct"
+                                                                : ""
+                                                        }${
+                                                            nearMiss
+                                                                ? " near-miss"
+                                                                : ""
+                                                        }`}
+                                                    >
+                                                        <span className="g-name">
+                                                            {g.username}
                                                         </span>
-                                                    )}
-                                                </li>
-                                            ))}
+                                                        <span className="g-text">
+                                                            {g.guess || "—"}
+                                                        </span>
+                                                        {g.isCorrect && (
+                                                            <span className="g-mark">
+                                                                ✓
+                                                            </span>
+                                                        )}
+                                                        {nearMiss && (
+                                                            <span className="g-near">
+                                                                {t("soClose")}
+                                                            </span>
+                                                        )}
+                                                    </li>
+                                                );
+                                            })}
                                     </ul>
                                 </details>
                             )}
@@ -1431,6 +1588,13 @@ function CurrentRound({
                                 <RecapCard recap={recap} t={t} />
                             )}
                         </div>
+                        {winnerText && levelUps.length > 0 && (
+                            <LevelUpCelebration
+                                levelUps={levelUps}
+                                viewerID={viewerID}
+                                t={t}
+                            />
+                        )}
                         {winnerText ? (
                             history.length > 0 ? (
                                 <div className="thumbnail-slot session-montage">
@@ -4818,6 +4982,8 @@ export default function App() {
                             guesses={ui.recentGuesses}
                             recap={ui.recap}
                             noActiveGame={ui.sessionEnded}
+                            levelUps={ui.levelUps}
+                            viewerID={authState?.userID ?? null}
                             t={t}
                             winnerText={
                                 ui.sessionEnded &&
@@ -5129,6 +5295,7 @@ function reduce(
                 roundHistory: [],
                 floatingEmotes: [],
                 recap: null,
+                levelUps: [],
             };
         case "roundStart":
             return {
@@ -5264,6 +5431,10 @@ function reduce(
                     },
                 ],
             };
+        case "levelUp":
+            // Arrives just after sessionEnd (server emits it post-stats), so it
+            // lands on the game-over screen as a celebration.
+            return { ...prev, levelUps: msg.levelUps };
         case "optionsChanged":
             return { ...prev, options: msg.options };
         case "roundTimerChanged":

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -773,10 +773,55 @@ body::before {
 
 .winner-streak {
     color: var(--gold);
+    display: inline-block;
+}
+
+/* Escalating combo flair: each tier scales up and glows harder. */
+.winner-streak.streak-tier-1 {
+    transform: scale(1);
+}
+
+.winner-streak.streak-tier-2 {
+    transform: scale(1.12);
+    text-shadow: 0 0 6px var(--gold);
+}
+
+.winner-streak.streak-tier-3 {
+    transform: scale(1.25);
+    font-weight: 800;
+    text-shadow: 0 0 10px var(--gold);
+    animation: streak-pulse 0.9s ease-in-out infinite;
+}
+
+@keyframes streak-pulse {
+    0%,
+    100% {
+        transform: scale(1.25);
+    }
+    50% {
+        transform: scale(1.4);
+    }
 }
 
 .winner-time.quick {
     color: var(--gold);
+}
+
+.winner-time.very-quick {
+    color: var(--gold);
+    font-weight: 800;
+    text-shadow: 0 0 8px var(--gold);
+    animation: very-quick-flash 1.1s ease-in-out infinite;
+}
+
+@keyframes very-quick-flash {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.55;
+    }
 }
 
 /* unique-songs-played counter under the reveal (fills the bottom space and
@@ -1034,6 +1079,87 @@ body::before {
         opacity: 0;
         transform: translateY(380px) translateX(var(--drift, 0)) rotate(560deg);
     }
+}
+
+/* ---- LEVEL-UP CELEBRATION (game-over screen) ---- */
+.level-up-celebration {
+    position: relative;
+    width: 100%;
+    margin: 10px 0 4px;
+    padding: 12px 14px;
+    border: 1px solid var(--gold);
+    border-radius: var(--radius-md);
+    background: var(--gold-light);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.level-up-title {
+    text-align: center;
+    font-weight: 800;
+    font-size: 0.95rem;
+    color: var(--gold);
+    animation: winner-pop 0.5s cubic-bezier(0.2, 0.9, 0.3, 1.4);
+}
+
+.level-up-title.rank-up {
+    font-size: 1.05rem;
+    text-shadow: 0 0 10px var(--gold);
+    animation: winner-pop 0.6s cubic-bezier(0.2, 0.9, 0.3, 1.4);
+}
+
+.level-up-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.level-up-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 0.82rem;
+}
+
+.level-up-row.viewer {
+    font-weight: 700;
+}
+
+.level-up-row .level-up-user {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.level-up-row .level-up-levels {
+    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.level-up-row.viewer .level-up-levels {
+    color: var(--text-primary);
+}
+
+.level-up-row .level-up-rank {
+    color: var(--gold);
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.level-up-row.rank-up .level-up-rank {
+    text-shadow: 0 0 8px var(--gold);
+}
+
+.level-up-more {
+    color: var(--text-tertiary);
+    font-size: 0.74rem;
+    text-align: center;
 }
 
 /* ---- BOOKMARK STAR ---- */
@@ -1580,6 +1706,20 @@ body::before {
 .all-guesses .g-mark {
     color: var(--green);
     font-weight: 700;
+}
+
+/* Near-miss: an incorrect guess that was within a hair of the answer. */
+.all-guesses li.near-miss {
+    background: var(--gold-light);
+    border-left: 2px solid var(--gold);
+}
+
+.all-guesses .g-near {
+    color: var(--gold);
+    font-weight: 700;
+    font-size: 0.72rem;
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 /* ---- BANNER ---- */

--- a/activity/src/types/activity_event.ts
+++ b/activity/src/types/activity_event.ts
@@ -6,6 +6,7 @@ import type { ActivityMultipleChoiceOption } from "./activity_round_meta";
 import type ActivityRoundReveal from "./activity_round_reveal";
 import type ActivityScoreboardSnapshot from "./activity_scoreboard_snapshot";
 import type ActivitySessionMeta from "./activity_session_meta";
+import type LevelUp from "./level_up";
 
 type ActivityEvent =
     | { type: "sessionStart"; session: ActivitySessionMeta }
@@ -57,6 +58,7 @@ type ActivityEvent =
           avatarUrl: string | null;
           emote: string;
       }
+    | { type: "levelUp"; levelUps: LevelUp[] }
     | { type: "hintProgress"; requesters: number; threshold: number }
     | { type: "hintRevealed"; text: string }
     | { type: "skipProgress"; requesters: number; threshold: number }

--- a/activity/src/types/level_up.ts
+++ b/activity/src/types/level_up.ts
@@ -1,0 +1,11 @@
+// Mirror of one entry of the "levelUp" ActivityEvent payload (server-resolved).
+export default interface LevelUp {
+    userID: string;
+    username: string;
+    startLevel: number;
+    endLevel: number;
+    /** Localized rank title at the new level (e.g. "Nugu"). */
+    rank: string;
+    /** True when the new level crosses into a new rank tier. */
+    isRankUp: boolean;
+}

--- a/activity/src/types/ui_state.ts
+++ b/activity/src/types/ui_state.ts
@@ -7,6 +7,7 @@ import type ActivityScoreboardSnapshot from "./activity_scoreboard_snapshot";
 import type ActivitySessionMeta from "./activity_session_meta";
 import type FloatingEmote from "./floating_emote";
 import type HintState from "./hint_state";
+import type LevelUp from "./level_up";
 import type RecentGuess from "./recent_guess";
 import type SessionRecap from "./session_recap";
 import type SkipState from "./skip_state";
@@ -42,4 +43,8 @@ export default interface UiState {
     floatingEmotes: FloatingEmote[];
     /** End-of-session recap, shown on the game-over screen. Null until received. */
     recap: SessionRecap | null;
+    /** Per-player level-ups from the just-ended session, shown as a game-over
+     *  celebration. Empty until a `levelUp` event arrives; reset on a new
+     *  session. */
+    levelUps: LevelUp[];
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "abstimmen",
         "historyEmpty": "Noch keine Songs.",
         "historyHeading": "Songverlauf",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} mehr",
+            "rankUpTitle": "Rang hoch!",
+            "title": "Level hoch!"
+        },
         "networkError": "Netzwerkfehler",
         "notInVCWarning": "Trete dem Sprachkanal bei, um ein Spiel zu starten.",
         "openOnYouTube": "Auf YouTube öffnen",
@@ -267,6 +273,7 @@
         "skipDone": "Übersprungen",
         "skipTitle": "Für das Überspringen dieses Songs abstimmen",
         "skipVoteFallback": "abstimmen",
+        "soClose": "so nah dran!",
         "songCounterLine": "{{played}}/{{total}} Songs gespielt",
         "songInfo": {
             "artistAliases": "Künstler Aliase",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "vote",
         "historyEmpty": "No songs yet.",
         "historyHeading": "Song History",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} more",
+            "rankUpTitle": "Rank Up!",
+            "title": "Level Up!"
+        },
         "networkError": "Network error",
         "notInVCWarning": "Join the voice channel to start a game.",
         "openOnYouTube": "Open on YouTube",
@@ -267,6 +273,7 @@
         "skipDone": "Skipped",
         "skipTitle": "Vote to skip this song",
         "skipVoteFallback": "vote",
+        "soClose": "so close!",
         "songCounterLine": "{{played}}/{{total}} songs played",
         "songInfo": {
             "artistAliases": "Artist Aliases",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "votar",
         "historyEmpty": "Aún no hay canciones.",
         "historyHeading": "Historial de canciones",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} más",
+            "rankUpTitle": "¡Aumentar de rango!",
+            "title": "¡Subir de nivel!"
+        },
         "networkError": "Error de red",
         "notInVCWarning": "Únete al canal de voz para comenzar un juego.",
         "openOnYouTube": "Abrir en YouTube",
@@ -267,6 +273,7 @@
         "skipDone": "Saltada",
         "skipTitle": "Vota para saltar esta canción",
         "skipVoteFallback": "votar",
+        "soClose": "¡tan cerca!",
         "songCounterLine": "{{played}}/{{total}} canciones reproducidas",
         "songInfo": {
             "artistAliases": "Alias del artista",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "voter",
         "historyEmpty": "Aucune chanson pour l'instant.",
         "historyHeading": "Historique des chansons",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} de plus",
+            "rankUpTitle": "Montée en grade!",
+            "title": "Monte en niveau !"
+        },
         "networkError": "Erreur réseau",
         "notInVCWarning": "Rejoignez le canal vocal pour commencer une partie.",
         "openOnYouTube": "Ouvrir sur YouTube",
@@ -267,6 +273,7 @@
         "skipDone": "Passée",
         "skipTitle": "Voter pour passer cette chanson",
         "skipVoteFallback": "voter",
+        "soClose": "si près!",
         "songCounterLine": "{{played}}/{{total}} chansons lues",
         "songInfo": {
             "artistAliases": "Alias de l'artiste",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "वोट",
         "historyEmpty": "अभी तक कोई गाना नहीं।",
         "historyHeading": "गाने का इतिहास",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} और",
+            "rankUpTitle": "रैंक ऊपर!",
+            "title": "स्तर ऊपर!"
+        },
         "networkError": "नेटवर्क त्रुटि",
         "notInVCWarning": "खेल शुरू करने के लिए वॉयस चैनल से जुड़ें।",
         "openOnYouTube": "YouTube पर खोलें",
@@ -267,6 +273,7 @@
         "skipDone": "छोड़ दिया",
         "skipTitle": "इस गाने को छोड़ने के लिए वोट दें",
         "skipVoteFallback": "वोट",
+        "soClose": "बहुत करीब!",
         "songCounterLine": "{{played}}/{{total}} गाने बजाए",
         "songInfo": {
             "artistAliases": "कलाकार उपनाम",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "pilih",
         "historyEmpty": "Belum ada lagu.",
         "historyHeading": "Riwayat Lagu",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} lagi",
+            "rankUpTitle": "Rank Up!",
+            "title": "Level Up!"
+        },
         "networkError": "Kesalahan jaringan",
         "notInVCWarning": "Bergabunglah dengan saluran suara untuk memulai permainan.",
         "openOnYouTube": "Buka di YouTube",
@@ -267,6 +273,7 @@
         "skipDone": "Dilewati",
         "skipTitle": "Pilih untuk melewati lagu ini",
         "skipVoteFallback": "pilih",
+        "soClose": "begitu dekat!",
         "songCounterLine": "{{played}}/{{total}} lagu diputar",
         "songInfo": {
             "artistAliases": "Alias Artis",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "投票",
         "historyEmpty": "まだ曲がありません。",
         "historyHeading": "曲の履歴",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} もっと",
+            "rankUpTitle": "ランクアップ！",
+            "title": "レベルアップ！"
+        },
         "networkError": "ネットワークエラー",
         "notInVCWarning": "ゲームを始めるにはボイスチャンネルに参加してください。",
         "openOnYouTube": "YouTubeで開く",
@@ -267,6 +273,7 @@
         "skipDone": "スキップ済み",
         "skipTitle": "この曲をスキップするか投票",
         "skipVoteFallback": "投票",
+        "soClose": "あと少し！",
         "songCounterLine": "{{played}}/{{total}} 曲再生済み",
         "songInfo": {
             "artistAliases": "アーティストの別名",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "투표",
         "historyEmpty": "아직 노래가 없습니다.",
         "historyHeading": "노래 기록",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} 더",
+            "rankUpTitle": "랭크 업!",
+            "title": "레벨 업!"
+        },
         "networkError": "네트워크 오류",
         "notInVCWarning": "게임을 시작하려면 음성 채널에 참여하세요.",
         "openOnYouTube": "YouTube에서 열기",
@@ -267,6 +273,7 @@
         "skipDone": "스킵됨",
         "skipTitle": "이 곡 스킵에 투표",
         "skipVoteFallback": "투표",
+        "soClose": "거의 다 왔어요!",
         "songCounterLine": "{{played}}/{{total}} 곡 재생됨",
         "songInfo": {
             "artistAliases": "아티스트 별명",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "stem",
         "historyEmpty": "Nog geen nummers.",
         "historyHeading": "Geschiedenis van nummers",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} meer",
+            "rankUpTitle": "Rank omhoog!",
+            "title": "Level omhoog!"
+        },
         "networkError": "Netwerkfout",
         "notInVCWarning": "Neem deel aan het spraakkanaal om een spel te starten.",
         "openOnYouTube": "Openen op YouTube",
@@ -267,6 +273,7 @@
         "skipDone": "Overgeslagen",
         "skipTitle": "Stem om dit nummer over te slaan",
         "skipVoteFallback": "stem",
+        "soClose": "zo dichtbij!",
         "songCounterLine": "{{played}}/{{total}} nummers afgespeeld",
         "songInfo": {
             "artistAliases": "Artiest Aliassen",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "votar",
         "historyEmpty": "Nenhuma música ainda.",
         "historyHeading": "Histórico de Músicas",
+        "levelUp": {
+            "levels": "Lv {{start}} → {{end}}",
+            "more": "+{{count}} mais",
+            "rankUpTitle": "Subir de classificação!",
+            "title": "Aumentar de nível!"
+        },
         "networkError": "Erro de rede",
         "notInVCWarning": "Entre no canal de voz para iniciar um jogo.",
         "openOnYouTube": "Abrir no YouTube",
@@ -267,6 +273,7 @@
         "skipDone": "Pulada",
         "skipTitle": "Votar para pular esta música",
         "skipVoteFallback": "votar",
+        "soClose": "tão perto!",
         "songCounterLine": "{{played}}/{{total}} músicas tocadas",
         "songInfo": {
             "artistAliases": "Apelidos do artista",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "голос",
         "historyEmpty": "Песен пока нет.",
         "historyHeading": "История песен",
+        "levelUp": {
+            "levels": "Ур {{start}} → {{end}}",
+            "more": "+{{count}} больше",
+            "rankUpTitle": "Повышение ранга!",
+            "title": "Повышение уровня!"
+        },
         "networkError": "Ошибка сети",
         "notInVCWarning": "Присоединитесь к голосовому каналу, чтобы начать игру.",
         "openOnYouTube": "Открыть на YouTube",
@@ -267,6 +273,7 @@
         "skipDone": "Пропущено",
         "skipTitle": "Голосовать за пропуск песни",
         "skipVoteFallback": "голос",
+        "soClose": "почти получилось!",
         "songCounterLine": "{{played}}/{{total}} песен воспроизведено",
         "songInfo": {
             "artistAliases": "Псевдонимы исполнителя",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -51,6 +51,12 @@
         "hintVoteFallback": "投票",
         "historyEmpty": "暂无歌曲。",
         "historyHeading": "歌曲历史",
+        "levelUp": {
+            "levels": "等級 {{start}} → {{end}}",
+            "more": "+{{count}} 更多",
+            "rankUpTitle": "提升等级！",
+            "title": "升级！"
+        },
         "networkError": "网络错误",
         "notInVCWarning": "加入语音频道开始游戏。",
         "openOnYouTube": "在 YouTube 中打开",
@@ -267,6 +273,7 @@
         "skipDone": "已跳过",
         "skipTitle": "投票跳过这首歌",
         "skipVoteFallback": "投票",
+        "soClose": "差点啦！",
         "songCounterLine": "{{played}}/{{total}} 首歌曲已播放",
         "songInfo": {
             "artistAliases": "艺术家别名",

--- a/src/interfaces/activity_event.ts
+++ b/src/interfaces/activity_event.ts
@@ -65,6 +65,17 @@ type ActivityEvent =
           avatarUrl: string | null;
           emote: string;
       }
+    | {
+          type: "levelUp";
+          levelUps: Array<{
+              userID: string;
+              username: string;
+              startLevel: number;
+              endLevel: number;
+              rank: string;
+              isRankUp: boolean;
+          }>;
+      }
     | { type: "hintProgress"; requesters: number; threshold: number }
     | { type: "hintRevealed"; text: string }
     | { type: "skipProgress"; requesters: number; threshold: number }

--- a/src/structures/activity_bridge.ts
+++ b/src/structures/activity_bridge.ts
@@ -437,6 +437,15 @@ interface SessionEndPayload {
     reason: string;
 }
 
+/** One entry of the GameSession `levelUp` event (names resolved by the bridge). */
+interface LevelUpEventEntry {
+    userID: string;
+    startLevel: number;
+    endLevel: number;
+    rank: string;
+    isRankUp: boolean;
+}
+
 /**
  * Registers a single worker-wide IPC listener for admiral→worker activity
  * requests. Idempotent: subsequent calls are a no-op. No-op when running
@@ -2019,11 +2028,28 @@ export function attachActivityBridge(session: GameSession): void {
             type: "sessionEnd",
             reason: payload.reason,
         });
+    });
 
-        // Drop our listeners now that the session is over. The Session object
-        // becomes unreachable when State.gameSessions[guildID] is deleted; this
-        // just avoids holding extra references via the EventEmitter for the
-        // brief window before GC.
+    session.on("levelUp", (levelUps: Array<LevelUpEventEntry>) => {
+        pushEvent(guildID, {
+            type: "levelUp",
+            levelUps: levelUps.map((l) => ({
+                userID: l.userID,
+                username: lookupName(l.userID).username,
+                startLevel: l.startLevel,
+                endLevel: l.endLevel,
+                rank: l.rank,
+                isRankUp: l.isRankUp,
+            })),
+        });
+    });
+
+    // Emitted last by endSessionCore, after all post-session events (sessionEnd,
+    // levelUp). Drop our listeners now that the session is over. The Session
+    // object becomes unreachable when State.gameSessions[guildID] is deleted;
+    // this just avoids holding extra references via the EventEmitter for the
+    // brief window before GC.
+    session.on("activityTeardown", () => {
         setImmediate(() => session.removeAllListeners());
     });
 }

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -1654,6 +1654,34 @@ export default class GameSession extends Session {
             );
         }
 
+        // Surface level-ups to the Activity for a game-over celebration. The
+        // sessionEnd listener defers its teardown to `activityTeardown` (emitted
+        // last), so this still has a live listener despite running post-await.
+        if (leveledUpPlayers.length > 0) {
+            this.emit(
+                "levelUp",
+                leveledUpPlayers.map((p) => {
+                    const startRank = ProfileCommand.getRankNameByLevel(
+                        p.startLevel,
+                        this.guildID,
+                    );
+
+                    const endRank = ProfileCommand.getRankNameByLevel(
+                        p.endLevel,
+                        this.guildID,
+                    );
+
+                    return {
+                        userID: p.userID,
+                        startLevel: p.startLevel,
+                        endLevel: p.endLevel,
+                        rank: endRank,
+                        isRankUp: startRank !== endRank,
+                    };
+                }),
+            );
+        }
+
         // commit guild's game session
         const sessionLength = (Date.now() - this.startedAt) / (1000 * 60);
         const averageGuessTime =
@@ -1677,6 +1705,11 @@ export default class GameSession extends Session {
         logger.info(
             `gid: ${this.guildID} | Game session ended. rounds_played = ${this.roundsPlayed}. session_length = ${sessionLength}. gameType = ${this.gameType}`,
         );
+
+        // Final signal for the Activity bridge to drop its listeners, emitted
+        // after all post-session events (sessionEnd, levelUp) so none are lost
+        // to an early teardown.
+        this.emit("activityTeardown");
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds "game feel" juice to the Activity, centered on a dedicated end-of-game **level-up moment**. When a session ends, per-player level-ups (and rank-tier crossings) are emitted as a new `levelUp` event and celebrated on the game-over screen — confetti for the viewer, extra emphasis for rank-ups — rather than the level-up only living quietly inside the profile card.

Part of the Activity engagement set. Independent of the social-juice work already on master (#2378); this branch was rebased onto current master, integrating cleanly alongside the recap/emote events.

## Changes

- **`levelUp` event** — new bot→client event on the `ActivityEvent` union (client + server interfaces). `GameSession.endSessionCore` emits it after `sessionEnd`, carrying each player's start/end level, rank, and `isRankUp`. Listener teardown is deferred to a final `activityTeardown` signal so the post-await emit still reaches subscribers.
- **`LevelUpCelebration`** — game-over flourish in `CurrentRound`: the viewer's own level-up leads (with confetti), rank-ups get a star + emphasis, other players follow, capped to avoid overflow.
- **Combo / near-miss polish** — escalating streak visuals and "so close!" styling on near-correct guesses (see `styles.css`).
- i18n: new `levelUp.*` keys added to `en.json` and propagated to all locales.

## Testing

- `activity` `tsc -b` clean; server `tsc --noEmit` clean; `lint-ci` + prettier clean; `lint-i18n` 0 warnings.
- `activity_hub` unit tests pass (36).
- Needs a deploy to verify the level-up celebration visually on the live game-over screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
