### PR TITLE
Port the Activity to a standalone website with rooms, browser audio, and guest play

### DIFF
--- a/activity/index.html
+++ b/activity/index.html
@@ -22,6 +22,7 @@
             href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap"
             rel="stylesheet"
         />
+        <link rel="icon" type="image/png" href="/src/assets/kmq_logo.png" />
         <title>KMQ</title>
     </head>
     <body>

--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -41,6 +41,7 @@ import {
     openExternalUrl,
     readSdkLocale,
 } from "./platform/discordPlatform";
+import { isEmbedded } from "./platform";
 import { makeTranslator } from "./i18n/translator";
 import SoundControls from "./web/SoundControls";
 import useRoundAudio from "./web/useRoundAudio";
@@ -226,7 +227,13 @@ function applySnapshot(prev: UiState, snapshot: ActivitySnapshot): UiState {
 // Discord Activities sandbox the iframe — only hosts registered as URL
 // Mappings in the developer portal can be reached. Rewrite YouTube image
 // hosts to a /external/yt/ prefix that the dev portal maps to i.ytimg.com.
+// The standalone website has no such mapping (and no sandbox): the original
+// i.ytimg.com URL is used directly.
 function proxyImageUrl(url: string): string {
+    if (!isEmbedded()) {
+        return url;
+    }
+
     return url.replace(
         YOUTUBE_IMAGE_HOST_PATTERN,
         EXTERNAL_YOUTUBE_PROXY_PREFIX,
@@ -4336,6 +4343,16 @@ type StreamEvent =
     | ActivityEvent
     | { type: "snapshot"; snapshot: ActivitySnapshot };
 
+// Web-only auto-reconnect after a dropped websocket. The embedded Activity
+// leaves this to the user (Discord itself reloads the iframe on real
+// trouble); on the open web transient drops are routine, so a few silent
+// retries with backoff come first, and the manual Reconnect screen is the
+// fallback. A connection that survived this long is considered healthy and
+// resets the attempt budget.
+const WEB_RECONNECT_MAX_ATTEMPTS = 3;
+const WEB_RECONNECT_BASE_DELAY_MS = 1500;
+const WEB_RECONNECT_HEALTHY_MS = 30_000;
+
 // Minimum time the round-end reveal stays on screen before the next round (or
 // the game-over screen) is allowed to replace it. The reveal naturally shows
 // for the gap between rounds, which is the guild's `song_start_delay`; when
@@ -4457,6 +4474,11 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
     }, []);
 
     const streamRef = useRef<{ close: () => void } | null>(null);
+
+    // Web auto-reconnect bookkeeping (see WEB_RECONNECT_*).
+    const reconnectAttemptsRef = useRef(0);
+    const reconnectTimerRef = useRef<number | null>(null);
+    const streamOpenedAtRef = useRef(0);
 
     // Reveal-hold bookkeeping (see MIN_REVEAL_HOLD_MS). `revealShownAt` marks
     // when the current reveal appeared (set on roundEnd); while a tear-down
@@ -4637,10 +4659,40 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                         // from when the effect ran); the render translates it
                         // with the current bundle. The error screen offers
                         // Reconnect, which re-runs this flow.
-                        if (!cancelled) {
-                            setReconnecting(false);
-                            setError({ kind: "disconnected" });
+                        if (cancelled) return;
+
+                        // Web: retry silently first. A long-lived connection
+                        // dropping restarts the budget; a crash loop (drops
+                        // right after connecting) burns through it and lands
+                        // on the manual Reconnect screen.
+                        if (webAuth) {
+                            if (
+                                Date.now() - streamOpenedAtRef.current >
+                                WEB_RECONNECT_HEALTHY_MS
+                            ) {
+                                reconnectAttemptsRef.current = 0;
+                            }
+
+                            if (
+                                reconnectAttemptsRef.current <
+                                WEB_RECONNECT_MAX_ATTEMPTS
+                            ) {
+                                const attempt = reconnectAttemptsRef.current;
+                                reconnectAttemptsRef.current += 1;
+                                setReconnecting(true);
+                                reconnectTimerRef.current = window.setTimeout(
+                                    () => {
+                                        reconnectTimerRef.current = null;
+                                        setConnectNonce((n) => n + 1);
+                                    },
+                                    WEB_RECONNECT_BASE_DELAY_MS * 2 ** attempt,
+                                );
+                                return;
+                            }
                         }
+
+                        setReconnecting(false);
+                        setError({ kind: "disconnected" });
                     },
                 );
 
@@ -4650,6 +4702,7 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                 }
 
                 streamRef.current = stream;
+                streamOpenedAtRef.current = Date.now();
                 setReconnecting(false);
             } catch (e) {
                 // Log the real error/status for debugging; show the user a
@@ -4666,6 +4719,11 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
             cancelled = true;
             streamRef.current?.close();
             streamRef.current = null;
+            if (reconnectTimerRef.current !== null) {
+                window.clearTimeout(reconnectTimerRef.current);
+                reconnectTimerRef.current = null;
+            }
+
             // Drop any pending reveal-hold so a reconnect's fresh snapshot
             // isn't clobbered by stale queued events from the old stream.
             if (holdTimerRef.current !== null) {
@@ -4683,6 +4741,8 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
     }, [connectNonce]);
 
     const reconnect = (): void => {
+        // A human clicking Reconnect restores the auto-retry budget.
+        reconnectAttemptsRef.current = 0;
         setReconnecting(true);
         setError(null);
         setReady(false);

--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -36,7 +36,11 @@ import {
     submitGuess,
     submitMcGuess,
 } from "./api";
-import { authenticate, openExternalUrl, readSdkLocale } from "./discordSdk";
+import {
+    authenticate,
+    openExternalUrl,
+    readSdkLocale,
+} from "./platform/discordPlatform";
 import { makeTranslator } from "./i18n/translator";
 import kmqLogoUrl from "./assets/kmq_logo.png";
 import thumbsUpUrl from "./assets/thumbs_up.png";

--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -42,6 +42,8 @@ import {
     readSdkLocale,
 } from "./platform/discordPlatform";
 import { makeTranslator } from "./i18n/translator";
+import SoundControls from "./web/SoundControls";
+import useRoundAudio from "./web/useRoundAudio";
 import kmqLogoUrl from "./assets/kmq_logo.png";
 import thumbsUpUrl from "./assets/thumbs_up.png";
 import type { ActivityArtist } from "./types/activity_options_snapshot";
@@ -4508,6 +4510,12 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
         apply(event);
     }, []);
 
+    // Web-only browser audio (on the embedded Activity the bot plays into
+    // the voice channel; the hook stays inert there). Destructured so the
+    // connect effect captures the stable callbacks, not the stateful object.
+    const roundAudio = useRoundAudio(!!webAuth);
+    const { handleRoundAudio, stop: stopRoundAudio } = roundAudio;
+
     // Translator is stable for a given bundle. Seed with an English stub for
     // the two strings rendered before the /api/activity/i18n fetch resolves,
     // so the splash isn't "appTitle" / "statusConnecting".
@@ -4563,6 +4571,12 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                 setAuthState({ accessToken, instanceId, userID });
                 setReady(true);
 
+                // Web rooms: a song may already be playing (late join /
+                // reconnect); each GET streams from the live position.
+                if (snapshot.currentAudio) {
+                    handleRoundAudio(snapshot.currentAudio.audioUrl);
+                }
+
                 // The SDK exposes the live Discord client locale, which can
                 // differ from the OAuth-embedded user.locale. Fetch the
                 // matching bundle and swap if it's different. On the web
@@ -4590,6 +4604,31 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                     accessToken,
                     instanceId,
                     (event) => {
+                        // roundAudio bypasses the reveal-hold queue: the
+                        // next round's audio must start on time even while
+                        // the previous reveal is held on screen.
+                        if (event.type === "roundAudio") {
+                            handleRoundAudio(event.audioUrl);
+                            return;
+                        }
+
+                        if (event.type === "sessionEnd") {
+                            // Discord parity: playback runs through the
+                            // reveal and only stops with the session.
+                            stopRoundAudio();
+                        }
+
+                        // Re-sync snapshots carry the live audio too (the
+                        // same-URL guard in the hook makes repeats free).
+                        if (
+                            event.type === "snapshot" &&
+                            event.snapshot.currentAudio
+                        ) {
+                            handleRoundAudio(
+                                event.snapshot.currentAudio.audioUrl,
+                            );
+                        }
+
                         handleStreamEvent(event);
                     },
                     () => {
@@ -5284,6 +5323,8 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                 emotes={ui.floatingEmotes}
                 onDismiss={dismissFloatingEmote}
             />
+
+            {webAuth && <SoundControls audio={roundAudio} />}
         </>
     );
 }

--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -4348,6 +4348,9 @@ export interface WebAuth {
     accessToken: string;
     instanceId: string;
     userID: string;
+    /** Website guest (no Discord account) — bookmarks (delivered by DM at
+     *  session end) can never reach them, so bookmarking UI is hidden. */
+    guest?: boolean;
 }
 
 // Fixed warning banner shown while a bot restart is announced (the Activity
@@ -4944,7 +4947,11 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                         <SongHistory
                             history={ui.roundHistory}
                             bookmarkedLinks={ui.bookmarkedLinks}
-                            active={ui.session !== null && !ui.sessionEnded}
+                            active={
+                                ui.session !== null &&
+                                !ui.sessionEnded &&
+                                !webAuth?.guest
+                            }
                             auth={
                                 authState
                                     ? {
@@ -5160,6 +5167,7 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                             }
                             bookmarkSlot={
                                 authState &&
+                                !webAuth?.guest &&
                                 (ui.currentRound || ui.lastReveal) ? (
                                     <BookmarkStar
                                         // Force a fresh component (and its optimistic

--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -42,6 +42,8 @@ import {
     readSdkLocale,
 } from "./platform/discordPlatform";
 import { isEmbedded } from "./platform";
+import { THEME_STORAGE_KEY, applyTheme, readInitialTheme } from "./theme";
+import type { Theme } from "./theme";
 import { makeTranslator } from "./i18n/translator";
 import SoundControls from "./web/SoundControls";
 import useRoundAudio from "./web/useRoundAudio";
@@ -113,9 +115,6 @@ const PRE_HYDRATE_STRINGS: Record<string, string> = {
     statusConnecting: "Connecting...",
 };
 
-type Theme = "light" | "dark";
-
-const THEME_STORAGE_KEY = "kmq:theme";
 // Mirrors the bot's QUICK_GUESS_MS (src/constants.ts) — guesses at or under
 // this get a ⚡ in the round-end reveal, matching the legacy text-chat look.
 const QUICK_GUESS_MS = 3500;
@@ -169,28 +168,6 @@ function isNearMiss(guess: string, targets: string[]): boolean {
 
         return editDistance(g, t) <= tol;
     });
-}
-
-function readInitialTheme(): Theme {
-    // localStorage can throw in sandboxed contexts (rare inside Discord's
-    // iframe but not impossible). Fall back to the OS preference.
-    try {
-        const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-        if (stored === "dark" || stored === "light") return stored;
-    } catch {
-        // ignore
-    }
-
-    // Discord's client defaults to dark; matching it is the better first
-    // impression for most users.
-    if (
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches
-    ) {
-        return "dark";
-    }
-
-    return "dark";
 }
 
 const initialUi: UiState = {
@@ -4373,6 +4350,38 @@ export interface WebAuth {
     userID: string;
 }
 
+// Fixed warning banner shown while a bot restart is announced (the Activity
+// counterpart of the text-channel restart embeds). Counts down locally from
+// the server-provided deadline; past it, holds an "any moment now" line until
+// the post-restart reconnect delivers a snapshot without the warning.
+function RestartBanner({
+    restartsAtEpochMs,
+    t,
+}: {
+    restartsAtEpochMs: number;
+    t: Translator;
+}) {
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        const timer = window.setInterval(() => setNow(Date.now()), 1000);
+        return () => window.clearInterval(timer);
+    }, []);
+
+    const remainingSec = Math.ceil((restartsAtEpochMs - now) / 1000);
+    return (
+        <div className="restart-banner" role="status">
+            <span aria-hidden="true">⚠️</span>
+            <span>
+                {remainingSec > 0
+                    ? t("restartCountdown", {
+                          countdown: formatDuration(remainingSec),
+                      })
+                    : t("restartImminent")}
+            </span>
+        </div>
+    );
+}
+
 export default function App({ webAuth }: { webAuth?: WebAuth }) {
     const [error, setError] = useState<ConnectionError | null>(null);
     const [ready, setReady] = useState(false);
@@ -4401,6 +4410,11 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
     // without reloading the iframe — drives the Reconnect button.
     const [connectNonce, setConnectNonce] = useState(0);
     const [reconnecting, setReconnecting] = useState(false);
+    // Epoch ms of an announced bot restart (null = none). Set from the
+    // snapshot on connect and updated by live restartWarning events.
+    const [restartsAtEpochMs, setRestartsAtEpochMs] = useState<number | null>(
+        null,
+    );
     // Profile cards. The cache is shared across every card for the session so
     // re-opening a player is free; the nonce is bumped on round/session end to
     // invalidate open cards (newly-earned EXP, level-ups).
@@ -4437,7 +4451,7 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
     // Mirror theme → <html data-theme>. Persist to localStorage so the
     // next iframe load doesn't flash the other theme while React boots.
     useEffect(() => {
-        document.documentElement.setAttribute("data-theme", theme);
+        applyTheme(theme);
         try {
             window.localStorage.setItem(THEME_STORAGE_KEY, theme);
         } catch {
@@ -4599,6 +4613,12 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                     handleRoundAudio(snapshot.currentAudio.audioUrl);
                 }
 
+                // A restart may have been announced before we connected (or
+                // retracted while we were disconnected).
+                setRestartsAtEpochMs(
+                    snapshot.restartWarning?.restartsAtEpochMs ?? null,
+                );
+
                 // The SDK exposes the live Discord client locale, which can
                 // differ from the OAuth-embedded user.locale. Fetch the
                 // matching bundle and swap if it's different. On the web
@@ -4634,6 +4654,13 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                             return;
                         }
 
+                        // Restart warnings bypass the reveal-hold queue too:
+                        // a system-level banner, not round flow.
+                        if (event.type === "restartWarning") {
+                            setRestartsAtEpochMs(event.restartsAtEpochMs);
+                            return;
+                        }
+
                         if (event.type === "sessionEnd") {
                             // Discord parity: playback runs through the
                             // reveal and only stops with the session.
@@ -4642,12 +4669,16 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
 
                         // Re-sync snapshots carry the live audio too (the
                         // same-URL guard in the hook makes repeats free).
-                        if (
-                            event.type === "snapshot" &&
-                            event.snapshot.currentAudio
-                        ) {
-                            handleRoundAudio(
-                                event.snapshot.currentAudio.audioUrl,
+                        if (event.type === "snapshot") {
+                            if (event.snapshot.currentAudio) {
+                                handleRoundAudio(
+                                    event.snapshot.currentAudio.audioUrl,
+                                );
+                            }
+
+                            setRestartsAtEpochMs(
+                                event.snapshot.restartWarning
+                                    ?.restartsAtEpochMs ?? null,
                             );
                         }
 
@@ -5385,6 +5416,10 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
             />
 
             {webAuth && <SoundControls audio={roundAudio} />}
+
+            {restartsAtEpochMs !== null && (
+                <RestartBanner restartsAtEpochMs={restartsAtEpochMs} t={t} />
+            )}
         </>
     );
 }

--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -4342,7 +4342,19 @@ type StreamEvent =
 // down. A longer song_start_delay already exceeds this, so it's a no-op there.
 const MIN_REVEAL_HOLD_MS = 1500;
 
-export default function App() {
+/**
+ * Credentials injected by the standalone-website shell: the web session token
+ * plus room code stand in for the Discord SDK's OAuth handshake and instance
+ * ID. When present, the connect flow skips every SDK call, so the Discord
+ * SDK chunk is never loaded on the web.
+ */
+export interface WebAuth {
+    accessToken: string;
+    instanceId: string;
+    userID: string;
+}
+
+export default function App({ webAuth }: { webAuth?: WebAuth }) {
     const [error, setError] = useState<ConnectionError | null>(null);
     const [ready, setReady] = useState(false);
     const [ui, setUi] = useState<UiState>(initialUi);
@@ -4522,6 +4534,10 @@ export default function App() {
                     accessToken = existingAuth.accessToken;
                     instanceId = existingAuth.instanceId;
                     userID = existingAuth.userID;
+                } else if (webAuth) {
+                    accessToken = webAuth.accessToken;
+                    instanceId = webAuth.instanceId;
+                    userID = webAuth.userID;
                 } else {
                     const auth = await authenticate();
                     if (cancelled) return;
@@ -4549,8 +4565,11 @@ export default function App() {
 
                 // The SDK exposes the live Discord client locale, which can
                 // differ from the OAuth-embedded user.locale. Fetch the
-                // matching bundle and swap if it's different.
-                const sdkLocale = await readSdkLocale();
+                // matching bundle and swap if it's different. On the web
+                // there's no SDK (and calling in would load its chunk); the
+                // snapshot's viewerLocale — the login-time Discord locale —
+                // already won.
+                const sdkLocale = webAuth ? null : await readSdkLocale();
                 if (
                     !cancelled &&
                     sdkLocale &&

--- a/activity/src/api.ts
+++ b/activity/src/api.ts
@@ -1,4 +1,4 @@
-import { ACTIVITY_PROXY_BASE, ACTIVITY_WS_PATH } from "./constants";
+import { getApiBase, getWsPath } from "./constants";
 import type {
     ActivityAnswerType,
     ActivityArtistType,
@@ -69,7 +69,7 @@ export async function fetchArtistAutocomplete(
     accessToken: string,
     q: string,
 ): Promise<AutocompleteArtist[]> {
-    const url = `${ACTIVITY_PROXY_BASE}/artist-autocomplete?q=${encodeURIComponent(q)}`;
+    const url = `${getApiBase()}/artist-autocomplete?q=${encodeURIComponent(q)}`;
     const resp = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },
     });
@@ -91,7 +91,7 @@ export interface ActivityI18nBundle {
 export async function fetchI18nBundle(
     locale: string,
 ): Promise<ActivityI18nBundle> {
-    const url = `${ACTIVITY_PROXY_BASE}/i18n?locale=${encodeURIComponent(locale)}`;
+    const url = `${getApiBase()}/i18n?locale=${encodeURIComponent(locale)}`;
     const resp = await fetch(url);
     if (!resp.ok) {
         throw new Error(`i18n bundle failed: ${resp.status}`);
@@ -104,7 +104,7 @@ export async function fetchSnapshot(
     accessToken: string,
     instanceId: string,
 ): Promise<ActivitySessionResponse> {
-    const url = `${ACTIVITY_PROXY_BASE}/session?instance_id=${encodeURIComponent(
+    const url = `${getApiBase()}/session?instance_id=${encodeURIComponent(
         instanceId,
     )}`;
 
@@ -125,7 +125,7 @@ async function postAction(
     path: "start" | "skip" | "end" | "hint" | "emote",
     extra?: Record<string, unknown>,
 ): Promise<GuessResult> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/${path}`, {
+    const resp = await fetch(`${getApiBase()}/${path}`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -195,7 +195,7 @@ export async function setOption(
     instanceId: string,
     option: SetOptionRequest,
 ): Promise<GuessResult> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/option`, {
+    const resp = await fetch(`${getApiBase()}/option`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -236,7 +236,7 @@ export async function preset(
     action: PresetAction,
     name?: string,
 ): Promise<PresetResult> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/preset`, {
+    const resp = await fetch(`${getApiBase()}/preset`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -273,7 +273,7 @@ export async function bookmarkSong(
     instanceId: string,
     youtubeLink?: string,
 ): Promise<BookmarkResult> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/bookmark`, {
+    const resp = await fetch(`${getApiBase()}/bookmark`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -319,7 +319,7 @@ export async function fetchProfile(
     instanceId: string,
     targetUserID?: string,
 ): Promise<ActivityProfileResponse | null> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/profile`, {
+    const resp = await fetch(`${getApiBase()}/profile`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -346,7 +346,7 @@ export async function fetchSongInfo(
     instanceId: string,
     youtubeLink: string,
 ): Promise<ActivitySongInfoResponse | null> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/song`, {
+    const resp = await fetch(`${getApiBase()}/song`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -372,7 +372,7 @@ export async function searchSongs(
     q: string,
     locale: string,
 ): Promise<ActivitySongSearchResult[]> {
-    const url = `${ACTIVITY_PROXY_BASE}/song-search?q=${encodeURIComponent(
+    const url = `${getApiBase()}/song-search?q=${encodeURIComponent(
         q,
     )}&locale=${encodeURIComponent(locale)}`;
 
@@ -390,7 +390,7 @@ export async function submitGuess(
     instanceId: string,
     guess: string,
 ): Promise<GuessResult> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/guess`, {
+    const resp = await fetch(`${getApiBase()}/guess`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -427,7 +427,7 @@ export async function submitMcGuess(
     instanceId: string,
     choiceID: string,
 ): Promise<GuessResult> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/mc-guess`, {
+    const resp = await fetch(`${getApiBase()}/mc-guess`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -462,7 +462,7 @@ async function requestWsTicket(
     accessToken: string,
     instanceId: string,
 ): Promise<string> {
-    const resp = await fetch(`${ACTIVITY_PROXY_BASE}/ws-ticket`, {
+    const resp = await fetch(`${getApiBase()}/ws-ticket`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -489,7 +489,7 @@ export async function openActivityStream(
 ): Promise<ActivityStreamHandle> {
     const ticket = await requestWsTicket(accessToken, instanceId);
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const url = `${proto}//${window.location.host}${ACTIVITY_WS_PATH}?ticket=${encodeURIComponent(ticket)}`;
+    const url = `${proto}//${window.location.host}${getWsPath()}?ticket=${encodeURIComponent(ticket)}`;
 
     const ws = new WebSocket(url);
     ws.addEventListener("message", (e) => {

--- a/activity/src/constants.ts
+++ b/activity/src/constants.ts
@@ -1,8 +1,14 @@
+import { isEmbedded } from "./platform";
+
 // Discord Activity sandboxes the iframe; only registered URL Mappings can be
 // reached. The reverse proxy at `/.proxy/*` is rewritten by the Embedded App
-// SDK runtime to the developer-portal-mapped origin.
-export const ACTIVITY_PROXY_BASE = "/.proxy/api/activity";
-export const ACTIVITY_WS_PATH = "/.proxy/ws/activity";
+// SDK runtime to the developer-portal-mapped origin. The standalone website
+// talks to the same server directly, without the proxy prefix.
+export const getApiBase = (): string =>
+    isEmbedded() ? "/.proxy/api/activity" : "/api/activity";
+
+export const getWsPath = (): string =>
+    isEmbedded() ? "/.proxy/ws/activity" : "/ws/activity";
 
 // Dev portal URL Mapping forwards `/external/yt/*` → `i.ytimg.com` so YouTube
 // thumbnails can render inside the iframe.

--- a/activity/src/discordSdk.ts
+++ b/activity/src/discordSdk.ts
@@ -1,4 +1,4 @@
-import { ACTIVITY_PROXY_BASE } from "./constants";
+import { getApiBase } from "./constants";
 import { DiscordSDK } from "@discord/embedded-app-sdk";
 
 let sdkPromise: Promise<DiscordSDK> | null = null;
@@ -60,7 +60,7 @@ export async function authenticate(): Promise<AuthedSession> {
         scope: ["identify", "guilds.members.read"],
     });
 
-    const tokenResp = await fetch(`${ACTIVITY_PROXY_BASE}/token`, {
+    const tokenResp = await fetch(`${getApiBase()}/token`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ code }),

--- a/activity/src/main.tsx
+++ b/activity/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { isEmbedded } from "./platform";
 import App from "./App";
+import LandingPage from "./web/LandingPage";
 import "./styles.css";
 
 const rootEl = document.getElementById("root");
@@ -8,8 +10,9 @@ if (!rootEl) {
     throw new Error("Missing #root element");
 }
 
+// Same bundle, two targets: inside Discord's iframe the full Activity mounts
+// as before; on the standalone website the web shell mounts instead (login
+// only for now — rooms and the full game arrive in later phases).
 createRoot(rootEl).render(
-    <StrictMode>
-        <App />
-    </StrictMode>,
+    <StrictMode>{isEmbedded() ? <App /> : <LandingPage />}</StrictMode>,
 );

--- a/activity/src/main.tsx
+++ b/activity/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { applyTheme, readInitialTheme } from "./theme";
 import { isEmbedded } from "./platform";
 import App from "./App";
 import LandingPage from "./web/LandingPage";
@@ -9,6 +10,11 @@ const rootEl = document.getElementById("root");
 if (!rootEl) {
     throw new Error("Missing #root element");
 }
+
+// Stamp the theme before anything renders. App re-applies it on toggle, but
+// the web landing page mounts without App — without this it would sit on the
+// default (light) palette until the first game.
+applyTheme(readInitialTheme());
 
 // Same bundle, two targets: inside Discord's iframe the full Activity mounts
 // as before; on the standalone website the web shell mounts instead (login

--- a/activity/src/platform/discordPlatform.ts
+++ b/activity/src/platform/discordPlatform.ts
@@ -1,0 +1,23 @@
+import type { AuthedSession } from "../discordSdk";
+
+/**
+ * Embedded-Activity platform adapter. Mirrors discordSdk.ts's API but loads
+ * that module (and with it @discord/embedded-app-sdk) dynamically, so the
+ * standalone-website target never downloads or evaluates the SDK. The
+ * embedded iframe is the only caller of these functions.
+ */
+
+export async function authenticate(): Promise<AuthedSession> {
+    const sdkModule = await import("../discordSdk");
+    return sdkModule.authenticate();
+}
+
+export async function readSdkLocale(): Promise<string | null> {
+    const sdkModule = await import("../discordSdk");
+    return sdkModule.readSdkLocale();
+}
+
+export async function openExternalUrl(url: string): Promise<void> {
+    const sdkModule = await import("../discordSdk");
+    return sdkModule.openExternalUrl(url);
+}

--- a/activity/src/platform/discordPlatform.ts
+++ b/activity/src/platform/discordPlatform.ts
@@ -1,3 +1,4 @@
+import { isEmbedded } from "./index";
 import type { AuthedSession } from "../discordSdk";
 
 /**
@@ -18,6 +19,13 @@ export async function readSdkLocale(): Promise<string | null> {
 }
 
 export async function openExternalUrl(url: string): Promise<void> {
+    // On the standalone website there's no iframe to escape — a plain new
+    // tab does it (and keeps the SDK chunk unloaded).
+    if (!isEmbedded()) {
+        window.open(url, "_blank", "noopener,noreferrer");
+        return;
+    }
+
     const sdkModule = await import("../discordSdk");
     return sdkModule.openExternalUrl(url);
 }

--- a/activity/src/platform/index.ts
+++ b/activity/src/platform/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Platform detection for the dual-target build: the same bundle runs inside
+ * Discord's embedded-app iframe (the Activity) and as a standalone website.
+ *
+ * Discord opens the Activity iframe with a `frame_id` query param and hosts
+ * it under *.discordsays.com; either signal means embedded. Detection must
+ * not touch the Embedded App SDK — the web target never loads it.
+ */
+export function isEmbedded(): boolean {
+    if (window.location.hostname.endsWith("discordsays.com")) {
+        return true;
+    }
+
+    return new URLSearchParams(window.location.search).has("frame_id");
+}
+
+/** Identity of the logged-in user as the platform layer knows it. */
+export interface PlatformUser {
+    id: string;
+    username: string;
+    avatarUrl?: string | null;
+}

--- a/activity/src/platform/index.ts
+++ b/activity/src/platform/index.ts
@@ -7,7 +7,11 @@
  * not touch the Embedded App SDK — the web target never loads it.
  */
 export function isEmbedded(): boolean {
-    if (window.location.hostname.endsWith("discordsays.com")) {
+    const { hostname } = window.location;
+    if (
+        hostname === "discordsays.com" ||
+        hostname.endsWith(".discordsays.com")
+    ) {
         return true;
     }
 

--- a/activity/src/platform/index.ts
+++ b/activity/src/platform/index.ts
@@ -19,4 +19,6 @@ export interface PlatformUser {
     id: string;
     username: string;
     avatarUrl?: string | null;
+    /** Website guest (no Discord account) — can join rooms but not host. */
+    guest?: boolean;
 }

--- a/activity/src/platform/webPlatform.ts
+++ b/activity/src/platform/webPlatform.ts
@@ -1,0 +1,140 @@
+import type { PlatformUser } from "./index";
+
+/**
+ * Standalone-website auth: a thin client for the /api/web/* routes. The
+ * server runs a standard Discord OAuth2 redirect flow and hands the SPA an
+ * opaque `web_`-prefixed bearer token via a one-time login code in the
+ * redirect URL; the token is then used exactly like the Activity's Discord
+ * access token on every /api/activity/* call.
+ */
+
+const WEB_SESSION_STORAGE_KEY = "kmq:webSession";
+
+export interface WebSession {
+    token: string;
+    user: PlatformUser;
+}
+
+/** Navigates to the server's OAuth entrypoint (full page redirect). */
+export function beginLogin(): void {
+    window.location.href = "/api/web/login";
+}
+
+export function getStoredSession(): WebSession | null {
+    try {
+        const raw = window.localStorage.getItem(WEB_SESSION_STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as WebSession;
+        if (!parsed?.token || !parsed?.user?.id) return null;
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+function storeSession(session: WebSession): void {
+    try {
+        window.localStorage.setItem(
+            WEB_SESSION_STORAGE_KEY,
+            JSON.stringify(session),
+        );
+    } catch {
+        // Storage may be unavailable (private mode); the session still works
+        // for this page's lifetime.
+    }
+}
+
+function clearStoredSession(): void {
+    try {
+        window.localStorage.removeItem(WEB_SESSION_STORAGE_KEY);
+    } catch {
+        // ignore
+    }
+}
+
+/**
+ * Exchanges the one-time `login_code` query param (present right after the
+ * OAuth callback redirect) for a session token, and strips it from the URL
+ * so refreshes/bookmarks don't retry a consumed code.
+ * @returns the new session, or null if no code is present / it was invalid
+ */
+export async function completeLoginFromUrl(): Promise<WebSession | null> {
+    const url = new URL(window.location.href);
+    const loginCode = url.searchParams.get("login_code");
+    if (!loginCode) return null;
+
+    url.searchParams.delete("login_code");
+    window.history.replaceState(null, "", url.toString());
+
+    const resp = await fetch("/api/web/complete-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ login_code: loginCode }),
+    });
+
+    if (!resp.ok) return null;
+
+    const body = (await resp.json()) as WebSession;
+    if (!body?.token || !body?.user?.id) return null;
+
+    const session: WebSession = { token: body.token, user: body.user };
+    storeSession(session);
+    return session;
+}
+
+/**
+ * Validates a stored token against the server (it may have expired or been
+ * revoked since the last visit). Clears storage when the server rejects it.
+ * @param session - the stored session to validate
+ * @returns the refreshed session, or null if it is no longer valid
+ */
+export async function validateSession(
+    session: WebSession,
+): Promise<WebSession | null> {
+    let resp: Response;
+    try {
+        resp = await fetch("/api/web/session", {
+            headers: { Authorization: `Bearer ${session.token}` },
+        });
+    } catch {
+        // Network error: keep the stored session rather than logging the
+        // user out over a blip; the next API call will surface real 401s.
+        return session;
+    }
+
+    if (resp.status === 401 || resp.status === 403) {
+        clearStoredSession();
+        return null;
+    }
+
+    if (!resp.ok) return session;
+
+    const body = (await resp.json()) as { user: PlatformUser };
+    const refreshed: WebSession = { token: session.token, user: body.user };
+    storeSession(refreshed);
+    return refreshed;
+}
+
+/** Invalidates the session server-side and locally. */
+export async function logout(session: WebSession | null): Promise<void> {
+    clearStoredSession();
+    if (!session) return;
+    try {
+        await fetch("/api/web/logout", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${session.token}` },
+        });
+    } catch {
+        // Local logout already happened; server row expires via TTL.
+    }
+}
+
+/** Web equivalent of the SDK's live-locale lookup. */
+export function readLocale(): string | null {
+    return navigator.language || null;
+}
+
+/** Web equivalent of sdk.commands.openExternalLink. */
+export function openExternalUrl(url: string): void {
+    window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/activity/src/platform/webPlatform.ts
+++ b/activity/src/platform/webPlatform.ts
@@ -15,9 +15,15 @@ export interface WebSession {
     user: PlatformUser;
 }
 
-/** Navigates to the server's OAuth entrypoint (full page redirect). */
-export function beginLogin(): void {
-    window.location.href = "/api/web/login";
+/**
+ * Navigates to the server's OAuth entrypoint (full page redirect).
+ * @param next - in-site /play path to land on after login (e.g. an invite
+ * link); the server validates it against open redirects
+ */
+export function beginLogin(next?: string): void {
+    window.location.href = next
+        ? `/api/web/login?next=${encodeURIComponent(next)}`
+        : "/api/web/login";
 }
 
 export function getStoredSession(): WebSession | null {
@@ -132,6 +138,116 @@ export async function logout(session: WebSession | null): Promise<void> {
 /** Web equivalent of the SDK's live-locale lookup. */
 export function readLocale(): string | null {
     return navigator.language || null;
+}
+
+// ---------------------------------------------------------------------------
+// Multiplayer rooms. A room's invite code doubles as the `instance_id` for
+// every /api/activity/* call, so the game client works unchanged inside one.
+
+export interface WebRoomMemberView {
+    id: string;
+    username: string;
+    avatarUrl: string | null;
+    connected: boolean;
+}
+
+export interface WebRoomView {
+    code: string;
+    ownerID: string;
+    members: WebRoomMemberView[];
+}
+
+export type WebRoomResult =
+    | { room: WebRoomView }
+    | { error: "not_found" | "full" | "unauthorized" | "unavailable" };
+
+async function roomRequest(
+    session: WebSession,
+    path: string,
+    init?: RequestInit,
+): Promise<WebRoomResult> {
+    let resp: Response;
+    try {
+        resp = await fetch(path, {
+            ...init,
+            headers: {
+                Authorization: `Bearer ${session.token}`,
+                ...(init?.body ? { "Content-Type": "application/json" } : {}),
+            },
+        });
+    } catch {
+        return { error: "unavailable" };
+    }
+
+    if (resp.status === 401 || resp.status === 403) {
+        return { error: "unauthorized" };
+    }
+
+    if (resp.status === 404) return { error: "not_found" };
+    if (resp.status === 409) return { error: "full" };
+    if (!resp.ok) return { error: "unavailable" };
+
+    const body = (await resp.json()) as { room?: WebRoomView };
+    if (!body?.room?.code) return { error: "unavailable" };
+    return { room: body.room };
+}
+
+export async function createRoom(session: WebSession): Promise<WebRoomResult> {
+    return roomRequest(session, "/api/web/room", { method: "POST" });
+}
+
+export async function joinRoom(
+    session: WebSession,
+    code: string,
+): Promise<WebRoomResult> {
+    return roomRequest(session, "/api/web/room/join", {
+        method: "POST",
+        body: JSON.stringify({ code }),
+    });
+}
+
+/**
+ * @param session - the web session
+ * @param code - the room to read; null reads whatever room the server still
+ * counts the user a member of (refresh/reconnect)
+ * @returns the room, or why it couldn't be read
+ */
+export async function fetchRoom(
+    session: WebSession,
+    code: string | null,
+): Promise<WebRoomResult> {
+    return roomRequest(
+        session,
+        code
+            ? `/api/web/room?code=${encodeURIComponent(code)}`
+            : "/api/web/room",
+    );
+}
+
+export async function leaveRoom(session: WebSession): Promise<void> {
+    try {
+        await fetch("/api/web/room/leave", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${session.token}` },
+        });
+    } catch {
+        // The server sweeps abandoned seats after the disconnect grace
+        // period regardless.
+    }
+}
+
+/** @returns the invite path for a room code (append to the site origin) */
+export function roomPath(code: string): string {
+    return `/play/r/${encodeURIComponent(code)}`;
+}
+
+/**
+ * @returns the room code embedded in an invite URL path (/play/r/<code>),
+ * if the current location is one
+ */
+export function roomCodeFromLocation(): string | null {
+    const match = /^\/play\/r\/([^/]+)$/.exec(window.location.pathname);
+    return match ? decodeURIComponent(match[1]!) : null;
 }
 
 /** Web equivalent of sdk.commands.openExternalLink. */

--- a/activity/src/platform/webPlatform.ts
+++ b/activity/src/platform/webPlatform.ts
@@ -89,6 +89,37 @@ export async function completeLoginFromUrl(): Promise<WebSession | null> {
 }
 
 /**
+ * Creates a guest session (no Discord account) under a self-chosen display
+ * name. Guests can join rooms via invite code/link but cannot host.
+ * @param username - the display name the guest picked
+ * @returns the new session, or null when guest mode is unavailable
+ */
+export async function guestLogin(username: string): Promise<WebSession | null> {
+    let resp: Response;
+    try {
+        resp = await fetch("/api/web/guest-login", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                username,
+                locale: navigator.language || "",
+            }),
+        });
+    } catch {
+        return null;
+    }
+
+    if (!resp.ok) return null;
+
+    const body = (await resp.json()) as WebSession;
+    if (!body?.token || !body?.user?.id) return null;
+
+    const session: WebSession = { token: body.token, user: body.user };
+    storeSession(session);
+    return session;
+}
+
+/**
  * Validates a stored token against the server (it may have expired or been
  * revoked since the last visit). Clears storage when the server rejects it.
  * @param session - the stored session to validate

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -3705,6 +3705,60 @@ fieldset.options-override:disabled .options-group {
     border: 1px solid var(--border);
 }
 
+/* Floating sound widget (standalone website): autoplay unlock, mute, volume.
+   Bottom-left, mirroring the room bar bottom-right. */
+.kmq-sound-controls {
+    position: fixed;
+    left: 12px;
+    bottom: 12px;
+    z-index: 60;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: var(--bg-elevated);
+    box-shadow: var(--shadow-md);
+}
+
+.kmq-sound-unlock {
+    border: none;
+    border-radius: var(--radius-pill);
+    padding: 6px 14px;
+    background: var(--red-primary);
+    color: #ffffff;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    animation: kmq-sound-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes kmq-sound-pulse {
+    0%,
+    100% {
+        transform: scale(1);
+    }
+
+    50% {
+        transform: scale(1.06);
+    }
+}
+
+.kmq-sound-mute {
+    border: none;
+    background: none;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+}
+
+.kmq-sound-volume {
+    width: 90px;
+    accent-color: var(--red-primary);
+}
+
 /* Respect users who opt out of motion at the OS level: drop the decorative
    loops (confetti, floating notes, etc.) and collapse entrance animations /
    transitions to a near-instant change. */

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -3594,6 +3594,23 @@ fieldset.options-override:disabled .options-group {
     outline-offset: -1px;
 }
 
+.kmq-web-landing-divider {
+    margin: 18px 0 10px;
+    color: var(--text-tertiary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.kmq-web-landing-note {
+    margin: 10px 0 0;
+    max-width: 340px;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    line-height: 1.45;
+}
+
 /* Floating room widget (standalone website): invite link, presence, leave.
    Fixed overlay so it never disturbs the game layout underneath. */
 .kmq-room-bar {

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -3480,6 +3480,93 @@ fieldset.options-override:disabled .options-group {
     cursor: pointer;
 }
 
+/* ============================================================
+   Standalone-website landing (web target only)
+   ============================================================ */
+
+.kmq-web-landing {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 24px;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    text-align: center;
+}
+
+.kmq-web-landing-logo {
+    width: 96px;
+    height: 96px;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+}
+
+.kmq-web-landing-title {
+    margin: 8px 0 0;
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+}
+
+.kmq-web-landing-tagline {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.kmq-web-landing-status {
+    margin: 12px 0 0;
+    font-size: 1rem;
+}
+
+.kmq-web-landing-error {
+    margin: 12px 0 0;
+    color: var(--red-primary);
+    font-size: 0.9rem;
+}
+
+.kmq-web-landing-button {
+    margin-top: 16px;
+    padding: 12px 28px;
+    border: none;
+    border-radius: var(--radius-pill);
+    background: var(--red-primary);
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: var(--shadow-glow);
+    transition: transform 0.1s ease;
+}
+
+.kmq-web-landing-button:hover {
+    transform: translateY(-1px);
+}
+
+.kmq-web-landing-button-secondary {
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    box-shadow: var(--shadow-sm);
+}
+
+.kmq-web-landing-account {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.kmq-web-landing-avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    box-shadow: var(--shadow-sm);
+}
+
 /* Respect users who opt out of motion at the OS level: drop the decorative
    loops (confetti, floating notes, etc.) and collapse entrance animations /
    transitions to a near-instant change. */

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -3759,6 +3759,28 @@ fieldset.options-override:disabled .options-group {
     accent-color: var(--red-primary);
 }
 
+/* Impending-restart warning (both platforms): fixed top-center so it stays
+   visible through lobby, game, and open overlays. */
+.restart-banner {
+    position: fixed;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 400;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: min(92vw, 560px);
+    padding: 8px 16px;
+    border: 1px solid var(--gold);
+    border-radius: var(--radius-pill);
+    background: var(--gold-light);
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    font-weight: 600;
+    box-shadow: var(--shadow-md);
+}
+
 /* Respect users who opt out of motion at the OS level: drop the decorative
    loops (confetti, floating notes, etc.) and collapse entrance animations /
    transitions to a near-instant change. */

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -3567,6 +3567,144 @@ fieldset.options-override:disabled .options-group {
     box-shadow: var(--shadow-sm);
 }
 
+.kmq-web-landing-join {
+    display: flex;
+    gap: 8px;
+    margin-top: 4px;
+    align-items: stretch;
+}
+
+.kmq-web-landing-join .kmq-web-landing-button {
+    margin-top: 0;
+}
+
+.kmq-web-landing-input {
+    padding: 10px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    min-width: 0;
+    width: 220px;
+}
+
+.kmq-web-landing-input:focus {
+    outline: 2px solid var(--red-primary);
+    outline-offset: -1px;
+}
+
+/* Floating room widget (standalone website): invite link, presence, leave.
+   Fixed overlay so it never disturbs the game layout underneath. */
+.kmq-room-bar {
+    position: fixed;
+    right: 12px;
+    bottom: 12px;
+    z-index: 60;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+    font-size: 0.85rem;
+}
+
+.kmq-room-bar-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: var(--shadow-md);
+}
+
+.kmq-room-bar-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--green);
+}
+
+.kmq-room-bar-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg-elevated);
+    box-shadow: var(--shadow-md);
+    max-width: 240px;
+}
+
+.kmq-room-bar-members {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.kmq-room-bar-member {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.kmq-room-bar-member[data-connected="false"] {
+    opacity: 0.45;
+}
+
+.kmq-room-bar-avatar {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.kmq-room-bar-avatar-fallback {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--red-primary);
+    color: #ffffff;
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
+.kmq-room-bar-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.kmq-room-bar-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.kmq-room-bar-button {
+    flex: 1;
+    padding: 6px 10px;
+    border: none;
+    border-radius: var(--radius-pill);
+    background: var(--red-primary);
+    color: #ffffff;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.kmq-room-bar-button-danger {
+    background: var(--bg-base);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+}
+
 /* Respect users who opt out of motion at the OS level: drop the decorative
    loops (confetti, floating notes, etc.) and collapse entrance animations /
    transitions to a near-instant change. */

--- a/activity/src/theme.ts
+++ b/activity/src/theme.ts
@@ -1,0 +1,40 @@
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "kmq:theme";
+
+/**
+ * @returns the stored theme choice, falling back to dark (Discord's client
+ * defaults to dark; matching it is the better first impression for most
+ * users)
+ */
+export function readInitialTheme(): Theme {
+    // localStorage can throw in sandboxed contexts (rare inside Discord's
+    // iframe but not impossible). Fall back to the OS preference.
+    try {
+        const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+        if (stored === "dark" || stored === "light") return stored;
+    } catch {
+        // ignore
+    }
+
+    // Discord's client defaults to dark; matching it is the better first
+    // impression for most users.
+    if (
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+    ) {
+        return "dark";
+    }
+
+    return "dark";
+}
+
+/**
+ * Stamp the theme onto <html> so the CSS palette applies. Called once at
+ * bootstrap (before React renders — the landing page has no other theme
+ * owner) and again by App whenever the user toggles.
+ * @param theme - the theme to apply
+ */
+export function applyTheme(theme: Theme): void {
+    document.documentElement.setAttribute("data-theme", theme);
+}

--- a/activity/src/types/activity_event.ts
+++ b/activity/src/types/activity_event.ts
@@ -68,6 +68,15 @@ type ActivityEvent =
           type: "roundTimerChanged";
           guessTimeoutSec: number | null;
           timerStartedAt: number;
+      }
+    | {
+          // Web rooms only: a new audio playback started (round start, clip
+          // replay, answer clip). The URL is an opaque server-relative token;
+          // fetching it always streams from the *live* position, so it can be
+          // re-fetched to resync.
+          type: "roundAudio";
+          audioUrl: string;
+          playbackDurationSec: number;
       };
 
 export default ActivityEvent;

--- a/activity/src/types/activity_event.ts
+++ b/activity/src/types/activity_event.ts
@@ -77,6 +77,12 @@ type ActivityEvent =
           type: "roundAudio";
           audioUrl: string;
           playbackDurationSec: number;
+      }
+    | {
+          // The bot announced (or, with null, retracted) an impending
+          // restart. Broadcast to every subscriber regardless of guild.
+          type: "restartWarning";
+          restartsAtEpochMs: number | null;
       };
 
 export default ActivityEvent;

--- a/activity/src/types/activity_snapshot.ts
+++ b/activity/src/types/activity_snapshot.ts
@@ -16,5 +16,9 @@ export default interface ActivitySnapshot {
         audioUrl: string;
         playbackDurationSec: number;
     };
+    /** Present while a bot restart has been announced and not yet retracted. */
+    restartWarning?: {
+        restartsAtEpochMs: number;
+    };
     options: ActivityOptionsSnapshot;
 }

--- a/activity/src/types/activity_snapshot.ts
+++ b/activity/src/types/activity_snapshot.ts
@@ -8,5 +8,13 @@ export default interface ActivitySnapshot {
     session?: ActivitySessionMeta;
     scoreboard?: ActivityScoreboardSnapshot;
     currentRound?: ActivityRoundMeta;
+    /**
+     * Web rooms only: audio already playing when the snapshot was taken, so
+     * reconnects and late joiners hear the current song.
+     */
+    currentAudio?: {
+        audioUrl: string;
+        playbackDurationSec: number;
+    };
     options: ActivityOptionsSnapshot;
 }

--- a/activity/src/web/LandingPage.tsx
+++ b/activity/src/web/LandingPage.tsx
@@ -5,6 +5,7 @@ import {
     createRoom,
     fetchRoom,
     getStoredSession,
+    guestLogin,
     joinRoom,
     leaveRoom,
     logout,
@@ -46,6 +47,7 @@ function roomErrorText(error: string): string {
 export default function LandingPage(): JSX.Element {
     const [state, setState] = useState<LandingState>({ phase: "loading" });
     const [joinCode, setJoinCode] = useState("");
+    const [guestName, setGuestName] = useState("");
     const [busy, setBusy] = useState(false);
 
     useEffect(() => {
@@ -163,6 +165,43 @@ export default function LandingPage(): JSX.Element {
         }
     };
 
+    const handleGuestLogin = async (): Promise<void> => {
+        setBusy(true);
+        try {
+            const session = await guestLogin(guestName);
+            if (!session) {
+                setState({
+                    phase: "loggedOut",
+                    error: "Guest play is unavailable right now.",
+                });
+                return;
+            }
+
+            // A guest arriving on an invite link goes straight into the room;
+            // otherwise they land on the join form (guests can't host).
+            const inviteCode = roomCodeFromLocation();
+            if (inviteCode) {
+                const result = await joinRoom(session, inviteCode);
+                if ("room" in result) {
+                    enterRoom(session, result.room);
+                    return;
+                }
+
+                window.history.replaceState(null, "", "/play");
+                setState({
+                    phase: "loggedIn",
+                    session,
+                    error: roomErrorText(result.error),
+                });
+                return;
+            }
+
+            setState({ phase: "loggedIn", session, error: null });
+        } finally {
+            setBusy(false);
+        }
+    };
+
     const handleLogout = async (): Promise<void> => {
         const session =
             state.phase === "loggedIn" || state.phase === "inRoom"
@@ -182,6 +221,7 @@ export default function LandingPage(): JSX.Element {
                         accessToken: state.session.token,
                         instanceId: state.room.code,
                         userID: state.session.user.id,
+                        guest: state.session.user.guest === true,
                     }}
                 />
                 <RoomBar
@@ -232,6 +272,38 @@ export default function LandingPage(): JSX.Element {
                     >
                         Log in with Discord
                     </button>
+
+                    <p className="kmq-web-landing-divider">or</p>
+
+                    <form
+                        className="kmq-web-landing-join"
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            void handleGuestLogin();
+                        }}
+                    >
+                        <input
+                            className="kmq-web-landing-input"
+                            value={guestName}
+                            onChange={(e) => setGuestName(e.target.value)}
+                            maxLength={32}
+                            placeholder="Pick a nickname"
+                            aria-label="Guest nickname"
+                        />
+                        <button
+                            type="submit"
+                            className="kmq-web-landing-button kmq-web-landing-button-secondary"
+                            disabled={busy}
+                        >
+                            {roomCodeFromLocation()
+                                ? "Join as guest"
+                                : "Play as guest"}
+                        </button>
+                    </form>
+                    <p className="kmq-web-landing-note">
+                        Guests can join rooms with an invite. Log in with
+                        Discord to host your own and keep your stats.
+                    </p>
                 </>
             )}
 
@@ -245,7 +317,9 @@ export default function LandingPage(): JSX.Element {
                         />
                     )}
                     <p className="kmq-web-landing-status">
-                        Logged in as{" "}
+                        {state.session.user.guest
+                            ? "Playing as guest "
+                            : "Logged in as "}
                         <strong>{state.session.user.username}</strong>
                     </p>
 
@@ -253,14 +327,22 @@ export default function LandingPage(): JSX.Element {
                         <p className="kmq-web-landing-error">{state.error}</p>
                     )}
 
-                    <button
-                        type="button"
-                        className="kmq-web-landing-button"
-                        disabled={busy}
-                        onClick={() => void handleCreate(state.session)}
-                    >
-                        Create a room
-                    </button>
+                    {state.session.user.guest ? (
+                        <p className="kmq-web-landing-note">
+                            You&apos;re playing as a guest — join a room with an
+                            invite code. Log in with Discord to host your own
+                            and keep your stats.
+                        </p>
+                    ) : (
+                        <button
+                            type="button"
+                            className="kmq-web-landing-button"
+                            disabled={busy}
+                            onClick={() => void handleCreate(state.session)}
+                        >
+                            Create a room
+                        </button>
+                    )}
 
                     <form
                         className="kmq-web-landing-join"

--- a/activity/src/web/LandingPage.tsx
+++ b/activity/src/web/LandingPage.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import {
+    beginLogin,
+    completeLoginFromUrl,
+    getStoredSession,
+    logout,
+    validateSession,
+} from "../platform/webPlatform";
+import kmqLogoUrl from "../assets/kmq_logo.png";
+import type { WebSession } from "../platform/webPlatform";
+
+type LandingState =
+    | { phase: "loading" }
+    | { phase: "loggedOut"; error: string | null }
+    | { phase: "loggedIn"; session: WebSession };
+
+/**
+ * Standalone-website entry view (Phase 1: login only). Resolves the session
+ * from the OAuth callback's one-time login code or from storage, and shows
+ * a login/logout surface. Room creation/joining mounts here in a later
+ * phase.
+ */
+export default function LandingPage(): JSX.Element {
+    const [state, setState] = useState<LandingState>({ phase: "loading" });
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const fromUrl = await completeLoginFromUrl();
+                if (cancelled) return;
+                if (fromUrl) {
+                    setState({ phase: "loggedIn", session: fromUrl });
+                    return;
+                }
+
+                const stored = getStoredSession();
+                if (!stored) {
+                    setState({ phase: "loggedOut", error: null });
+                    return;
+                }
+
+                const validated = await validateSession(stored);
+                if (cancelled) return;
+                setState(
+                    validated
+                        ? { phase: "loggedIn", session: validated }
+                        : { phase: "loggedOut", error: null },
+                );
+            } catch (e) {
+                console.warn("Web login bootstrap failed", e);
+                if (!cancelled) {
+                    setState({
+                        phase: "loggedOut",
+                        error: "Login failed. Please try again.",
+                    });
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const handleLogout = async (): Promise<void> => {
+        const session =
+            state.phase === "loggedIn" ? state.session : getStoredSession();
+
+        setState({ phase: "loggedOut", error: null });
+        await logout(session);
+    };
+
+    return (
+        <div className="kmq-web-landing">
+            <img className="kmq-web-landing-logo" src={kmqLogoUrl} alt="KMQ" />
+            <h1 className="kmq-web-landing-title">KMQ</h1>
+            <p className="kmq-web-landing-tagline">
+                The K-pop music guessing game
+            </p>
+
+            {state.phase === "loading" && (
+                <p className="kmq-web-landing-status">Loading...</p>
+            )}
+
+            {state.phase === "loggedOut" && (
+                <>
+                    {state.error && (
+                        <p className="kmq-web-landing-error">{state.error}</p>
+                    )}
+                    <button
+                        type="button"
+                        className="kmq-web-landing-button"
+                        onClick={beginLogin}
+                    >
+                        Log in with Discord
+                    </button>
+                </>
+            )}
+
+            {state.phase === "loggedIn" && (
+                <div className="kmq-web-landing-account">
+                    {state.session.user.avatarUrl && (
+                        <img
+                            className="kmq-web-landing-avatar"
+                            src={state.session.user.avatarUrl}
+                            alt=""
+                        />
+                    )}
+                    <p className="kmq-web-landing-status">
+                        Logged in as{" "}
+                        <strong>{state.session.user.username}</strong>
+                    </p>
+                    <p className="kmq-web-landing-tagline">
+                        Game rooms are coming soon.
+                    </p>
+                    <button
+                        type="button"
+                        className="kmq-web-landing-button kmq-web-landing-button-secondary"
+                        onClick={() => void handleLogout()}
+                    >
+                        Log out
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/activity/src/web/LandingPage.tsx
+++ b/activity/src/web/LandingPage.tsx
@@ -2,53 +2,100 @@ import { useEffect, useState } from "react";
 import {
     beginLogin,
     completeLoginFromUrl,
+    createRoom,
+    fetchRoom,
     getStoredSession,
+    joinRoom,
+    leaveRoom,
     logout,
+    roomCodeFromLocation,
+    roomPath,
     validateSession,
 } from "../platform/webPlatform";
+import App from "../App";
+import RoomBar from "./RoomBar";
 import kmqLogoUrl from "../assets/kmq_logo.png";
-import type { WebSession } from "../platform/webPlatform";
+import type { WebRoomView, WebSession } from "../platform/webPlatform";
 
 type LandingState =
     | { phase: "loading" }
     | { phase: "loggedOut"; error: string | null }
-    | { phase: "loggedIn"; session: WebSession };
+    | { phase: "loggedIn"; session: WebSession; error: string | null }
+    | { phase: "inRoom"; session: WebSession; room: WebRoomView };
+
+function roomErrorText(error: string): string {
+    switch (error) {
+        case "not_found":
+            return "That room doesn't exist (or everyone left).";
+        case "full":
+            return "That room is full.";
+        case "unauthorized":
+            return "Your login expired. Please log in again.";
+        default:
+            return "Something went wrong. Please try again.";
+    }
+}
 
 /**
- * Standalone-website entry view (Phase 1: login only). Resolves the session
- * from the OAuth callback's one-time login code or from storage, and shows
- * a login/logout surface. Room creation/joining mounts here in a later
- * phase.
+ * Standalone-website shell. Resolves the session (OAuth login code, then
+ * storage), then the room (invite URL, then server-side membership), and
+ * mounts the full game <App> once inside one. The room's invite code is the
+ * game's instance_id, so everything downstream of App is shared with the
+ * embedded Activity untouched.
  */
 export default function LandingPage(): JSX.Element {
     const [state, setState] = useState<LandingState>({ phase: "loading" });
+    const [joinCode, setJoinCode] = useState("");
+    const [busy, setBusy] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
         (async () => {
             try {
-                const fromUrl = await completeLoginFromUrl();
-                if (cancelled) return;
-                if (fromUrl) {
-                    setState({ phase: "loggedIn", session: fromUrl });
-                    return;
-                }
+                const session =
+                    (await completeLoginFromUrl()) ??
+                    (getStoredSession()
+                        ? await validateSession(getStoredSession()!)
+                        : null);
 
-                const stored = getStoredSession();
-                if (!stored) {
+                if (cancelled) return;
+                if (!session) {
                     setState({ phase: "loggedOut", error: null });
                     return;
                 }
 
-                const validated = await validateSession(stored);
+                // An invite link takes precedence; otherwise rejoin whatever
+                // room the server still counts us in (refresh/reconnect).
+                const inviteCode = roomCodeFromLocation();
+                const result = inviteCode
+                    ? await joinRoom(session, inviteCode)
+                    : await fetchRoom(session, null);
+
                 if (cancelled) return;
-                setState(
-                    validated
-                        ? { phase: "loggedIn", session: validated }
-                        : { phase: "loggedOut", error: null },
-                );
+                if ("room" in result) {
+                    window.history.replaceState(
+                        null,
+                        "",
+                        roomPath(result.room.code),
+                    );
+
+                    setState({ phase: "inRoom", session, room: result.room });
+                    return;
+                }
+
+                if (inviteCode) {
+                    window.history.replaceState(null, "", "/play");
+                }
+
+                setState({
+                    phase: "loggedIn",
+                    session,
+                    // Only surface an error when an invite link failed; not
+                    // being in any room is the normal logged-in state.
+                    error: inviteCode ? roomErrorText(result.error) : null,
+                });
             } catch (e) {
-                console.warn("Web login bootstrap failed", e);
+                console.warn("Web bootstrap failed", e);
                 if (!cancelled) {
                     setState({
                         phase: "loggedOut",
@@ -63,13 +110,97 @@ export default function LandingPage(): JSX.Element {
         };
     }, []);
 
+    const enterRoom = (session: WebSession, room: WebRoomView): void => {
+        window.history.pushState(null, "", roomPath(room.code));
+        setState({ phase: "inRoom", session, room });
+    };
+
+    const exitRoom = (session: WebSession, error: string | null): void => {
+        window.history.pushState(null, "", "/play");
+        setState({ phase: "loggedIn", session, error });
+    };
+
+    const handleCreate = async (session: WebSession): Promise<void> => {
+        setBusy(true);
+        try {
+            const result = await createRoom(session);
+            if ("room" in result) {
+                enterRoom(session, result.room);
+            } else {
+                setState({
+                    phase: "loggedIn",
+                    session,
+                    error: roomErrorText(result.error),
+                });
+            }
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleJoin = async (session: WebSession): Promise<void> => {
+        // Accept a pasted invite URL or a bare code.
+        const raw = joinCode.trim();
+        const fromUrl = /\/play\/r\/([^/\s?#]+)/.exec(raw);
+        const code = fromUrl ? decodeURIComponent(fromUrl[1]!) : raw;
+        if (!code) return;
+
+        setBusy(true);
+        try {
+            const result = await joinRoom(session, code);
+            if ("room" in result) {
+                setJoinCode("");
+                enterRoom(session, result.room);
+            } else {
+                setState({
+                    phase: "loggedIn",
+                    session,
+                    error: roomErrorText(result.error),
+                });
+            }
+        } finally {
+            setBusy(false);
+        }
+    };
+
     const handleLogout = async (): Promise<void> => {
         const session =
-            state.phase === "loggedIn" ? state.session : getStoredSession();
+            state.phase === "loggedIn" || state.phase === "inRoom"
+                ? state.session
+                : getStoredSession();
 
         setState({ phase: "loggedOut", error: null });
         await logout(session);
     };
+
+    if (state.phase === "inRoom") {
+        return (
+            <>
+                <App
+                    key={state.room.code}
+                    webAuth={{
+                        accessToken: state.session.token,
+                        instanceId: state.room.code,
+                        userID: state.session.user.id,
+                    }}
+                />
+                <RoomBar
+                    session={state.session}
+                    room={state.room}
+                    onLeave={() => {
+                        void leaveRoom(state.session);
+                        exitRoom(state.session, null);
+                    }}
+                    onEvicted={() =>
+                        exitRoom(
+                            state.session,
+                            "You were removed from the room.",
+                        )
+                    }
+                />
+            </>
+        );
+    }
 
     return (
         <div className="kmq-web-landing">
@@ -91,7 +222,13 @@ export default function LandingPage(): JSX.Element {
                     <button
                         type="button"
                         className="kmq-web-landing-button"
-                        onClick={beginLogin}
+                        onClick={() =>
+                            beginLogin(
+                                roomCodeFromLocation()
+                                    ? window.location.pathname
+                                    : undefined,
+                            )
+                        }
                     >
                         Log in with Discord
                     </button>
@@ -111,9 +248,43 @@ export default function LandingPage(): JSX.Element {
                         Logged in as{" "}
                         <strong>{state.session.user.username}</strong>
                     </p>
-                    <p className="kmq-web-landing-tagline">
-                        Game rooms are coming soon.
-                    </p>
+
+                    {state.error && (
+                        <p className="kmq-web-landing-error">{state.error}</p>
+                    )}
+
+                    <button
+                        type="button"
+                        className="kmq-web-landing-button"
+                        disabled={busy}
+                        onClick={() => void handleCreate(state.session)}
+                    >
+                        Create a room
+                    </button>
+
+                    <form
+                        className="kmq-web-landing-join"
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            void handleJoin(state.session);
+                        }}
+                    >
+                        <input
+                            className="kmq-web-landing-input"
+                            value={joinCode}
+                            onChange={(e) => setJoinCode(e.target.value)}
+                            placeholder="Invite code or link"
+                            aria-label="Invite code or link"
+                        />
+                        <button
+                            type="submit"
+                            className="kmq-web-landing-button kmq-web-landing-button-secondary"
+                            disabled={busy || !joinCode.trim()}
+                        >
+                            Join
+                        </button>
+                    </form>
+
                     <button
                         type="button"
                         className="kmq-web-landing-button kmq-web-landing-button-secondary"

--- a/activity/src/web/RoomBar.tsx
+++ b/activity/src/web/RoomBar.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from "react";
+import { fetchRoom, roomPath } from "../platform/webPlatform";
+import type { WebRoomView } from "../platform/webPlatform";
+import type { WebSession } from "../platform/webPlatform";
+
+const ROOM_POLL_INTERVAL_MS = 5_000;
+const COPY_FLASH_MS = 1_500;
+
+/**
+ * Floating room widget shown over the game on the standalone website: the
+ * invite link, live member presence, and a leave button. Presence is
+ * server-derived (websocket open/close), polled here — game events and
+ * options already flow over the game websocket, this only decorates them
+ * with who's in the room.
+ */
+export default function RoomBar({
+    session,
+    room: initialRoom,
+    onLeave,
+    onEvicted,
+}: {
+    session: WebSession;
+    room: WebRoomView;
+    onLeave: () => void;
+    /** Called when the server no longer recognizes us as a member. */
+    onEvicted: () => void;
+}): JSX.Element {
+    const [room, setRoom] = useState<WebRoomView>(initialRoom);
+    const [expanded, setExpanded] = useState(true);
+    const [copied, setCopied] = useState(false);
+    const copyTimerRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const poll = async (): Promise<void> => {
+            const result = await fetchRoom(session, initialRoom.code);
+            if (cancelled) return;
+            if ("room" in result) {
+                setRoom(result.room);
+            } else if (
+                result.error === "not_found" ||
+                result.error === "unauthorized"
+            ) {
+                onEvicted();
+            }
+            // "unavailable" (network blip): keep showing the last state.
+        };
+
+        const id = window.setInterval(() => void poll(), ROOM_POLL_INTERVAL_MS);
+        return () => {
+            cancelled = true;
+            window.clearInterval(id);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [session.token, initialRoom.code]);
+
+    useEffect(
+        () => () => {
+            if (copyTimerRef.current !== null) {
+                window.clearTimeout(copyTimerRef.current);
+            }
+        },
+        [],
+    );
+
+    const copyInvite = async (): Promise<void> => {
+        const invite = `${window.location.origin}${roomPath(room.code)}`;
+        try {
+            await navigator.clipboard.writeText(invite);
+        } catch {
+            // Clipboard API unavailable (http, permissions): select-free
+            // fallback via a transient input.
+            const el = document.createElement("input");
+            el.value = invite;
+            document.body.appendChild(el);
+            el.select();
+            try {
+                document.execCommand("copy");
+            } finally {
+                el.remove();
+            }
+        }
+
+        setCopied(true);
+        if (copyTimerRef.current !== null) {
+            window.clearTimeout(copyTimerRef.current);
+        }
+
+        copyTimerRef.current = window.setTimeout(
+            () => setCopied(false),
+            COPY_FLASH_MS,
+        );
+    };
+
+    const connectedCount = room.members.filter((m) => m.connected).length;
+
+    return (
+        <div className="kmq-room-bar" data-expanded={expanded}>
+            <button
+                type="button"
+                className="kmq-room-bar-toggle"
+                onClick={() => setExpanded((v) => !v)}
+                aria-expanded={expanded}
+            >
+                <span className="kmq-room-bar-dot" aria-hidden />
+                Room · {connectedCount}/{room.members.length}
+            </button>
+
+            {expanded && (
+                <div className="kmq-room-bar-body">
+                    <div className="kmq-room-bar-members">
+                        {room.members.map((member) => (
+                            <span
+                                key={member.id}
+                                className="kmq-room-bar-member"
+                                data-connected={member.connected}
+                                title={
+                                    member.connected
+                                        ? member.username
+                                        : `${member.username} (away)`
+                                }
+                            >
+                                {member.avatarUrl ? (
+                                    <img
+                                        className="kmq-room-bar-avatar"
+                                        src={member.avatarUrl}
+                                        alt=""
+                                    />
+                                ) : (
+                                    <span className="kmq-room-bar-avatar kmq-room-bar-avatar-fallback">
+                                        {member.username
+                                            .slice(0, 1)
+                                            .toUpperCase()}
+                                    </span>
+                                )}
+                                <span className="kmq-room-bar-name">
+                                    {member.username}
+                                    {member.id === room.ownerID ? " ★" : ""}
+                                </span>
+                            </span>
+                        ))}
+                    </div>
+
+                    <div className="kmq-room-bar-actions">
+                        <button
+                            type="button"
+                            className="kmq-room-bar-button"
+                            onClick={() => void copyInvite()}
+                        >
+                            {copied ? "Copied!" : "Copy invite link"}
+                        </button>
+                        <button
+                            type="button"
+                            className="kmq-room-bar-button kmq-room-bar-button-danger"
+                            onClick={onLeave}
+                        >
+                            Leave
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/activity/src/web/SoundControls.tsx
+++ b/activity/src/web/SoundControls.tsx
@@ -1,0 +1,51 @@
+import type { RoundAudio } from "./useRoundAudio";
+
+/**
+ * Floating sound widget for the standalone website (the embedded Activity
+ * plays through Discord's voice channel and never renders this). Two states:
+ * an attention-grabbing "Enable sound" pill while the browser's autoplay
+ * policy is blocking playback — clicking it retries inside the user gesture —
+ * and a mute toggle + volume slider otherwise.
+ */
+export default function SoundControls({
+    audio,
+}: {
+    audio: RoundAudio;
+}): JSX.Element {
+    if (audio.needsUnlock) {
+        return (
+            <div className="kmq-sound-controls">
+                <button
+                    type="button"
+                    className="kmq-sound-unlock"
+                    onClick={audio.unlock}
+                >
+                    🔊 Enable sound
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="kmq-sound-controls">
+            <button
+                type="button"
+                className="kmq-sound-mute"
+                onClick={audio.toggleMuted}
+                aria-label={audio.muted ? "Unmute" : "Mute"}
+                title={audio.muted ? "Unmute" : "Mute"}
+            >
+                {audio.muted || audio.volume === 0 ? "🔇" : "🔊"}
+            </button>
+            <input
+                className="kmq-sound-volume"
+                type="range"
+                min={0}
+                max={100}
+                value={audio.muted ? 0 : Math.round(audio.volume * 100)}
+                onChange={(e) => audio.setVolume(Number(e.target.value) / 100)}
+                aria-label="Volume"
+            />
+        </div>
+    );
+}

--- a/activity/src/web/useRoundAudio.ts
+++ b/activity/src/web/useRoundAudio.ts
@@ -165,6 +165,20 @@ export default function useRoundAudio(enabled: boolean): RoundAudio {
         }
     }, []);
 
+    // While blocked, any interaction with the page (clicking anything,
+    // typing a guess) doubles as the unlock gesture — the pill is only
+    // needed by someone who watches without touching anything.
+    useEffect(() => {
+        if (!needsUnlock) return undefined;
+        const handler = (): void => unlock();
+        window.addEventListener("pointerdown", handler, { once: true });
+        window.addEventListener("keydown", handler, { once: true });
+        return () => {
+            window.removeEventListener("pointerdown", handler);
+            window.removeEventListener("keydown", handler);
+        };
+    }, [needsUnlock, unlock]);
+
     // Unmount: silence and release the element.
     useEffect(
         () => () => {

--- a/activity/src/web/useRoundAudio.ts
+++ b/activity/src/web/useRoundAudio.ts
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const VOLUME_STORAGE_KEY = "kmq_web_volume";
+const DEFAULT_VOLUME = 0.6;
+
+function readStoredVolume(): number {
+    try {
+        const raw = window.localStorage.getItem(VOLUME_STORAGE_KEY);
+        const parsed = raw === null ? NaN : parseFloat(raw);
+        if (Number.isFinite(parsed)) {
+            return Math.min(1, Math.max(0, parsed));
+        }
+    } catch {
+        // ignore
+    }
+
+    return DEFAULT_VOLUME;
+}
+
+export interface RoundAudio {
+    /**
+     * True when the browser blocked autoplay: nothing will sound until
+     * unlock() is called from inside a user gesture.
+     */
+    needsUnlock: boolean;
+    /** True while a stream is loaded and playing. */
+    playing: boolean;
+    volume: number;
+    setVolume: (volume: number) => void;
+    muted: boolean;
+    toggleMuted: () => void;
+    /** Feed a roundAudio event's (or snapshot's) stream URL. */
+    handleRoundAudio: (audioUrl: string) => void;
+    /** Session over: silence and drop the pending URL. */
+    stop: () => void;
+    /** Call from a click handler; retries the pending stream. */
+    unlock: () => void;
+}
+
+/**
+ * Owns the standalone website's single <audio> element. Each roundAudio
+ * event swaps in a new stream URL; the server seeks every GET to the live
+ * position, so (re)fetching the same URL after a block/unlock or a reload
+ * stays in sync with the room. Playback deliberately runs to the stream's
+ * end rather than stopping at roundEnd — the Discord bot keeps playing
+ * through the reveal too, only stopping when the next round starts (a new
+ * URL arrives) or the session ends (stop()).
+ * @param enabled - false on the embedded Activity, where Discord plays the
+ * audio and this hook must stay inert
+ * @returns the audio element controls
+ */
+export default function useRoundAudio(enabled: boolean): RoundAudio {
+    const [needsUnlock, setNeedsUnlock] = useState(false);
+    const [playing, setPlaying] = useState(false);
+    const [volume, setVolumeState] = useState(readStoredVolume);
+    const [muted, setMuted] = useState(false);
+
+    const elementRef = useRef<HTMLAudioElement | null>(null);
+    // The most recent stream URL, kept while autoplay is blocked so the
+    // unlock gesture can retry it.
+    const pendingUrlRef = useRef<string | null>(null);
+    const volumeRef = useRef(volume);
+    const mutedRef = useRef(muted);
+
+    const getElement = (): HTMLAudioElement => {
+        let el = elementRef.current;
+        if (!el) {
+            el = new Audio();
+            el.preload = "none";
+            el.addEventListener("ended", () => setPlaying(false));
+            el.addEventListener("error", () => setPlaying(false));
+            elementRef.current = el;
+        }
+
+        return el;
+    };
+
+    // Detach the current stream. Clearing src closes the connection, which
+    // kills the server-side ffmpeg instead of encoding to a dead socket.
+    const detach = (): void => {
+        const el = elementRef.current;
+        if (!el) return;
+        el.removeAttribute("src");
+        el.load();
+        setPlaying(false);
+    };
+
+    const startPlayback = useCallback((audioUrl: string): void => {
+        const el = getElement();
+        el.volume = mutedRef.current ? 0 : volumeRef.current;
+        el.src = audioUrl;
+        el.play().then(
+            () => {
+                setNeedsUnlock(false);
+                setPlaying(true);
+            },
+            () => {
+                // Autoplay policy (or a dead stream). Abort the fetch but
+                // keep the URL: the server re-seeks to the live position on
+                // the next GET, so the unlock retry is still in sync.
+                detach();
+                setNeedsUnlock(true);
+            },
+        );
+    }, []);
+
+    const handleRoundAudio = useCallback(
+        (audioUrl: string): void => {
+            if (!enabled) return;
+            // Snapshots re-delivered on (re)connect repeat the current URL;
+            // don't restart a stream that's already playing it.
+            const el = elementRef.current;
+            if (pendingUrlRef.current === audioUrl && el && !el.paused) {
+                return;
+            }
+
+            pendingUrlRef.current = audioUrl;
+            startPlayback(audioUrl);
+        },
+        [enabled, startPlayback],
+    );
+
+    const stop = useCallback((): void => {
+        pendingUrlRef.current = null;
+        detach();
+    }, []);
+
+    const unlock = useCallback((): void => {
+        // Must run synchronously inside the user gesture for the play() call
+        // to be blessed by the autoplay policy.
+        setNeedsUnlock(false);
+        const url = pendingUrlRef.current;
+        if (url) {
+            startPlayback(url);
+        }
+    }, [startPlayback]);
+
+    const setVolume = useCallback((next: number): void => {
+        const clamped = Math.min(1, Math.max(0, next));
+        volumeRef.current = clamped;
+        setVolumeState(clamped);
+        // Dragging the slider un-mutes; muting-then-adjusting is never what
+        // the user meant.
+        mutedRef.current = false;
+        setMuted(false);
+        const el = elementRef.current;
+        if (el) {
+            el.volume = clamped;
+        }
+
+        try {
+            window.localStorage.setItem(VOLUME_STORAGE_KEY, String(clamped));
+        } catch {
+            // ignore
+        }
+    }, []);
+
+    const toggleMuted = useCallback((): void => {
+        const next = !mutedRef.current;
+        mutedRef.current = next;
+        setMuted(next);
+        const el = elementRef.current;
+        if (el) {
+            el.volume = next ? 0 : volumeRef.current;
+        }
+    }, []);
+
+    // Unmount: silence and release the element.
+    useEffect(
+        () => () => {
+            const el = elementRef.current;
+            if (el) {
+                el.removeAttribute("src");
+                el.load();
+            }
+
+            elementRef.current = null;
+        },
+        [],
+    );
+
+    return {
+        needsUnlock,
+        playing,
+        volume,
+        setVolume,
+        muted,
+        toggleMuted,
+        handleRoundAudio,
+        stop,
+        unlock,
+    };
+}

--- a/activity/vite.config.ts
+++ b/activity/vite.config.ts
@@ -17,6 +17,16 @@ export default defineConfig({
     },
     server: {
         port: 5173,
+        // Standalone-website dev: forward API + WS calls to the bot's web
+        // server so `vite dev` works without CORS or a reverse proxy. The
+        // embedded Activity path is unaffected (it goes through /.proxy/).
+        proxy: {
+            "/api": "http://127.0.0.1:5858",
+            "/ws": {
+                target: "http://127.0.0.1:5858",
+                ws: true,
+            },
+        },
     },
     build: {
         outDir: "dist",

--- a/docs/ACTIVITY.md
+++ b/docs/ACTIVITY.md
@@ -6,6 +6,9 @@ input, song history, game controls, and game options in-client. The bot keeps
 owning audio playback and Discord command entry points; the iframe is a
 richer view on the same session.
 
+The same server and SPA also power a standalone website with multiplayer
+rooms and browser audio — see [WEB.md](WEB.md).
+
 This document covers:
 
 1. [Discord developer portal configuration](#1-discord-developer-portal-configuration)

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -1,0 +1,151 @@
+# KMQ Web (standalone website)
+
+KMQ Web is the full game running in a plain browser tab — no Discord client
+required. Players log in with Discord OAuth, group up in shareable
+multiplayer rooms, and the song audio is streamed to the browser. It is the
+same server and the same SPA bundle as the [Discord Activity](ACTIVITY.md);
+the bundle detects at load time whether it's inside Discord's iframe or on
+the open web.
+
+This document covers:
+
+1. [How it fits together](#1-how-it-fits-together)
+2. [Discord developer portal configuration](#2-discord-developer-portal-configuration)
+3. [Environment variables](#3-environment-variables)
+4. [Turning it on](#4-turning-it-on)
+5. [Rooms](#5-rooms)
+6. [Audio streaming](#6-audio-streaming)
+7. [Analytics note](#7-analytics-note)
+8. [Troubleshooting](#8-troubleshooting)
+
+---
+
+## 1. How it fits together
+
+- `/play` (and `/play/*`) serve the SPA. On the open web the landing page
+  (login / create / join room) mounts instead of the Activity shell.
+- `/play/r/<code>` is a room invite link; visiting it while logged in joins
+  the room.
+- `/api/web/*` are the web-only routes: OAuth login
+  (`login`, `callback`, `complete-login`, `session`, `logout`), rooms
+  (`room`, `room/join`, `room/leave`), and the audio stream
+  (`audio/:token`).
+- All gameplay goes through the **same** `/api/activity/*` + `/ws/activity`
+  routes as the embedded Activity — the room's invite code stands in for the
+  Activity `instance_id`, and a `web_`-prefixed bearer token (backed by the
+  `web_sessions` table, 30-day sliding expiry, sha256-hashed at rest) stands
+  in for the Discord OAuth access token.
+- Game sessions for rooms run as headless `WebGameSession`s on the cluster
+  workers: real `GameSession` logic (EXP, stats, presets, every option), no
+  voice channel, round end driven by a timer instead of the voice stream.
+
+## 2. Discord developer portal configuration
+
+One addition on top of the [Activity setup](ACTIVITY.md#1-discord-developer-portal-configuration):
+
+- **OAuth2 → Redirects**: add the exact callback URL
+  `https://<your-web-origin>/api/web/callback`.
+
+Unlike the Activity (which only needs the origin), the web login is a
+standard OAuth redirect flow, so the redirect URI must match **exactly**,
+path included. Only the `identify` scope is requested.
+
+## 3. Environment variables
+
+| Var                     | Where it's read | Value                                                                                                   |
+| ----------------------- | --------------- | ------------------------------------------------------------------------------------------------------- |
+| `WEB_PUBLIC_BASE_URL`   | Server only     | Public HTTPS origin of the website, no trailing `/`. Falls back to `ACTIVITY_PUBLIC_BASE_URL` if unset. |
+| `BOT_CLIENT_ID`         | Server + bundle | Same as the Activity.                                                                                   |
+| `DISCORD_CLIENT_SECRET` | Server only     | Same as the Activity.                                                                                   |
+| `WEB_SERVER_PORT`       | Server only     | Same Fastify server as the Activity/status pages.                                                       |
+
+No new build-time vars: the login URL is built server-side, so a web-only
+deployment doesn't need `BOT_CLIENT_ID` baked into the bundle.
+
+## 4. Turning it on
+
+Web mode ships **off**. Every `/api/web/*` route (and the web branch of
+`/api/activity/start`) returns `503 {"error": "Web mode disabled"}` until the
+`webModeEnabled` feature switch is flipped in
+`data/feature_switch_config.json`:
+
+```json
+{ "webModeEnabled": true }
+```
+
+Feature switches hot-reload (cron on the admiral, `reload_config` IPC on
+workers), so flipping the file enables the site within a minute — no restart
+or deploy. Flip it back to shed the web surface instantly while leaving the
+Activity and the bot untouched.
+
+## 5. Rooms
+
+- A room is identified by an unguessable invite code; internally it maps to a
+  synthetic guild ID `(1 << 62) | ownerUserID`. The ID is deterministic per
+  owner, so a recreated room keeps its game options, presets, and unique-song
+  history.
+- One active room per owner; 8 members max; solo play is a room of one.
+- Presence is derived from the game websocket: a member whose socket stays
+  closed for 60s is dropped, ownership transfers on leave, and an empty room
+  is closed (ending any running game).
+- Rooms live in admiral memory: an admiral restart drops room membership
+  (players just create/join again — options and presets survive via the
+  deterministic ID).
+
+## 6. Audio streaming
+
+- The worker never tells clients what song is playing pre-reveal. The
+  playback spec stops at the admiral, which mints an opaque single-playback
+  token; browsers only ever see `/api/web/audio/<token>`.
+- Each `GET` spawns a dedicated `ffmpeg` that re-runs the round's exact
+  playback args (seek, clip bounds, special-mode filters) and trims the
+  output to the wall-clock live position — so reloads and late joiners are
+  always in sync, including for tempo-warped and reversed special modes.
+- Output is chunked MP3 (`libmp3lame`, 128k): plays natively in every
+  browser including iOS Safari, no MSE required.
+- Tokens die with the playback (each clip replay / next round mints a new
+  one), on session end, and on a TTL sweep. Concurrent transcodes are capped
+  (`WEB_AUDIO_MAX_CONCURRENT_STREAMS`); encode runs much faster than
+  realtime, so processes live seconds, not song-lengths.
+- Browsers block un-gestured audio: the site shows an "Enable sound" pill
+  until the player clicks it once. Volume/mute persist in `localStorage`.
+
+## 7. Analytics note
+
+Web rooms flow through every guild-keyed table with their synthetic guild
+IDs. When querying, `guild_id >= 4611686018427387904` (2^62) means "web
+room"; real Discord snowflakes won't reach that bit until ~2049. E.g.:
+
+```sql
+-- Web-room game sessions
+SELECT COUNT(*) FROM game_sessions WHERE CAST(guild_id AS UNSIGNED) >= 1 << 62;
+```
+
+## 8. Troubleshooting
+
+### Everything returns `503 {"error": "Web mode disabled"}`
+
+The `webModeEnabled` feature switch is off — see [Turning it on](#4-turning-it-on).
+
+### Discord shows "Invalid OAuth2 redirect_uri" at login
+
+The exact URL `<WEB_PUBLIC_BASE_URL>/api/web/callback` isn't registered
+under OAuth2 → Redirects (or `WEB_PUBLIC_BASE_URL` disagrees with the origin
+you're browsing).
+
+### Login redirects back but the page says login failed
+
+The one-time login code expired (60s) or the server restarted between
+callback and exchange (login codes are in-memory). Log in again.
+
+### No sound
+
+Click the "Enable sound" pill (bottom-left) — browsers refuse autoplay
+until a user gesture. If it persists, check the `/api/web/audio/<token>`
+request: `404` = stale token (reconnect re-syncs via the snapshot), `410` =
+playback already over, `503` = stream cap reached.
+
+### Thumbnails are broken
+
+On the web the SPA loads `i.ytimg.com` directly (no Discord proxy). If they
+fail, something upstream (CSP header, adblock) is blocking that host.

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -92,6 +92,25 @@ Activity and the bot untouched.
   (players just create/join again — options and presets survive via the
   deterministic ID).
 
+### Guests
+
+- With the `webGuestsEnabled` feature switch on (in addition to
+  `webModeEnabled`), visitors without a Discord account can pick a nickname
+  and play. It hot-reloads like every other switch, so the free-identity
+  surface can be shed instantly without taking down the site.
+- Guests can **join** rooms (via invite link or code) but never host: room
+  creation returns `403 {"error": "guest_forbidden"}` and the UI doesn't
+  offer it. Hosting stays tied to Discord accounts, which keeps persistent
+  per-owner state (options, presets) and the room-ID scheme meaningful, and
+  caps the abuse value of free identities.
+- A guest is a synthetic numeric user ID with bits 62+61 set (disjoint from
+  real snowflakes and from room guild IDs) on a normal `web_sessions` row —
+  everything downstream (guessing, EXP, scoreboards) treats it like any
+  player. The identity is ephemeral by design: logging out (or the 30-day
+  session TTL) orphans it, and any stats it accrued stay behind under an ID
+  that can never be logged into again. `user_id >= 6917529027641081856`
+  (2^62 + 2^61) identifies guest rows when querying.
+
 ## 6. Audio streaming
 
 - The worker never tells clients what song is playing pre-reveal. The

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Langsamer — zu viele Anfragen.",
         "rejectSessionAlreadyRunning": "Ein Spiel läuft bereits.",
         "rejectUnauthorized": "Sitzung abgelaufen — neu laden.",
+        "restartCountdown": "KMQ startet in {{countdown}} neu — dein Spiel wird kurz pausiert!",
+        "restartImminent": "KMQ startet neu — gleich geht's weiter!",
         "revealAllGuessesSummary": "Alle Tipps ({{count}})",
         "revealWinners": "{{username}}: +{{points}} Pkt., +{{exp}} EXP",
         "roundLabel": "Runde {{num}}",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Slow down — too many requests.",
         "rejectSessionAlreadyRunning": "A game is already running.",
         "rejectUnauthorized": "Session expired — refresh.",
+        "restartCountdown": "KMQ is restarting in {{countdown}} — your game will pause for a moment!",
+        "restartImminent": "KMQ is restarting — back in a moment!",
         "revealAllGuessesSummary": "All guesses ({{count}})",
         "revealWinners": "{{username}}: +{{points}} pts, +{{exp}} EXP",
         "roundLabel": "Round {{num}}",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Más despacio — demasiadas solicitudes.",
         "rejectSessionAlreadyRunning": "Ya hay una partida en curso.",
         "rejectUnauthorized": "Sesión expirada — actualiza.",
+        "restartCountdown": "KMQ se reiniciará en {{countdown}} — ¡tu partida se pausará un momento!",
+        "restartImminent": "KMQ se está reiniciando — ¡volvemos en un momento!",
         "revealAllGuessesSummary": "Todas las respuestas ({{count}})",
         "revealWinners": "{{username}}: +{{points}} pts, +{{exp}} EXP",
         "roundLabel": "Ronda {{num}}",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Doucement — trop de requêtes.",
         "rejectSessionAlreadyRunning": "Une partie est déjà en cours.",
         "rejectUnauthorized": "Session expirée — actualisez.",
+        "restartCountdown": "KMQ redémarre dans {{countdown}} — votre partie sera mise en pause un instant !",
+        "restartImminent": "KMQ redémarre — de retour dans un instant !",
         "revealAllGuessesSummary": "Toutes les réponses ({{count}})",
         "revealWinners": "{{username}} : +{{points}} pts, +{{exp}} EXP",
         "roundLabel": "Manche {{num}}",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "धीरे — बहुत ज़्यादा अनुरोध।",
         "rejectSessionAlreadyRunning": "एक खेल पहले से चल रहा है।",
         "rejectUnauthorized": "सत्र समाप्त — रीफ्रेश करें।",
+        "restartCountdown": "KMQ {{countdown}} में रीस्टार्ट होगा — आपका गेम थोड़ी देर के लिए रुक जाएगा!",
+        "restartImminent": "KMQ रीस्टार्ट हो रहा है — बस एक पल में वापस!",
         "revealAllGuessesSummary": "सारे अनुमान ({{count}})",
         "revealWinners": "{{username}}: +{{points}} अंक, +{{exp}} EXP",
         "roundLabel": "राउंड {{num}}",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Lebih pelan — terlalu banyak permintaan.",
         "rejectSessionAlreadyRunning": "Permainan sudah berjalan.",
         "rejectUnauthorized": "Sesi kedaluwarsa — refresh.",
+        "restartCountdown": "KMQ akan dimulai ulang dalam {{countdown}} — permainanmu akan terjeda sebentar!",
+        "restartImminent": "KMQ sedang dimulai ulang — kembali sebentar lagi!",
         "revealAllGuessesSummary": "Semua tebakan ({{count}})",
         "revealWinners": "{{username}}: +{{points}} poin, +{{exp}} EXP",
         "roundLabel": "Ronde {{num}}",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "ゆっくり — リクエストが多すぎます。",
         "rejectSessionAlreadyRunning": "ゲームは既に実行中です。",
         "rejectUnauthorized": "セッションが期限切れ — 更新してください。",
+        "restartCountdown": "KMQは{{countdown}}後に再起動します — ゲームは少しの間中断されます！",
+        "restartImminent": "KMQは再起動中です — まもなく戻ります！",
         "revealAllGuessesSummary": "全回答 ({{count}})",
         "revealWinners": "{{username}}: +{{points}}pts, +{{exp}} EXP",
         "roundLabel": "ラウンド {{num}}",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "천천히 — 요청이 너무 많습니다.",
         "rejectSessionAlreadyRunning": "이미 게임이 진행 중입니다.",
         "rejectUnauthorized": "세션 만료 — 새로고침하세요.",
+        "restartCountdown": "KMQ가 {{countdown}} 후 재시작됩니다 — 게임이 잠시 중단됩니다!",
+        "restartImminent": "KMQ가 재시작 중입니다 — 곧 돌아올게요!",
         "revealAllGuessesSummary": "모든 정답 ({{count}})",
         "revealWinners": "{{username}}: +{{points}}점, +{{exp}} EXP",
         "roundLabel": "{{num}}라운드",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Rustig — te veel verzoeken.",
         "rejectSessionAlreadyRunning": "Er loopt al een spel.",
         "rejectUnauthorized": "Sessie verlopen — ververs.",
+        "restartCountdown": "KMQ herstart over {{countdown}} — je spel wordt even gepauzeerd!",
+        "restartImminent": "KMQ wordt herstart — zo terug!",
         "revealAllGuessesSummary": "Alle antwoorden ({{count}})",
         "revealWinners": "{{username}}: +{{points}} pnt, +{{exp}} EXP",
         "roundLabel": "Ronde {{num}}",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Mais devagar — muitas solicitações.",
         "rejectSessionAlreadyRunning": "Já existe um jogo em andamento.",
         "rejectUnauthorized": "Sessão expirada — atualize.",
+        "restartCountdown": "O KMQ vai reiniciar em {{countdown}} — seu jogo vai pausar por um momento!",
+        "restartImminent": "O KMQ está reiniciando — voltamos em instantes!",
         "revealAllGuessesSummary": "Todos os palpites ({{count}})",
         "revealWinners": "{{username}}: +{{points}} pts, +{{exp}} EXP",
         "roundLabel": "Rodada {{num}}",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "Помедленнее — слишком много запросов.",
         "rejectSessionAlreadyRunning": "Игра уже идёт.",
         "rejectUnauthorized": "Сессия истекла — обновите страницу.",
+        "restartCountdown": "KMQ перезапустится через {{countdown}} — игра ненадолго приостановится!",
+        "restartImminent": "KMQ перезапускается — скоро вернёмся!",
         "revealAllGuessesSummary": "Все ответы ({{count}})",
         "revealWinners": "{{username}}: +{{points}} очк., +{{exp}} EXP",
         "roundLabel": "Раунд {{num}}",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -243,6 +243,8 @@
         "rejectRateLimit": "慢一点 — 请求过多。",
         "rejectSessionAlreadyRunning": "已有游戏在进行。",
         "rejectUnauthorized": "会话过期 — 请刷新。",
+        "restartCountdown": "KMQ 将在 {{countdown}} 后重启 — 游戏将暂停片刻！",
+        "restartImminent": "KMQ 正在重启 — 马上回来！",
         "revealAllGuessesSummary": "全部答案 ({{count}})",
         "revealWinners": "{{username}}: +{{points}} 分, +{{exp}} EXP",
         "roundLabel": "第 {{num}} 回合",

--- a/src/activity_hub.ts
+++ b/src/activity_hub.ts
@@ -73,6 +73,13 @@ export default class ActivityHub {
     /** Opaque-token registry for web-room audio streams. */
     private audioRegistry: WebAudioRegistry = new WebAudioRegistry();
 
+    /**
+     * Epoch ms of the announced bot restart, or null when none is pending.
+     * Set from the admiral's /announce-restart endpoint — the same signal
+     * that warns Discord text channels — and broadcast to every subscriber.
+     */
+    private restartsAtEpochMs: number | null = null;
+
     constructor(fleet: Fleet) {
         this.fleet = fleet;
     }
@@ -141,6 +148,17 @@ export default class ActivityHub {
             snapshot.currentAudio = {
                 audioUrl: audioUrlForToken(audio.token),
                 playbackDurationSec: audio.playbackDurationSec,
+            };
+        }
+
+        // Late joiners/reconnects learn about a pending restart from the
+        // snapshot; everyone already connected got the broadcast.
+        if (
+            this.restartsAtEpochMs !== null &&
+            this.restartsAtEpochMs > Date.now()
+        ) {
+            snapshot.restartWarning = {
+                restartsAtEpochMs: this.restartsAtEpochMs,
             };
         }
 
@@ -437,6 +455,32 @@ export default class ActivityHub {
      */
     getAudioEntry(token: string): WebAudioEntry | null {
         return this.audioRegistry.get(token, Date.now());
+    }
+
+    /**
+     * Announces (or retracts, with null) an impending bot restart to every
+     * connected subscriber — embedded Activities and web rooms alike, whether
+     * or not a game is running.
+     * @param restartsAtEpochMs - when the restart happens, or null to retract
+     */
+    setRestartNotice(restartsAtEpochMs: number | null): void {
+        this.restartsAtEpochMs = restartsAtEpochMs;
+        const wireData = JSON.stringify({
+            type: "restartWarning",
+            restartsAtEpochMs,
+        });
+
+        for (const guildID of this.guildSubscribers.keys()) {
+            this.fanOut(guildID, wireData);
+        }
+
+        logger.info(
+            `Restart notice ${
+                restartsAtEpochMs === null
+                    ? "cleared"
+                    : `set for ${new Date(restartsAtEpochMs).toISOString()}`
+            }; ${this.getSubscriberCount()} subscribers notified.`,
+        );
     }
 
     /** @returns total number of active subscribers across all guilds */

--- a/src/activity_hub.ts
+++ b/src/activity_hub.ts
@@ -29,6 +29,7 @@ import type ActivitySongInfoArgs from "./interfaces/activity_song_info_args";
 import type ActivitySongInfoResponse from "./interfaces/activity_song_info_response";
 import type ActivityStartGameArgs from "./interfaces/activity_start_game_args";
 import type ActivityUserActionArgs from "./interfaces/activity_user_action_args";
+import type ActivityWebRoomMembershipArgs from "./interfaces/activity_web_room_membership_args";
 import type ActivityWorkerEventMessage from "./interfaces/activity_worker_event_message";
 
 const logger = new IPCLogger("activity_hub");
@@ -212,6 +213,23 @@ export default class ActivityHub {
     ): Promise<ActivityGuessResponse> {
         const target = await this.resolveCluster(args.guildID);
         return this.sendRequest<ActivityGuessResponse>(target, "endGame", args);
+    }
+
+    /**
+     * Pushes a web room's membership snapshot to the worker owning its
+     * synthetic guild ID (empty members = room closed, ends any game).
+     * @param args - guildID/members
+     * @returns the worker's ack
+     */
+    async webRoomMembership(
+        args: ActivityWebRoomMembershipArgs,
+    ): Promise<ActivityGuessResponse> {
+        const target = await this.resolveCluster(args.guildID);
+        return this.sendRequest<ActivityGuessResponse>(
+            target,
+            "webRoomMembership",
+            args,
+        );
     }
 
     /**
@@ -444,6 +462,13 @@ export default class ActivityHub {
     }
 
     private handleWorkerEvent(msg: ActivityWorkerEventMessage): void {
+        // roundAudio carries the raw playback spec, which names the song —
+        // it must never reach clients pre-reveal. Phase 4 turns it into an
+        // opaque audio-stream token; until then it stops here.
+        if (msg.event.type === "roundAudio") {
+            return;
+        }
+
         const subscribers = this.guildSubscribers.get(msg.guildID);
         if (!subscribers || subscribers.size === 0) {
             return;
@@ -489,7 +514,8 @@ export default class ActivityHub {
             | ActivityBookmarkArgs
             | ActivitySetOptionArgs
             | ActivityAutocompleteArtistsArgs
-            | ActivityPresetArgs,
+            | ActivityPresetArgs
+            | ActivityWebRoomMembershipArgs,
     ): Promise<T> {
         const cid = uuid.v4();
         return new Promise<T>((resolve, reject) => {

--- a/src/activity_hub.ts
+++ b/src/activity_hub.ts
@@ -4,9 +4,13 @@ import {
     ACTIVITY_IPC_REPLY,
     ACTIVITY_IPC_REQUEST,
     ACTIVITY_REQUEST_TIMEOUT_MS,
+    WEB_AUDIO_SWEEP_INTERVAL_MS,
+    WEB_AUDIO_URL_PREFIX,
 } from "./constants";
 import { IPCLogger } from "./logger";
+import { WebAudioRegistry } from "./web_audio_registry";
 import type { Fleet } from "eris-fleet";
+import type { WebAudioEntry } from "./web_audio_registry";
 import type ActivityAutocompleteArtistsArgs from "./interfaces/activity_autocomplete_artists_args";
 import type ActivityAutocompleteArtistsResponse from "./interfaces/activity_autocomplete_artists_response";
 import type ActivityBookmarkArgs from "./interfaces/activity_bookmark_args";
@@ -33,6 +37,9 @@ import type ActivityWebRoomMembershipArgs from "./interfaces/activity_web_room_m
 import type ActivityWorkerEventMessage from "./interfaces/activity_worker_event_message";
 
 const logger = new IPCLogger("activity_hub");
+
+const audioUrlForToken = (token: string): string =>
+    `${WEB_AUDIO_URL_PREFIX}/${token}`;
 
 export interface ActivitySubscriber {
     id: string;
@@ -63,6 +70,9 @@ export default class ActivityHub {
 
     private wired: boolean = false;
 
+    /** Opaque-token registry for web-room audio streams. */
+    private audioRegistry: WebAudioRegistry = new WebAudioRegistry();
+
     constructor(fleet: Fleet) {
         this.fleet = fleet;
     }
@@ -80,6 +90,10 @@ export default class ActivityHub {
         this.fleet.on(ACTIVITY_IPC_REPLY, (msg: ActivityReplyMessage) => {
             this.handleWorkerReply(msg);
         });
+
+        setInterval(() => {
+            this.audioRegistry.sweep(Date.now());
+        }, WEB_AUDIO_SWEEP_INTERVAL_MS).unref();
 
         logger.info(
             `ActivityHub started. shardCount=${this.shardCount}, clusters=${this.clusterRanges.length}`,
@@ -113,24 +127,24 @@ export default class ActivityHub {
      * @returns the snapshot; `hasSession` is false if no GameSession is active
      */
     async requestSnapshot(guildID: string): Promise<ActivitySnapshot> {
-        const clusterID = this.clusterIdForGuild(guildID);
-        if (clusterID === null) {
-            await this.refreshClusterMap();
-            const retry = this.clusterIdForGuild(guildID);
-            if (retry === null) {
-                throw new Error(
-                    `No cluster found for guild ${guildID} (cluster map unavailable)`,
-                );
-            }
+        const clusterID = await this.resolveCluster(guildID);
+        const snapshot = await this.sendRequest<ActivitySnapshot>(
+            clusterID,
+            "snapshot",
+            { guildID },
+        );
 
-            return this.sendRequest<ActivitySnapshot>(retry, "snapshot", {
-                guildID,
-            });
+        // Web rooms: point late joiners/reconnects at the audio already
+        // playing (the registry only ever has entries for web guilds).
+        const audio = this.audioRegistry.currentForGuild(guildID, Date.now());
+        if (audio && snapshot.hasSession) {
+            snapshot.currentAudio = {
+                audioUrl: audioUrlForToken(audio.token),
+                playbackDurationSec: audio.playbackDurationSec,
+            };
         }
 
-        return this.sendRequest<ActivitySnapshot>(clusterID, "snapshot", {
-            guildID,
-        });
+        return snapshot;
     }
 
     /**
@@ -416,6 +430,15 @@ export default class ActivityHub {
         }
     }
 
+    /**
+     * Redeems an audio-stream token minted from a roundAudio event.
+     * @param token - the opaque token from the audio URL
+     * @returns the playback entry, or null if unknown/expired
+     */
+    getAudioEntry(token: string): WebAudioEntry | null {
+        return this.audioRegistry.get(token, Date.now());
+    }
+
     /** @returns total number of active subscribers across all guilds */
     getSubscriberCount(): number {
         let total = 0;
@@ -463,18 +486,44 @@ export default class ActivityHub {
 
     private handleWorkerEvent(msg: ActivityWorkerEventMessage): void {
         // roundAudio carries the raw playback spec, which names the song —
-        // it must never reach clients pre-reveal. Phase 4 turns it into an
-        // opaque audio-stream token; until then it stops here.
+        // it must never reach clients pre-reveal. Mint an opaque streaming
+        // token and fan out only the URL.
         if (msg.event.type === "roundAudio") {
+            const entry = this.audioRegistry.mint(
+                msg.guildID,
+                {
+                    songLocation: msg.event.songLocation,
+                    inputArgs: msg.event.inputArgs,
+                    encoderArgs: msg.event.encoderArgs,
+                    playbackDurationSec: msg.event.playbackDurationSec,
+                },
+                Date.now(),
+            );
+
+            this.fanOut(
+                msg.guildID,
+                JSON.stringify({
+                    type: "roundAudio",
+                    audioUrl: audioUrlForToken(entry.token),
+                    playbackDurationSec: entry.playbackDurationSec,
+                }),
+            );
             return;
         }
 
-        const subscribers = this.guildSubscribers.get(msg.guildID);
+        if (msg.event.type === "sessionEnd") {
+            this.audioRegistry.clearGuild(msg.guildID);
+        }
+
+        this.fanOut(msg.guildID, JSON.stringify(msg.event));
+    }
+
+    private fanOut(guildID: string, wireData: string): void {
+        const subscribers = this.guildSubscribers.get(guildID);
         if (!subscribers || subscribers.size === 0) {
             return;
         }
 
-        const wireData = JSON.stringify(msg.event);
         for (const sub of subscribers) {
             try {
                 sub.send(wireData);

--- a/src/commands/game_commands/hint.ts
+++ b/src/commands/game_commands/hint.ts
@@ -142,7 +142,7 @@ export default class HintCommand implements BaseCommand {
     }
 
     static isHintMajority(
-        messageContext: MessageContext,
+        _messageContext: MessageContext,
         gameSession: GameSession,
     ): boolean {
         if (!gameSession.round) {
@@ -162,7 +162,7 @@ export default class HintCommand implements BaseCommand {
 
         return (
             gameSession.round.getHintRequests() >=
-            getMajorityCount(messageContext.guildID)
+            gameSession.getVoteMajorityCount()
         );
     }
 

--- a/src/commands/game_commands/skip.ts
+++ b/src/commands/game_commands/skip.ts
@@ -84,7 +84,10 @@ export default class SkipCommand implements BaseCommand {
             return;
         }
 
+        // Web sessions have no voice channel; the activity bridge has
+        // already verified room membership before calling in.
         if (
+            !session.isWebSession() &&
             !areUserAndBotInSameVoiceChannel(
                 messageContext.author.id,
                 messageContext.guildID,
@@ -244,11 +247,11 @@ export default class SkipCommand implements BaseCommand {
 
     /**
      * Whether there are enough votes to skip the song
-     * @param guildID - The guild's ID
+     * @param _guildID - Unused (kept for call-site compatibility)
      * @param session - The current session
      * @returns whether the song has enough votes to be skipped
      */
-    static isSkipMajority(guildID: string, session: Session): boolean {
+    static isSkipMajority(_guildID: string, session: Session): boolean {
         if (!session.round) {
             return false;
         }
@@ -267,7 +270,7 @@ export default class SkipCommand implements BaseCommand {
             }
         }
 
-        return session.round.getSkipCount() >= getMajorityCount(guildID);
+        return session.round.getSkipCount() >= session.getVoteMajorityCount();
     }
 
     /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -405,6 +405,19 @@ export const WEB_LOGIN_CODE_TTL_MS = 60_000;
 export const WEB_OAUTH_STATE_TTL_MS = 5 * 60 * 1000;
 export const WEB_OAUTH_STATE_COOKIE = "kmq_oauth_state";
 
+// Standalone-website multiplayer rooms. A room's synthetic guild ID sets bit
+// 62, which real Discord snowflakes won't reach until ~2049, so rooms flow
+// through every guild-keyed code path (game options, sessions, IPC shard
+// routing) without colliding with real guilds. Derived from the creator's
+// user ID so a recreated room keeps its game options and presets.
+export const WEB_ROOM_ID_FLAG = 1n << 62n;
+export const WEB_ROOM_MAX_MEMBERS = 8;
+// A member with no open websocket is dropped from the room after this grace
+// period (survives refreshes and brief network blips); a room with no members
+// left is closed.
+export const WEB_ROOM_DISCONNECT_GRACE_MS = 60_000;
+export const WEB_ROOM_SWEEP_INTERVAL_MS = 30_000;
+
 // Fixed set of emotes a player can fling during an Activity round. Server-side
 // allow-list so the broadcast can't be used to inject arbitrary content.
 export const ACTIVITY_EMOTES = ["🔥", "😂", "👏", "😱", "❤️", "🎉"] as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -390,6 +390,21 @@ export const ACTIVITY_RATE_LIMIT_READ = 60;
 export const ACTIVITY_RATE_LIMIT_ACTION = 60;
 export const ACTIVITY_RATE_LIMIT_GUESS = 120;
 
+// Standalone-website ("web mode") auth. Web session tokens are opaque bearer
+// strings prefixed so resolveAccessToken can route them to the local
+// web_sessions store instead of Discord's users/@me.
+export const WEB_SESSION_TOKEN_PREFIX = "web_";
+export const WEB_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+// Sliding-expiry writes are throttled: only touch the row when the last use
+// is older than this, so hot sessions don't write on every request.
+export const WEB_SESSION_TOUCH_INTERVAL_MS = 60 * 60 * 1000;
+// One-time codes bridging the OAuth callback redirect to the SPA (keeps the
+// real session token out of URLs, logs, and browser history).
+export const WEB_LOGIN_CODE_TTL_MS = 60_000;
+// OAuth `state` nonces pending callback (mirrored in a short-lived cookie).
+export const WEB_OAUTH_STATE_TTL_MS = 5 * 60 * 1000;
+export const WEB_OAUTH_STATE_COOKIE = "kmq_oauth_state";
+
 // Fixed set of emotes a player can fling during an Activity round. Server-side
 // allow-list so the broadcast can't be used to inject arbitrary content.
 export const ACTIVITY_EMOTES = ["🔥", "😂", "👏", "😱", "❤️", "🎉"] as const;
@@ -400,7 +415,18 @@ export const ACTIVITY_EMOTE_COOLDOWN_MS = 600;
 // Discord OAuth + activity REST endpoints used by the admiral.
 const DISCORD_API_BASE = "https://discord.com/api";
 export const DISCORD_OAUTH_TOKEN_URL = `${DISCORD_API_BASE}/oauth2/token`;
+export const DISCORD_OAUTH_AUTHORIZE_URL = `${DISCORD_API_BASE}/oauth2/authorize`;
 export const DISCORD_USERS_ME_URL = `${DISCORD_API_BASE}/users/@me`;
+export const discordAvatarUrl = (
+    userID: string,
+    avatarHash: string | null | undefined,
+): string | null =>
+    avatarHash
+        ? `https://cdn.discordapp.com/avatars/${encodeURIComponent(
+              userID,
+          )}/${encodeURIComponent(avatarHash)}.png`
+        : null;
+
 export const DISCORD_ACTIVITY_INSTANCE_URL = (
     appId: string,
     instanceId: string,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -405,6 +405,15 @@ export const WEB_LOGIN_CODE_TTL_MS = 60_000;
 export const WEB_OAUTH_STATE_TTL_MS = 5 * 60 * 1000;
 export const WEB_OAUTH_STATE_COOKIE = "kmq_oauth_state";
 
+// Guests (no Discord account) get synthetic numeric user IDs with bits 62+61
+// set plus 60 random bits: disjoint from real snowflakes (below 2^61 until
+// ~2032) and from room guild IDs (bit 62 | owner snowflake, so bit 61 stays
+// clear for decades). Guests can join rooms but never host, so a guest ID is
+// never fed to roomIDForOwner (which would collide, as bit 62 is already
+// set).
+export const WEB_GUEST_ID_FLAG = (1n << 62n) | (1n << 61n);
+export const WEB_GUEST_USERNAME_MAX_LENGTH = 32;
+
 // Standalone-website multiplayer rooms. A room's synthetic guild ID sets bit
 // 62, which real Discord snowflakes won't reach until ~2049, so rooms flow
 // through every guild-keyed code path (game options, sessions, IPC shard

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -418,6 +418,19 @@ export const WEB_ROOM_MAX_MEMBERS = 8;
 export const WEB_ROOM_DISCONNECT_GRACE_MS = 60_000;
 export const WEB_ROOM_SWEEP_INTERVAL_MS = 30_000;
 
+// Browser audio streaming for web rooms. A minted token stays redeemable for
+// the playback's remaining duration plus this buffer (reconnects/reloads can
+// re-hit the same URL; the server recomputes the live seek per request).
+export const WEB_AUDIO_TOKEN_TTL_BUFFER_MS = 5 * 60 * 1000;
+export const WEB_AUDIO_SWEEP_INTERVAL_MS = 60_000;
+// Each listener gets their own ffmpeg; cap the concurrent transcodes so a
+// burst of tabs can't exhaust the host (~1 process per active listener).
+export const WEB_AUDIO_MAX_CONCURRENT_STREAMS = 64;
+// Route prefix shared by the hub (minting URLs) and the web server (serving
+// them). Server-relative on purpose: only web-room subscribers receive it,
+// and their page is same-origin with the API.
+export const WEB_AUDIO_URL_PREFIX = "/api/web/audio";
+
 // Fixed set of emotes a player can fling during an Activity round. Server-side
 // allow-list so the broadcast can't be used to inject arbitrary content.
 export const ACTIVITY_EMOTES = ["🔥", "😂", "👏", "😱", "❤️", "🎉"] as const;

--- a/src/enums/activity_request_op.ts
+++ b/src/enums/activity_request_op.ts
@@ -13,6 +13,7 @@ type ActivityRequestOp =
     | "preset"
     | "profile"
     | "songInfo"
-    | "searchSongs";
+    | "searchSongs"
+    | "webRoomMembership";
 
 export default ActivityRequestOp;

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -44,5 +44,6 @@ declare namespace NodeJS {
         POWER_HOUR_NOTIF_WEBHOOK_URL: string | undefined;
         DISCORD_CLIENT_SECRET?: string | undefined;
         ACTIVITY_PUBLIC_BASE_URL?: string | undefined;
+        WEB_PUBLIC_BASE_URL?: string | undefined;
     }
 }

--- a/src/helpers/discord_utils.ts
+++ b/src/helpers/discord_utils.ts
@@ -1564,6 +1564,10 @@ export function botHasVoicePermissions(voiceChannelID: string): boolean {
 export function getVoiceChannel(
     voiceChannelID: string,
 ): Eris.VoiceChannel | null {
+    // Web sessions have no voice channel (empty ID) — Eris's getChannel
+    // throws on falsy IDs instead of returning undefined.
+    if (!voiceChannelID) return null;
+
     const voiceChannel = State.client.getChannel(
         voiceChannelID,
     ) as Eris.VoiceChannel;
@@ -1578,6 +1582,9 @@ export function getVoiceChannel(
 export function getCurrentVoiceMembers(
     voiceChannelID: string,
 ): Array<Eris.Member> {
+    // No channel to inspect (web session) — not a cache miss, so no warn.
+    if (!voiceChannelID) return [];
+
     const voiceChannel = getVoiceChannel(voiceChannelID);
     // getVoiceChannel casts whatever getChannel returns to VoiceChannel, so a
     // missing/uncached channel (null) OR a channel that isn't actually a voice

--- a/src/helpers/web_session_manager.ts
+++ b/src/helpers/web_session_manager.ts
@@ -1,0 +1,127 @@
+import {
+    WEB_SESSION_TOKEN_PREFIX,
+    WEB_SESSION_TOUCH_INTERVAL_MS,
+    WEB_SESSION_TTL_MS,
+} from "../constants";
+import crypto from "crypto";
+import dbContext from "../database_context";
+
+/**
+ * Identity attached to a standalone-website login. Provider-agnostic on
+ * purpose: rows come from Discord OAuth today, but nothing downstream assumes
+ * that beyond `id` being a Discord snowflake (required for EXP/stats parity).
+ */
+// eslint-disable-next-line import/no-unused-modules
+export interface WebSessionUser {
+    id: string;
+    username: string;
+    avatarUrl: string | null;
+    locale: string;
+}
+
+/**
+ * @param token - the opaque bearer token held by the browser
+ * @returns whether the token is a web session token (vs. a Discord OAuth
+ * access token from the embedded Activity)
+ */
+export function isWebSessionToken(token: string): boolean {
+    return token.startsWith(WEB_SESSION_TOKEN_PREFIX);
+}
+
+/**
+ * @param token - the raw session token
+ * @returns the sha256 hex digest stored in the DB (the raw token is never
+ * persisted, so a DB leak doesn't leak usable bearer tokens)
+ */
+export function hashWebSessionToken(token: string): string {
+    return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Creates a new web session row and returns the raw bearer token.
+ * @param user - the authenticated user's identity
+ * @returns the raw token to hand to the browser
+ */
+export async function createWebSession(user: WebSessionUser): Promise<string> {
+    const token = `${WEB_SESSION_TOKEN_PREFIX}${crypto
+        .randomBytes(32)
+        .toString("hex")}`;
+
+    const now = new Date();
+    await dbContext.kmq
+        .insertInto("web_sessions")
+        .values({
+            token_hash: hashWebSessionToken(token),
+            user_id: user.id,
+            username: user.username,
+            avatar_url: user.avatarUrl,
+            locale: user.locale,
+            created_at: now,
+            expires_at: new Date(now.getTime() + WEB_SESSION_TTL_MS),
+            last_used_at: now,
+        })
+        .execute();
+
+    return token;
+}
+
+/**
+ * Resolves a web session token to its user, enforcing expiry and sliding the
+ * expiration forward. The sliding write is throttled to once per
+ * WEB_SESSION_TOUCH_INTERVAL_MS so hot sessions don't write per request.
+ * @param token - the raw bearer token from the Authorization header
+ * @returns the session's user, or null if unknown/expired
+ */
+export async function resolveWebSession(
+    token: string,
+): Promise<WebSessionUser | null> {
+    if (!isWebSessionToken(token)) return null;
+    const tokenHash = hashWebSessionToken(token);
+    const row = await dbContext.kmq
+        .selectFrom("web_sessions")
+        .selectAll()
+        .where("token_hash", "=", tokenHash)
+        .executeTakeFirst();
+
+    if (!row) return null;
+
+    const now = Date.now();
+    if (row.expires_at.getTime() <= now) {
+        await dbContext.kmq
+            .deleteFrom("web_sessions")
+            .where("token_hash", "=", tokenHash)
+            .execute();
+
+        return null;
+    }
+
+    if (now - row.last_used_at.getTime() > WEB_SESSION_TOUCH_INTERVAL_MS) {
+        await dbContext.kmq
+            .updateTable("web_sessions")
+            .set({
+                last_used_at: new Date(now),
+                expires_at: new Date(now + WEB_SESSION_TTL_MS),
+            })
+            .where("token_hash", "=", tokenHash)
+            .execute();
+    }
+
+    return {
+        id: row.user_id,
+        username: row.username,
+        avatarUrl: row.avatar_url,
+        locale: row.locale,
+    };
+}
+
+/**
+ * Deletes the session row for the given token (logout). No-op for unknown
+ * tokens.
+ * @param token - the raw bearer token to invalidate
+ */
+export async function deleteWebSession(token: string): Promise<void> {
+    await dbContext.kmq
+        .deleteFrom("web_sessions")
+        .where("token_hash", "=", hashWebSessionToken(token))
+        .execute();
+}

--- a/src/helpers/web_session_manager.ts
+++ b/src/helpers/web_session_manager.ts
@@ -1,4 +1,6 @@
 import {
+    WEB_GUEST_ID_FLAG,
+    WEB_GUEST_USERNAME_MAX_LENGTH,
     WEB_SESSION_TOKEN_PREFIX,
     WEB_SESSION_TOUCH_INTERVAL_MS,
     WEB_SESSION_TTL_MS,
@@ -35,6 +37,50 @@ export function isWebSessionToken(token: string): boolean {
  */
 export function hashWebSessionToken(token: string): string {
     return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Mints a synthetic numeric user ID for a guest login. Bits 62+61 set plus
+ * 60 random bits — see WEB_GUEST_ID_FLAG for the disjointness argument. The
+ * ID flows through every user-keyed code path (EXP, stats, scoreboards) as a
+ * plain numeric string, just like a snowflake.
+ * @returns a fresh guest user ID
+ */
+export function mintGuestUserID(): string {
+    const random = crypto.randomBytes(8).readBigUInt64BE() >> 4n;
+    return (WEB_GUEST_ID_FLAG | random).toString();
+}
+
+/**
+ * @param userID - a user ID from any transport
+ * @returns whether it's a synthetic guest ID (both flag bits set — real
+ * snowflakes and room-owner IDs can't reach this range for decades)
+ */
+export function isGuestUserID(userID: string): boolean {
+    try {
+        return (BigInt(userID) & WEB_GUEST_ID_FLAG) === WEB_GUEST_ID_FLAG;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Normalizes a guest's self-chosen display name: collapses whitespace,
+ * strips control characters, and caps the length.
+ * @param raw - the name as submitted
+ * @returns a display-safe name, "Guest" if nothing usable remains
+ */
+export function sanitizeGuestUsername(raw: unknown): string {
+    if (typeof raw !== "string") return "Guest";
+    const cleaned = raw
+        // eslint-disable-next-line no-control-regex
+        .replace(/[\u0000-\u001f\u007f]/g, "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, WEB_GUEST_USERNAME_MAX_LENGTH)
+        .trim();
+
+    return cleaned || "Guest";
 }
 
 /**

--- a/src/interfaces/activity_event.ts
+++ b/src/interfaces/activity_event.ts
@@ -99,6 +99,13 @@ type ActivityEvent =
           encoderArgs: string[];
           playbackDurationSec: number;
           songStartedAt: number | null;
+      }
+    | {
+          // Admiral-minted (never emitted by workers): an impending bot
+          // restart, announced to every subscriber regardless of guild.
+          // null retracts a previously announced restart.
+          type: "restartWarning";
+          restartsAtEpochMs: number | null;
       };
 
 export default ActivityEvent;

--- a/src/interfaces/activity_event.ts
+++ b/src/interfaces/activity_event.ts
@@ -85,6 +85,20 @@ type ActivityEvent =
           type: "roundTimerChanged";
           guessTimeoutSec: number | null;
           timerStartedAt: number;
+      }
+    | {
+          // Web sessions only: the playback spec for the round's audio.
+          // Worker → admiral ONLY: the hub must intercept this (it names the
+          // song) and mint an opaque streaming URL instead of forwarding.
+          type: "roundAudio";
+          youtubeLink: string;
+          songLocation: string;
+          seekLocation: number;
+          songDuration: number;
+          inputArgs: string[];
+          encoderArgs: string[];
+          playbackDurationSec: number;
+          songStartedAt: number | null;
       };
 
 export default ActivityEvent;

--- a/src/interfaces/activity_snapshot.ts
+++ b/src/interfaces/activity_snapshot.ts
@@ -17,6 +17,14 @@ export default interface ActivitySnapshot {
         audioUrl: string;
         playbackDurationSec: number;
     };
+    /**
+     * Present while a bot restart has been announced and not yet retracted.
+     * Injected by the admiral (workers never set it) so late joiners and
+     * reconnects see the warning between broadcast intervals.
+     */
+    restartWarning?: {
+        restartsAtEpochMs: number;
+    };
     /** Current GuildPreference values the Activity panel needs. */
     options: ActivityOptionsSnapshot;
 }

--- a/src/interfaces/activity_snapshot.ts
+++ b/src/interfaces/activity_snapshot.ts
@@ -8,6 +8,15 @@ export default interface ActivitySnapshot {
     session?: ActivitySessionMeta;
     scoreboard?: ActivityScoreboardSnapshot;
     currentRound?: ActivityRoundMeta;
+    /**
+     * Web rooms only. The stream URL for audio already playing, injected by
+     * the admiral (never the worker) so reconnects and late joiners hear the
+     * current song; each GET re-seeks to the live position.
+     */
+    currentAudio?: {
+        audioUrl: string;
+        playbackDurationSec: number;
+    };
     /** Current GuildPreference values the Activity panel needs. */
     options: ActivityOptionsSnapshot;
 }

--- a/src/interfaces/activity_start_game_args.ts
+++ b/src/interfaces/activity_start_game_args.ts
@@ -1,3 +1,4 @@
+import type { WebRoomMemberInfo } from "../structures/web_room_state";
 import type GameType from "../enums/game_type";
 
 export default interface ActivityStartGameArgs {
@@ -12,4 +13,11 @@ export default interface ActivityStartGameArgs {
     eliminationLives?: number;
     /** Clip length in seconds for clip mode; ignored otherwise. */
     clipDuration?: number;
+    /** "web": a standalone-website room game (guildID is a synthetic room
+     *  ID, channel IDs are empty, and `members` seeds the worker's
+     *  membership mirror). Absent for the embedded Activity. */
+    mode?: "web";
+    /** Room membership at start time (web mode only) — embedded here so the
+     *  session never races the separate membership push. */
+    members?: WebRoomMemberInfo[];
 }

--- a/src/interfaces/activity_web_room_membership_args.ts
+++ b/src/interfaces/activity_web_room_membership_args.ts
@@ -1,0 +1,7 @@
+import type { WebRoomMemberInfo } from "../structures/web_room_state";
+
+export default interface ActivityWebRoomMembershipArgs {
+    guildID: string;
+    /** Full membership snapshot; empty means the room closed. */
+    members: WebRoomMemberInfo[];
+}

--- a/src/kmq_configuration.ts
+++ b/src/kmq_configuration.ts
@@ -103,4 +103,14 @@ export default class KmqConfiguration {
     activityReducedEmbeds(): boolean {
         return this.config["activityReducedEmbeds"] ?? false;
     }
+
+    /**
+     * Gates the standalone-website surface (`/api/web/*` routes and web-room
+     * game starts). Off by default so the port can ship dark and be enabled
+     * per-environment via feature_switch_config.json + reload_config.
+     * @returns whether web mode is enabled
+     */
+    webModeEnabled(): boolean {
+        return this.config["webModeEnabled"] ?? false;
+    }
 }

--- a/src/kmq_configuration.ts
+++ b/src/kmq_configuration.ts
@@ -113,4 +113,15 @@ export default class KmqConfiguration {
     webModeEnabled(): boolean {
         return this.config["webModeEnabled"] ?? false;
     }
+
+    /**
+     * Gates guest (no Discord account) logins on the standalone website.
+     * Guests can join rooms via invite but never host; gated separately from
+     * webModeEnabled so the free-identity surface can be killed without
+     * taking down the site.
+     * @returns whether guest logins are enabled
+     */
+    webGuestsEnabled(): boolean {
+        return this.config["webGuestsEnabled"] ?? false;
+    }
 }

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -541,18 +541,40 @@ export default class KmqWebServer {
         this.activityHub = activityHub;
 
         if (activityHub) {
+            // Mirror membership to the worker owning the room's guild ID —
+            // it feeds WebGameSession participants; an empty push means the
+            // room closed and tears any running game down. Fire-and-forget:
+            // a lost push self-heals on the next membership change.
+            const pushMembership = (
+                roomID: string,
+                members: Array<{
+                    id: string;
+                    username: string;
+                    avatarUrl: string | null;
+                }>,
+            ): void => {
+                activityHub
+                    .webRoomMembership({ guildID: roomID, members })
+                    .catch((e) => {
+                        logger.warn(
+                            `Web room membership push failed for ${roomID}. err=${(e as Error).message}`,
+                        );
+                    });
+            };
+
             this.webRoomManager = new WebRoomManager({
-                onRoomClosed: (roomID, lastMemberID) => {
-                    // End any game running against the room's synthetic guild
-                    // ID. Fire-and-forget: with no session the worker just
-                    // reports no_session.
-                    activityHub
-                        .endGame({ guildID: roomID, userID: lastMemberID })
-                        .catch((e) => {
-                            logger.debug(
-                                `endGame for closed web room ${roomID} failed. err=${(e as Error).message}`,
-                            );
-                        });
+                onRoomClosed: (roomID) => {
+                    pushMembership(roomID, []);
+                },
+                onRoomChanged: (room) => {
+                    pushMembership(
+                        room.roomID,
+                        [...room.members.values()].map((m) => ({
+                            id: m.id,
+                            username: m.username,
+                            avatarUrl: m.avatarUrl,
+                        })),
+                    );
                 },
             });
 
@@ -1187,6 +1209,7 @@ export default class KmqWebServer {
                 guildID: string;
                 channelID: string | null;
                 participantIDs: Set<string>;
+                webRoom: boolean;
             };
         } | null> => {
             if (!this.activityHub) {
@@ -1223,7 +1246,7 @@ export default class KmqWebServer {
                 const ctx = await requireAuthedInstance(request, reply);
                 if (!ctx) return;
 
-                if (!ctx.instance.channelID) {
+                if (!ctx.instance.webRoom && !ctx.instance.channelID) {
                     await reply.code(400).send({ error: "Missing channel" });
                     return;
                 }
@@ -1283,14 +1306,33 @@ export default class KmqWebServer {
                 }
 
                 try {
+                    // Web rooms have no channels; the worker gets the room's
+                    // membership inline so the first round can't race the
+                    // separate membership push.
+                    const room = ctx.instance.webRoom
+                        ? this.webRoomManager?.getRoomForUser(ctx.user.id)
+                        : undefined;
+
                     const result = await this.activityHub!.startGame({
                         guildID: ctx.instance.guildID,
                         userID: ctx.user.id,
-                        voiceChannelID: ctx.instance.channelID,
-                        textChannelID: ctx.instance.channelID,
+                        voiceChannelID: ctx.instance.channelID ?? "",
+                        textChannelID: ctx.instance.channelID ?? "",
                         gameType,
                         eliminationLives,
                         clipDuration,
+                        ...(ctx.instance.webRoom
+                            ? {
+                                  mode: "web" as const,
+                                  members: [
+                                      ...(room?.members.values() ?? []),
+                                  ].map((m) => ({
+                                      id: m.id,
+                                      username: m.username,
+                                      avatarUrl: m.avatarUrl,
+                                  })),
+                              }
+                            : {}),
                     });
 
                     if (!result.ok) {

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -728,6 +728,13 @@ export default class KmqWebServer {
             await fleet.ipc.allClustersCommand(
                 `announce_restart|${restartMinutes}`,
             );
+
+            // Activity/web subscribers get the warning as a live banner; the
+            // clusters only reach text channels.
+            this.activityHub?.setRestartNotice(
+                Date.now() + restartMinutes * 60 * 1000,
+            );
+
             await reply.code(200).send();
         });
 
@@ -739,6 +746,7 @@ export default class KmqWebServer {
             }
 
             await fleet.ipc.allClustersCommand("clear_restart");
+            this.activityHub?.setRestartNotice(null);
             await reply.code(200).send();
         });
 

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -36,8 +36,11 @@ import { buildAudioStreamArgs } from "./web_audio_registry";
 import {
     createWebSession,
     deleteWebSession,
+    isGuestUserID,
     isWebSessionToken,
+    mintGuestUserID,
     resolveWebSession,
+    sanitizeGuestUsername,
 } from "./helpers/web_session_manager";
 import { measureExecutionTime, standardDateFormat } from "./helpers/utils";
 import { spawn } from "child_process";
@@ -2558,6 +2561,55 @@ export default class KmqWebServer {
                         id: entry.user.id,
                         username: entry.user.username,
                         avatarUrl: entry.user.avatarUrl,
+                        guest: false,
+                    },
+                });
+            },
+        );
+
+        httpServer.post(
+            "/api/web/guest-login",
+            limit(ACTIVITY_RATE_LIMIT_TOKEN),
+            async (request, reply) => {
+                if (!(await requireWebMode(reply))) return;
+
+                if (!KmqConfiguration.Instance.webGuestsEnabled()) {
+                    await reply
+                        .code(503)
+                        .send({ error: "Guest mode disabled" });
+                    return;
+                }
+
+                const body = request.body as {
+                    username?: string;
+                    locale?: string;
+                } | null;
+
+                const username = sanitizeGuestUsername(body?.username);
+                const locale =
+                    typeof body?.locale === "string"
+                        ? body.locale.slice(0, 16)
+                        : "";
+
+                const id = mintGuestUserID();
+                const token = await createWebSession({
+                    id,
+                    username,
+                    avatarUrl: null,
+                    locale,
+                });
+
+                logger.info(
+                    `Guest web session created. id=${id}, username=${username}`,
+                );
+
+                await reply.code(200).send({
+                    token,
+                    user: {
+                        id,
+                        username,
+                        avatarUrl: null,
+                        guest: true,
                     },
                 });
             },
@@ -2585,6 +2637,7 @@ export default class KmqWebServer {
                         id: user.id,
                         username: user.username,
                         avatarUrl: user.avatarUrl,
+                        guest: isGuestUserID(user.id),
                     },
                 });
             },
@@ -2679,6 +2732,15 @@ export default class KmqWebServer {
             async (request, reply) => {
                 const user = await requireWebUser(request, reply);
                 if (!user) return;
+
+                // Guests can join rooms but never host: free identities
+                // shouldn't own persistent per-owner state (game options,
+                // presets), and a guest ID fed to roomIDForOwner would
+                // collide with the guest ID range (bit 62 already set).
+                if (isGuestUserID(user.id)) {
+                    await reply.code(403).send({ error: "guest_forbidden" });
+                    return;
+                }
 
                 const result = this.webRoomManager!.createRoom({
                     id: user.id,

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -16,14 +16,25 @@ import {
     CLIP_MIN_DURATION_SEC,
     DEFAULT_LOCALE,
     DISCORD_ACTIVITY_INSTANCE_URL,
+    DISCORD_OAUTH_AUTHORIZE_URL,
     DISCORD_OAUTH_TOKEN_URL,
     DISCORD_USERS_ME_URL,
     EARLIEST_BEGINNING_SEARCH_YEAR,
     ELIMINATION_DEFAULT_LIVES,
     ELIMINATION_MAX_LIVES,
+    WEB_LOGIN_CODE_TTL_MS,
+    WEB_OAUTH_STATE_COOKIE,
+    WEB_OAUTH_STATE_TTL_MS,
+    discordAvatarUrl,
 } from "./constants";
 import { IPCLogger } from "./logger";
 import { availableGenders } from "./enums/option_types/gender";
+import {
+    createWebSession,
+    deleteWebSession,
+    isWebSessionToken,
+    resolveWebSession,
+} from "./helpers/web_session_manager";
 import { measureExecutionTime, standardDateFormat } from "./helpers/utils";
 import { sql } from "kysely";
 import { userVoted } from "./helpers/bot_listing_manager";
@@ -31,6 +42,7 @@ import AnswerType from "./enums/option_types/answer_type";
 import ArtistType from "./enums/option_types/artist_type";
 import GameType from "./enums/game_type";
 import GuessModeType from "./enums/option_types/guess_mode_type";
+import KmqConfiguration from "./kmq_configuration";
 import LanguageType from "./enums/option_types/language_type";
 import LocaleType from "./enums/locale_type";
 import MultiGuessType from "./enums/option_types/multiguess_type";
@@ -55,6 +67,7 @@ import path from "path";
 import type { ActivityPresetAction } from "./interfaces/activity_preset_args";
 import type { ActivitySubscriber } from "./activity_hub";
 import type { DatabaseContext } from "./database_context";
+import type { FastifyInstance } from "fastify";
 import type { Fleet, Stats } from "eris-fleet";
 import type { GenderModeOptions } from "./enums/option_types/gender";
 import type ActivityHub from "./activity_hub";
@@ -95,6 +108,7 @@ interface CachedDiscordUser {
     username: string;
     /** Discord user locale (e.g. "en-US"). Empty if Discord didn't return one. */
     locale: string;
+    avatarUrl: string | null;
     cachedAt: number;
 }
 
@@ -499,6 +513,20 @@ export default class KmqWebServer {
         }
     > = new Map();
 
+    // OAuth `state` nonces awaiting the web-login callback.
+    private webOauthStates: Map<string, number> = new Map();
+
+    // One-time codes bridging the OAuth callback redirect to the SPA. Values
+    // hold the freshly minted session token until the SPA collects it.
+    private webLoginCodes: Map<
+        string,
+        {
+            token: string;
+            user: CachedDiscordUser;
+            expiresAt: number;
+        }
+    > = new Map();
+
     constructor(
         databaseContext: DatabaseContext,
         activityHub: ActivityHub | null = null,
@@ -571,26 +599,47 @@ export default class KmqWebServer {
             // there so the SPA can pick up the params from window.location.
             const activityIndexPath = path.join(activityDistRoot, "index.html");
 
+            const serveActivityIndex = async (
+                _request: unknown,
+                reply: any,
+            ): Promise<void> => {
+                try {
+                    const html = await fs.promises.readFile(
+                        activityIndexPath,
+                        "utf8",
+                    );
+
+                    await reply.type("text/html").send(html);
+                } catch (e) {
+                    logger.warn(
+                        `Failed to serve activity index. err=${
+                            (e as Error).message
+                        }`,
+                    );
+                    await reply.code(500).send();
+                }
+            };
+
             httpServer.get(
                 "/",
                 limit(ACTIVITY_RATE_LIMIT_READ),
-                async (request, reply) => {
-                    try {
-                        const html = await fs.promises.readFile(
-                            activityIndexPath,
-                            "utf8",
-                        );
+                serveActivityIndex,
+            );
 
-                        await reply.type("text/html").send(html);
-                    } catch (e) {
-                        logger.warn(
-                            `Failed to serve activity index. err=${
-                                (e as Error).message
-                            }`,
-                        );
-                        await reply.code(500).send();
-                    }
-                },
+            // The standalone website mounts the same SPA at /play; deep links
+            // like /play/r/<room-code> must also resolve to the index so the
+            // client can route from the path. Asset URLs are absolute
+            // (/activity/...), so serving the index at any depth is safe.
+            httpServer.get(
+                "/play",
+                limit(ACTIVITY_RATE_LIMIT_READ),
+                serveActivityIndex,
+            );
+
+            httpServer.get(
+                "/play/*",
+                limit(ACTIVITY_RATE_LIMIT_READ),
+                serveActivityIndex,
             );
         } else {
             logger.info(
@@ -643,6 +692,9 @@ export default class KmqWebServer {
                 return;
             }
 
+            // The admiral process reads feature switches too (web-mode
+            // gating), so reload locally in addition to the clusters.
+            KmqConfiguration.reload();
             await fleet.ipc.allClustersCommand("reload_config");
             await reply.code(200).send();
         });
@@ -991,6 +1043,8 @@ export default class KmqWebServer {
                 }
             },
         );
+
+        this.registerWebAuthRoutes(httpServer, limit);
 
         httpServer.get(
             "/api/activity/i18n",
@@ -1941,6 +1995,38 @@ export default class KmqWebServer {
             return cached.user;
         }
 
+        // Web session tokens resolve against the local web_sessions store;
+        // everything else is a Discord OAuth access token from the embedded
+        // Activity and resolves via users/@me.
+        if (isWebSessionToken(token)) {
+            try {
+                const webUser = await resolveWebSession(token);
+                if (!webUser) return null;
+
+                const user: CachedDiscordUser = {
+                    id: webUser.id,
+                    username: webUser.username,
+                    locale: webUser.locale,
+                    avatarUrl: webUser.avatarUrl,
+                    cachedAt: now,
+                };
+
+                this.accessTokenCache.set(token, {
+                    user,
+                    expiresAt: now + ACTIVITY_ACCESS_TOKEN_CACHE_TTL_MS,
+                });
+
+                return user;
+            } catch (e) {
+                logger.warn(
+                    `Failed to resolve web session token. err=${
+                        (e as Error).message
+                    }`,
+                );
+                return null;
+            }
+        }
+
         try {
             const response = await axios.get(DISCORD_USERS_ME_URL, {
                 headers: { Authorization: `Bearer ${token}` },
@@ -1954,6 +2040,10 @@ export default class KmqWebServer {
                     typeof response.data.locale === "string"
                         ? response.data.locale
                         : "",
+                avatarUrl: discordAvatarUrl(
+                    response.data.id,
+                    response.data.avatar,
+                ),
                 cachedAt: now,
             };
 
@@ -2051,5 +2141,345 @@ export default class KmqWebServer {
             );
             return null;
         }
+    }
+
+    /**
+     * Registers the standalone-website auth routes (/api/web/*): a standard
+     * Discord OAuth2 redirect flow that ends in an opaque `web_`-prefixed
+     * bearer token the SPA uses exactly like the Activity's access token.
+     * All routes 503 while the webModeEnabled feature switch is off.
+     * @param httpServer - the fastify instance
+     * @param limit - per-route rate-limit config builder
+     */
+    private registerWebAuthRoutes(
+        httpServer: FastifyInstance,
+        limit: (max: number) => {
+            config: { rateLimit: { max: number; timeWindow: string } };
+        },
+    ): void {
+        // WEB_PUBLIC_BASE_URL is the site origin used to build the OAuth
+        // redirect_uri; it falls back to the Activity tunnel URL so a dev
+        // setup configured for the Activity works for the website too.
+        const webPublicBaseUrl = (): string | null => {
+            const base =
+                process.env.WEB_PUBLIC_BASE_URL ||
+                process.env.ACTIVITY_PUBLIC_BASE_URL;
+
+            return base ? base.replace(/\/+$/, "") : null;
+        };
+
+        const requireWebMode = async (reply: any): Promise<boolean> => {
+            if (KmqConfiguration.Instance.webModeEnabled()) {
+                return true;
+            }
+
+            await reply.code(503).send({ error: "Web mode disabled" });
+            return false;
+        };
+
+        const parseCookie = (
+            header: string | undefined,
+            name: string,
+        ): string | null => {
+            if (!header) return null;
+            for (const part of header.split(";")) {
+                const eq = part.indexOf("=");
+                if (eq === -1) continue;
+                if (part.slice(0, eq).trim() === name) {
+                    return part.slice(eq + 1).trim();
+                }
+            }
+
+            return null;
+        };
+
+        const stateCookie = (value: string, maxAgeSec: number): string => {
+            const secure = webPublicBaseUrl()?.startsWith("https")
+                ? "; Secure"
+                : "";
+
+            // SameSite=Lax still sends the cookie on the top-level GET
+            // navigation back from Discord's consent screen.
+            return `${WEB_OAUTH_STATE_COOKIE}=${value}; Max-Age=${maxAgeSec}; Path=/api/web; HttpOnly; SameSite=Lax${secure}`;
+        };
+
+        const pruneExpired = (
+            map: Map<string, { expiresAt: number }>,
+        ): void => {
+            const now = Date.now();
+            for (const [key, value] of map) {
+                if (value.expiresAt <= now) {
+                    map.delete(key);
+                }
+            }
+        };
+
+        httpServer.get(
+            "/api/web/login",
+            limit(ACTIVITY_RATE_LIMIT_TOKEN),
+            async (_request, reply) => {
+                if (!(await requireWebMode(reply))) return;
+
+                const baseUrl = webPublicBaseUrl();
+                if (
+                    !baseUrl ||
+                    !process.env.BOT_CLIENT_ID ||
+                    !process.env.DISCORD_CLIENT_SECRET
+                ) {
+                    logger.error(
+                        "Web login misconfigured: WEB_PUBLIC_BASE_URL, BOT_CLIENT_ID, or DISCORD_CLIENT_SECRET missing",
+                    );
+
+                    await reply
+                        .code(500)
+                        .send({ error: "OAuth not configured" });
+                    return;
+                }
+
+                const state = uuid.v4();
+                const now = Date.now();
+                for (const [key, expiresAt] of this.webOauthStates) {
+                    if (expiresAt <= now) this.webOauthStates.delete(key);
+                }
+
+                this.webOauthStates.set(state, now + WEB_OAUTH_STATE_TTL_MS);
+
+                const params = new URLSearchParams({
+                    client_id: process.env.BOT_CLIENT_ID,
+                    response_type: "code",
+                    redirect_uri: `${baseUrl}/api/web/callback`,
+                    scope: "identify",
+                    state,
+                });
+
+                await reply
+                    .header(
+                        "set-cookie",
+                        stateCookie(state, WEB_OAUTH_STATE_TTL_MS / 1000),
+                    )
+                    .redirect(
+                        `${DISCORD_OAUTH_AUTHORIZE_URL}?${params.toString()}`,
+                    );
+            },
+        );
+
+        httpServer.get(
+            "/api/web/callback",
+            limit(ACTIVITY_RATE_LIMIT_TOKEN),
+            async (request, reply) => {
+                if (!(await requireWebMode(reply))) return;
+
+                const query = request.query as {
+                    code?: string;
+                    state?: string;
+                };
+
+                const cookieState = parseCookie(
+                    request.headers.cookie,
+                    WEB_OAUTH_STATE_COOKIE,
+                );
+
+                const state = query.state;
+                const stateValid =
+                    !!state &&
+                    cookieState === state &&
+                    (this.webOauthStates.get(state) ?? 0) > Date.now();
+
+                if (state) this.webOauthStates.delete(state);
+
+                // Expire the state cookie regardless of outcome.
+                const expireStateCookie = (): typeof reply =>
+                    reply.header("set-cookie", stateCookie("", 0));
+
+                if (!stateValid || !query.code) {
+                    await expireStateCookie()
+                        .code(400)
+                        .send({ error: "Invalid OAuth state or code" });
+                    return;
+                }
+
+                const baseUrl = webPublicBaseUrl();
+                if (
+                    !baseUrl ||
+                    !process.env.BOT_CLIENT_ID ||
+                    !process.env.DISCORD_CLIENT_SECRET
+                ) {
+                    await expireStateCookie()
+                        .code(500)
+                        .send({ error: "OAuth not configured" });
+                    return;
+                }
+
+                try {
+                    const params = new URLSearchParams();
+                    params.set("client_id", process.env.BOT_CLIENT_ID);
+                    params.set(
+                        "client_secret",
+                        process.env.DISCORD_CLIENT_SECRET,
+                    );
+                    params.set("grant_type", "authorization_code");
+                    params.set("code", query.code);
+                    params.set("redirect_uri", `${baseUrl}/api/web/callback`);
+
+                    const tokenResponse = await axios.post(
+                        DISCORD_OAUTH_TOKEN_URL,
+                        params.toString(),
+                        {
+                            headers: {
+                                "Content-Type":
+                                    "application/x-www-form-urlencoded",
+                            },
+                            timeout: ACTIVITY_HTTP_TIMEOUT_MS,
+                        },
+                    );
+
+                    const meResponse = await axios.get(DISCORD_USERS_ME_URL, {
+                        headers: {
+                            Authorization: `Bearer ${tokenResponse.data.access_token}`,
+                        },
+                        timeout: ACTIVITY_HTTP_TIMEOUT_MS,
+                    });
+
+                    const user: CachedDiscordUser = {
+                        id: meResponse.data.id,
+                        username: meResponse.data.username,
+                        locale:
+                            typeof meResponse.data.locale === "string"
+                                ? meResponse.data.locale
+                                : "",
+                        avatarUrl: discordAvatarUrl(
+                            meResponse.data.id,
+                            meResponse.data.avatar,
+                        ),
+                        cachedAt: Date.now(),
+                    };
+
+                    const token = await createWebSession({
+                        id: user.id,
+                        username: user.username,
+                        avatarUrl: user.avatarUrl,
+                        locale: user.locale,
+                    });
+
+                    pruneExpired(this.webLoginCodes);
+                    const loginCode = uuid.v4();
+                    this.webLoginCodes.set(loginCode, {
+                        token,
+                        user,
+                        expiresAt: Date.now() + WEB_LOGIN_CODE_TTL_MS,
+                    });
+
+                    await expireStateCookie().redirect(
+                        `/play?login_code=${encodeURIComponent(loginCode)}`,
+                    );
+                } catch (e) {
+                    const err = e as {
+                        message: string;
+                        response?: { status?: number };
+                    };
+
+                    logger.warn(
+                        `Web OAuth callback failed. err=${err.message} status=${err.response?.status}`,
+                    );
+
+                    await expireStateCookie()
+                        .code(401)
+                        .send({ error: "Login failed" });
+                }
+            },
+        );
+
+        httpServer.post(
+            "/api/web/complete-login",
+            limit(ACTIVITY_RATE_LIMIT_TOKEN),
+            async (request, reply) => {
+                if (!(await requireWebMode(reply))) return;
+
+                const loginCode = (request.body as any)?.login_code as
+                    | string
+                    | undefined;
+
+                if (!loginCode) {
+                    await reply.code(400).send({ error: "Missing login_code" });
+                    return;
+                }
+
+                const entry = this.webLoginCodes.get(loginCode);
+                // Single-use: consumed on first attempt, valid or not.
+                this.webLoginCodes.delete(loginCode);
+
+                if (!entry || entry.expiresAt <= Date.now()) {
+                    await reply
+                        .code(401)
+                        .send({ error: "Invalid or expired login code" });
+                    return;
+                }
+
+                await reply.code(200).send({
+                    token: entry.token,
+                    user: {
+                        id: entry.user.id,
+                        username: entry.user.username,
+                        avatarUrl: entry.user.avatarUrl,
+                    },
+                });
+            },
+        );
+
+        httpServer.get(
+            "/api/web/session",
+            limit(ACTIVITY_RATE_LIMIT_READ),
+            async (request, reply) => {
+                if (!(await requireWebMode(reply))) return;
+
+                const header = request.headers["authorization"];
+                const token = header?.startsWith("Bearer ")
+                    ? header.slice(7)
+                    : undefined;
+
+                const user = await this.resolveAccessToken(token);
+                if (!user) {
+                    await reply.code(401).send({ error: "Unauthorized" });
+                    return;
+                }
+
+                await reply.code(200).send({
+                    user: {
+                        id: user.id,
+                        username: user.username,
+                        avatarUrl: user.avatarUrl,
+                    },
+                });
+            },
+        );
+
+        httpServer.post(
+            "/api/web/logout",
+            limit(ACTIVITY_RATE_LIMIT_TOKEN),
+            async (request, reply) => {
+                if (!(await requireWebMode(reply))) return;
+
+                const header = request.headers["authorization"];
+                const token = header?.startsWith("Bearer ")
+                    ? header.slice(7)
+                    : undefined;
+
+                if (token && isWebSessionToken(token)) {
+                    try {
+                        await deleteWebSession(token);
+                    } catch (e) {
+                        logger.warn(
+                            `Web logout failed to delete session. err=${
+                                (e as Error).message
+                            }`,
+                        );
+                    }
+
+                    this.accessTokenCache.delete(token);
+                }
+
+                await reply.code(204).send();
+            },
+        );
     }
 }

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -22,6 +22,8 @@ import {
     EARLIEST_BEGINNING_SEARCH_YEAR,
     ELIMINATION_DEFAULT_LIVES,
     ELIMINATION_MAX_LIVES,
+    WEB_AUDIO_MAX_CONCURRENT_STREAMS,
+    WEB_AUDIO_URL_PREFIX,
     WEB_LOGIN_CODE_TTL_MS,
     WEB_OAUTH_STATE_COOKIE,
     WEB_OAUTH_STATE_TTL_MS,
@@ -30,6 +32,7 @@ import {
 } from "./constants";
 import { IPCLogger } from "./logger";
 import { availableGenders } from "./enums/option_types/gender";
+import { buildAudioStreamArgs } from "./web_audio_registry";
 import {
     createWebSession,
     deleteWebSession,
@@ -37,6 +40,7 @@ import {
     resolveWebSession,
 } from "./helpers/web_session_manager";
 import { measureExecutionTime, standardDateFormat } from "./helpers/utils";
+import { spawn } from "child_process";
 import { sql } from "kysely";
 import { userVoted } from "./helpers/bot_listing_manager";
 import AnswerType from "./enums/option_types/answer_type";
@@ -532,6 +536,10 @@ export default class KmqWebServer {
     > = new Map();
 
     private webRoomManager: WebRoomManager | null = null;
+
+    // Live ffmpeg transcodes serving /api/web/audio streams (one per
+    // listener), for the global concurrency cap.
+    private activeAudioStreams = 0;
 
     constructor(
         databaseContext: DatabaseContext,
@@ -1095,6 +1103,7 @@ export default class KmqWebServer {
 
         this.registerWebAuthRoutes(httpServer, limit);
         this.registerWebRoomRoutes(httpServer, limit);
+        this.registerWebAudioRoutes(httpServer, limit);
 
         httpServer.get(
             "/api/activity/i18n",
@@ -2755,6 +2764,124 @@ export default class KmqWebServer {
                 await reply.code(200).send({
                     room: this.webRoomManager!.serializeRoom(room),
                 });
+            },
+        );
+    }
+
+    /**
+     * Registers the web-room audio stream route. The token is the bearer
+     * capability (audio elements can't attach Authorization headers); it's
+     * an unguessable uuid distributed only to the room's subscribers, and it
+     * expires with the playback. Each GET spawns a dedicated ffmpeg seeked to
+     * the live position, so reloads and late joiners stay in sync.
+     * @param httpServer - the fastify instance
+     * @param limit - per-route rate-limit config builder
+     */
+    private registerWebAudioRoutes(
+        httpServer: FastifyInstance,
+        limit: (max: number) => {
+            config: { rateLimit: { max: number; timeWindow: string } };
+        },
+    ): void {
+        httpServer.get(
+            `${WEB_AUDIO_URL_PREFIX}/:token`,
+            limit(ACTIVITY_RATE_LIMIT_READ),
+            async (request, reply) => {
+                if (!KmqConfiguration.Instance.webModeEnabled()) {
+                    await reply.code(503).send({ error: "Web mode disabled" });
+                    return;
+                }
+
+                if (!this.activityHub) {
+                    await reply
+                        .code(503)
+                        .send({ error: "Activity hub not available" });
+                    return;
+                }
+
+                const token = (request.params as { token: string }).token;
+                const entry = this.activityHub.getAudioEntry(token);
+                if (!entry) {
+                    await reply.code(404).send({ error: "Unknown token" });
+                    return;
+                }
+
+                const args = buildAudioStreamArgs(entry, Date.now());
+                if (!args) {
+                    await reply.code(410).send({ error: "Playback ended" });
+                    return;
+                }
+
+                if (
+                    this.activeAudioStreams >= WEB_AUDIO_MAX_CONCURRENT_STREAMS
+                ) {
+                    logger.warn(
+                        `Audio stream cap hit (${this.activeAudioStreams} active)`,
+                    );
+
+                    await reply
+                        .code(503)
+                        .send({ error: "Too many active streams" });
+                    return;
+                }
+
+                this.activeAudioStreams++;
+                let released = false;
+                const release = (): void => {
+                    if (released) return;
+                    released = true;
+                    this.activeAudioStreams--;
+                };
+
+                const child = spawn("ffmpeg", args, {
+                    stdio: ["ignore", "pipe", "pipe"],
+                });
+
+                // -loglevel error: anything here is a real failure. Drain it
+                // regardless so ffmpeg can't block on a full stderr pipe.
+                let stderr = "";
+                child.stderr.on("data", (chunk: Buffer) => {
+                    if (stderr.length < 2048) {
+                        stderr += chunk.toString();
+                    }
+                });
+
+                child.on("close", (code) => {
+                    release();
+                    if (code !== 0 && code !== null && stderr) {
+                        logger.error(
+                            `Audio stream ffmpeg failed. gid=${entry.guildID}, code=${code}, err=${stderr.trim()}`,
+                        );
+                    }
+                });
+
+                child.on("error", (e) => {
+                    release();
+                    logger.error(`Audio stream ffmpeg spawn failed. err=${e}`);
+                    if (!reply.sent) {
+                        reply
+                            .code(500)
+                            .send({ error: "Stream unavailable" })
+                            .then(
+                                () => {},
+                                () => {},
+                            );
+                    }
+                });
+
+                // Tab closed / element released: kill the transcode instead
+                // of encoding to a dead socket for the rest of the song.
+                request.raw.on("close", () => {
+                    child.kill("SIGKILL");
+                    release();
+                });
+
+                await reply
+                    .code(200)
+                    .header("Content-Type", "audio/mpeg")
+                    .header("Cache-Control", "no-store")
+                    .header("Accept-Ranges", "none")
+                    .send(child.stdout);
             },
         );
     }

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -25,6 +25,7 @@ import {
     WEB_LOGIN_CODE_TTL_MS,
     WEB_OAUTH_STATE_COOKIE,
     WEB_OAUTH_STATE_TTL_MS,
+    WEB_ROOM_SWEEP_INTERVAL_MS,
     discordAvatarUrl,
 } from "./constants";
 import { IPCLogger } from "./logger";
@@ -52,6 +53,7 @@ import SeekType from "./enums/option_types/seek_type";
 import ShuffleType from "./enums/option_types/shuffle_type";
 import SpecialType from "./enums/option_types/special_type";
 import SubunitsPreference from "./enums/option_types/subunit_preference";
+import WebRoomManager from "./web_room_manager";
 import _ from "lodash";
 import axios from "axios";
 import ejs from "ejs";
@@ -513,8 +515,10 @@ export default class KmqWebServer {
         }
     > = new Map();
 
-    // OAuth `state` nonces awaiting the web-login callback.
-    private webOauthStates: Map<string, number> = new Map();
+    // OAuth `state` nonces awaiting the web-login callback. `next` is the
+    // validated in-site path to land on after login (e.g. an invite link).
+    private webOauthStates: Map<string, { expiresAt: number; next: string }> =
+        new Map();
 
     // One-time codes bridging the OAuth callback redirect to the SPA. Values
     // hold the freshly minted session token until the SPA collects it.
@@ -527,12 +531,35 @@ export default class KmqWebServer {
         }
     > = new Map();
 
+    private webRoomManager: WebRoomManager | null = null;
+
     constructor(
         databaseContext: DatabaseContext,
         activityHub: ActivityHub | null = null,
     ) {
         this.dbContext = databaseContext;
         this.activityHub = activityHub;
+
+        if (activityHub) {
+            this.webRoomManager = new WebRoomManager({
+                onRoomClosed: (roomID, lastMemberID) => {
+                    // End any game running against the room's synthetic guild
+                    // ID. Fire-and-forget: with no session the worker just
+                    // reports no_session.
+                    activityHub
+                        .endGame({ guildID: roomID, userID: lastMemberID })
+                        .catch((e) => {
+                            logger.debug(
+                                `endGame for closed web room ${roomID} failed. err=${(e as Error).message}`,
+                            );
+                        });
+                },
+            });
+
+            setInterval(() => {
+                this.webRoomManager?.sweep();
+            }, WEB_ROOM_SWEEP_INTERVAL_MS).unref();
+        }
     }
 
     /**
@@ -1045,6 +1072,7 @@ export default class KmqWebServer {
         );
 
         this.registerWebAuthRoutes(httpServer, limit);
+        this.registerWebRoomRoutes(httpServer, limit);
 
         httpServer.get(
             "/api/activity/i18n",
@@ -1112,7 +1140,7 @@ export default class KmqWebServer {
                     return;
                 }
 
-                const instance = await this.resolveActivityInstance(instanceId);
+                const instance = await this.resolveInstanceOrRoom(instanceId);
                 if (!instance) {
                     await reply.code(404).send({ error: "Unknown instance" });
                     return;
@@ -1179,7 +1207,7 @@ export default class KmqWebServer {
                 return null;
             }
 
-            const instance = await this.resolveActivityInstance(instanceId);
+            const instance = await this.resolveInstanceOrRoom(instanceId);
             if (!instance || !instance.participantIDs.has(user.id)) {
                 await reply.code(403).send({ error: "Forbidden" });
                 return null;
@@ -1730,7 +1758,7 @@ export default class KmqWebServer {
                     return;
                 }
 
-                const instance = await this.resolveActivityInstance(instanceId);
+                const instance = await this.resolveInstanceOrRoom(instanceId);
                 if (!instance || !instance.participantIDs.has(user.id)) {
                     await reply.code(403).send({ error: "Forbidden" });
                     return;
@@ -1801,7 +1829,7 @@ export default class KmqWebServer {
                     return;
                 }
 
-                const instance = await this.resolveActivityInstance(instanceId);
+                const instance = await this.resolveInstanceOrRoom(instanceId);
                 if (!instance || !instance.participantIDs.has(user.id)) {
                     await reply.code(403).send({ error: "Forbidden" });
                     return;
@@ -1922,6 +1950,9 @@ export default class KmqWebServer {
                 };
 
                 this.activityHub.subscribe(guildID, subscriber);
+                // For web rooms the instance ID is the room code; an open
+                // socket is what marks the member present.
+                this.webRoomManager?.memberConnected(instanceId, userID);
 
                 let alive = true;
                 const heartbeat = setInterval(() => {
@@ -1952,6 +1983,8 @@ export default class KmqWebServer {
                     if (this.activityHub) {
                         this.activityHub.unsubscribe(guildID, subscriber);
                     }
+
+                    this.webRoomManager?.memberDisconnected(instanceId, userID);
                 });
 
                 try {
@@ -2061,6 +2094,34 @@ export default class KmqWebServer {
             );
             return null;
         }
+    }
+
+    /**
+     * Resolves a client-supplied instance ID to its guild/participants. Web
+     * room codes and Discord Activity instance IDs share the `instance_id`
+     * field on the wire; a room-code hit wins (codes are unguessable random
+     * strings, so a real Activity instance ID can't collide with a live one).
+     * @param instanceId - Activity instance ID or web room invite code
+     * @returns the instance context, or null if neither resolves
+     */
+    private async resolveInstanceOrRoom(instanceId: string): Promise<{
+        guildID: string;
+        channelID: string | null;
+        participantIDs: Set<string>;
+        webRoom: boolean;
+    } | null> {
+        const room = this.webRoomManager?.getRoomByCode(instanceId);
+        if (room) {
+            return {
+                guildID: room.roomID,
+                channelID: null,
+                participantIDs: new Set(room.members.keys()),
+                webRoom: true,
+            };
+        }
+
+        const instance = await this.resolveActivityInstance(instanceId);
+        return instance ? { ...instance, webRoom: false } : null;
     }
 
     private async resolveActivityInstance(instanceId: string): Promise<{
@@ -2217,7 +2278,7 @@ export default class KmqWebServer {
         httpServer.get(
             "/api/web/login",
             limit(ACTIVITY_RATE_LIMIT_TOKEN),
-            async (_request, reply) => {
+            async (request, reply) => {
                 if (!(await requireWebMode(reply))) return;
 
                 const baseUrl = webPublicBaseUrl();
@@ -2237,12 +2298,23 @@ export default class KmqWebServer {
                 }
 
                 const state = uuid.v4();
-                const now = Date.now();
-                for (const [key, expiresAt] of this.webOauthStates) {
-                    if (expiresAt <= now) this.webOauthStates.delete(key);
-                }
+                pruneExpired(this.webOauthStates);
 
-                this.webOauthStates.set(state, now + WEB_OAUTH_STATE_TTL_MS);
+                // Where to land after login. Restricted to in-site /play
+                // paths so the callback can't be used as an open redirect —
+                // this is how invite links survive the OAuth round-trip.
+                const rawNext = (request.query as { next?: string }).next;
+                const next =
+                    rawNext &&
+                    rawNext.startsWith("/play") &&
+                    !rawNext.startsWith("//")
+                        ? rawNext
+                        : "/play";
+
+                this.webOauthStates.set(state, {
+                    expiresAt: Date.now() + WEB_OAUTH_STATE_TTL_MS,
+                    next,
+                });
 
                 const params = new URLSearchParams({
                     client_id: process.env.BOT_CLIENT_ID,
@@ -2280,10 +2352,14 @@ export default class KmqWebServer {
                 );
 
                 const state = query.state;
+                const stateEntry = state
+                    ? this.webOauthStates.get(state)
+                    : undefined;
+
                 const stateValid =
                     !!state &&
                     cookieState === state &&
-                    (this.webOauthStates.get(state) ?? 0) > Date.now();
+                    (stateEntry?.expiresAt ?? 0) > Date.now();
 
                 if (state) this.webOauthStates.delete(state);
 
@@ -2369,8 +2445,10 @@ export default class KmqWebServer {
                         expiresAt: Date.now() + WEB_LOGIN_CODE_TTL_MS,
                     });
 
+                    const next = stateEntry?.next ?? "/play";
+                    const joiner = next.includes("?") ? "&" : "?";
                     await expireStateCookie().redirect(
-                        `/play?login_code=${encodeURIComponent(loginCode)}`,
+                        `${next}${joiner}login_code=${encodeURIComponent(loginCode)}`,
                     );
                 } catch (e) {
                     const err = e as {
@@ -2475,10 +2553,166 @@ export default class KmqWebServer {
                         );
                     }
 
+                    // A logged-out user can't hold a room seat.
+                    const cached = this.accessTokenCache.get(token);
+                    if (cached) {
+                        this.webRoomManager?.leaveRoom(cached.user.id);
+                    }
+
                     this.accessTokenCache.delete(token);
                 }
 
                 await reply.code(204).send();
+            },
+        );
+    }
+
+    /**
+     * Registers the standalone-website room routes (/api/web/room*): create/
+     * join/leave/read multiplayer rooms whose invite code doubles as the
+     * client's instance_id for every gameplay route. Gated behind the same
+     * webModeEnabled feature switch as the auth routes.
+     * @param httpServer - the fastify instance
+     * @param limit - per-route rate-limit config builder
+     */
+    private registerWebRoomRoutes(
+        httpServer: FastifyInstance,
+        limit: (max: number) => {
+            config: { rateLimit: { max: number; timeWindow: string } };
+        },
+    ): void {
+        // Resolves the requester or replies with the right error; returns
+        // null when a response has already been sent.
+        const requireWebUser = async (
+            request: any,
+            reply: any,
+        ): Promise<CachedDiscordUser | null> => {
+            if (!KmqConfiguration.Instance.webModeEnabled()) {
+                await reply.code(503).send({ error: "Web mode disabled" });
+                return null;
+            }
+
+            if (!this.webRoomManager) {
+                await reply.code(503).send({ error: "Rooms not enabled" });
+                return null;
+            }
+
+            const header = request.headers["authorization"] as
+                | string
+                | undefined;
+
+            const token = header?.startsWith("Bearer ")
+                ? header.slice(7)
+                : undefined;
+
+            const user = await this.resolveAccessToken(token);
+            if (!user) {
+                await reply.code(401).send({ error: "Unauthorized" });
+                return null;
+            }
+
+            return user;
+        };
+
+        httpServer.post(
+            "/api/web/room",
+            limit(ACTIVITY_RATE_LIMIT_LIFECYCLE),
+            async (request, reply) => {
+                const user = await requireWebUser(request, reply);
+                if (!user) return;
+
+                const result = this.webRoomManager!.createRoom({
+                    id: user.id,
+                    username: user.username,
+                    avatarUrl: user.avatarUrl,
+                });
+
+                if ("error" in result) {
+                    // Only possible when rejoining one's own still-alive room
+                    // that has since filled up.
+                    await reply.code(409).send({ error: result.error });
+                    return;
+                }
+
+                await reply.code(200).send({
+                    room: this.webRoomManager!.serializeRoom(result.room),
+                });
+            },
+        );
+
+        httpServer.post(
+            "/api/web/room/join",
+            limit(ACTIVITY_RATE_LIMIT_LIFECYCLE),
+            async (request, reply) => {
+                const user = await requireWebUser(request, reply);
+                if (!user) return;
+
+                const code = (request.body as { code?: string } | null)?.code;
+                if (!code || typeof code !== "string") {
+                    await reply.code(400).send({ error: "Missing code" });
+                    return;
+                }
+
+                const result = this.webRoomManager!.joinRoom(code, {
+                    id: user.id,
+                    username: user.username,
+                    avatarUrl: user.avatarUrl,
+                });
+
+                if ("error" in result) {
+                    await reply
+                        .code(result.error === "not_found" ? 404 : 409)
+                        .send({ error: result.error });
+                    return;
+                }
+
+                await reply.code(200).send({
+                    room: this.webRoomManager!.serializeRoom(result.room),
+                });
+            },
+        );
+
+        httpServer.post(
+            "/api/web/room/leave",
+            limit(ACTIVITY_RATE_LIMIT_LIFECYCLE),
+            async (request, reply) => {
+                const user = await requireWebUser(request, reply);
+                if (!user) return;
+
+                this.webRoomManager!.leaveRoom(user.id);
+                await reply.code(204).send();
+            },
+        );
+
+        httpServer.get(
+            "/api/web/room",
+            limit(ACTIVITY_RATE_LIMIT_READ),
+            async (request, reply) => {
+                const user = await requireWebUser(request, reply);
+                if (!user) return;
+
+                // With ?code=, read that room (members only — the code is
+                // the room's bearer capability, but presence/usernames still
+                // shouldn't leak to non-members probing codes). Without it,
+                // resolve the requester's current room for reconnects.
+                const code = (request.query as { code?: string }).code;
+                const room = code
+                    ? this.webRoomManager!.getRoomByCode(code)
+                    : this.webRoomManager!.getRoomForUser(user.id);
+
+                if (!room) {
+                    await reply.code(404).send({ error: "No room" });
+                    return;
+                }
+
+                if (!room.members.has(user.id)) {
+                    await reply.code(403).send({ error: "Not a member" });
+                    return;
+                }
+
+                await reply.code(200).send({
+                    room: this.webRoomManager!.serializeRoom(room),
+                });
             },
         );
     }

--- a/src/migrations/2026-07-08T00:00:00.000Z-web-sessions.ts
+++ b/src/migrations/2026-07-08T00:00:00.000Z-web-sessions.ts
@@ -1,0 +1,32 @@
+import { Kysely, sql } from "kysely";
+import { KmqDB } from "../typings/kmq_db";
+
+export async function up(db: Kysely<KmqDB>): Promise<void> {
+    await db.schema
+        .createTable("web_sessions")
+        .addColumn("token_hash", "char(64)", (col) => col.primaryKey())
+        .addColumn("user_id", "varchar(255)", (col) => col.notNull())
+        .addColumn("username", "varchar(255)", (col) => col.notNull())
+        .addColumn("avatar_url", "varchar(512)")
+        .addColumn("locale", "varchar(16)", (col) =>
+            col.notNull().defaultTo(""),
+        )
+        .addColumn("created_at", "datetime", (col) =>
+            col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+        )
+        .addColumn("expires_at", "datetime", (col) => col.notNull())
+        .addColumn("last_used_at", "datetime", (col) =>
+            col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+        )
+        .execute();
+
+    await db.schema
+        .createIndex("web_sessions_user_id")
+        .on("web_sessions")
+        .column("user_id")
+        .execute();
+}
+
+export async function down(db: Kysely<KmqDB>): Promise<void> {
+    await db.schema.dropTable("web_sessions").execute();
+}

--- a/src/structures/activity_bridge.ts
+++ b/src/structures/activity_bridge.ts
@@ -13,10 +13,14 @@ import {
 import { IPCLogger } from "../logger";
 import {
     botHasVoicePermissions,
-    getMajorityCount,
     getUserVoiceChannelID,
     searchArtists,
 } from "../helpers/discord_utils";
+import {
+    clearWebRoomMembers,
+    getWebRoomMembers,
+    setWebRoomMembers,
+} from "./web_room_state";
 import { onGuildPreferenceChanged } from "../helpers/guild_preference_events";
 import { parseKmqPlaylistIdentifier } from "../helpers/utils";
 import { songTagEmojisToUnicode } from "../helpers/game_utils";
@@ -46,6 +50,7 @@ import Session from "./session";
 import SkipCommand from "../commands/game_commands/skip";
 import SongSelector from "./song_selector";
 import State from "../state";
+import WebGameSession from "./web_game_session";
 import type { ActivityMultipleChoiceOption } from "../interfaces/activity_round_meta";
 import type ActivityAutocompleteArtistsArgs from "../interfaces/activity_autocomplete_artists_args";
 import type ActivityAutocompleteArtistsResponse from "../interfaces/activity_autocomplete_artists_response";
@@ -75,6 +80,7 @@ import type ActivitySongInfoArgs from "../interfaces/activity_song_info_args";
 import type ActivitySongInfoResponse from "../interfaces/activity_song_info_response";
 import type ActivityStartGameArgs from "../interfaces/activity_start_game_args";
 import type ActivityUserActionArgs from "../interfaces/activity_user_action_args";
+import type ActivityWebRoomMembershipArgs from "../interfaces/activity_web_room_membership_args";
 import type GameSessionRecap from "../interfaces/game_session_recap";
 import type MatchedArtist from "../interfaces/matched_artist";
 import type Player from "./player";
@@ -316,6 +322,21 @@ function userInVoiceChannel(
     return getUserVoiceChannelID(guildID, userID) === voiceChannelID;
 }
 
+/**
+ * Transport-aware participation guard: web sessions check pushed room
+ * membership, Discord sessions check the session's voice channel.
+ * @param session - the session the user is acting on
+ * @param userID - the acting user
+ * @returns whether the user may act in the session
+ */
+function userCanActInSession(session: Session, userID: string): boolean {
+    if (session.isWebSession()) {
+        return getWebRoomMembers(session.guildID).some((m) => m.id === userID);
+    }
+
+    return userInVoiceChannel(session.guildID, userID, session.voiceChannelID);
+}
+
 // Per-user emote cooldown, keyed by `${guildID}:${userID}`. Module-scoped so it
 // persists across requests within the worker; bounded by natural churn (one
 // entry per recently-active emoter).
@@ -516,13 +537,7 @@ function ensureWorkerHandlerRegistered(): void {
                         return;
                     }
 
-                    if (
-                        !userInVoiceChannel(
-                            guessArgs.guildID,
-                            guessArgs.userID,
-                            session.voiceChannelID,
-                        )
-                    ) {
+                    if (!userCanActInSession(session, guessArgs.userID)) {
                         reply({ ok: false, reason: "not_in_vc" });
                         return;
                     }
@@ -581,13 +596,7 @@ function ensureWorkerHandlerRegistered(): void {
                         return;
                     }
 
-                    if (
-                        !userInVoiceChannel(
-                            mcArgs.guildID,
-                            mcArgs.userID,
-                            session.voiceChannelID,
-                        )
-                    ) {
+                    if (!userCanActInSession(session, mcArgs.userID)) {
                         reply({ ok: false, reason: "not_in_vc" });
                         return;
                     }
@@ -679,33 +688,57 @@ function ensureWorkerHandlerRegistered(): void {
                             return;
                         }
 
-                        // Start the game in the channel the caller is actually
-                        // connected to — NOT startArgs.voiceChannelID, which is
-                        // where the activity was launched (it can be a text
-                        // channel, or a VC the user later left/changed). The
-                        // activity can be opened without joining voice, so being
-                        // a Discord participant isn't enough.
-                        const startVoiceChannelID = getUserVoiceChannelID(
-                            startArgs.guildID,
-                            startArgs.userID,
-                        );
+                        const isWebStart = startArgs.mode === "web";
+                        let startVoiceChannelID = "";
+                        if (isWebStart) {
+                            // Web rooms have no VC; seed the membership
+                            // mirror from the args so the very first round
+                            // sees its participants.
+                            setWebRoomMembers(
+                                startArgs.guildID,
+                                startArgs.members ?? [],
+                            );
 
-                        if (!startVoiceChannelID) {
-                            reply({ ok: false, reason: "not_in_vc" });
-                            return;
-                        }
+                            if (
+                                !getWebRoomMembers(startArgs.guildID).some(
+                                    (m) => m.id === startArgs.userID,
+                                )
+                            ) {
+                                reply({ ok: false, reason: "not_in_vc" });
+                                return;
+                            }
+                        } else {
+                            // Start the game in the channel the caller is
+                            // actually connected to — NOT
+                            // startArgs.voiceChannelID, which is where the
+                            // activity was launched (it can be a text channel,
+                            // or a VC the user later left/changed). The
+                            // activity can be opened without joining voice, so
+                            // being a Discord participant isn't enough.
+                            const userVoiceChannelID = getUserVoiceChannelID(
+                                startArgs.guildID,
+                                startArgs.userID,
+                            );
 
-                        // ...and the bot must be able to join that channel.
-                        if (!botHasVoicePermissions(startVoiceChannelID)) {
-                            reply({
-                                ok: false,
-                                reason: "bot_no_voice_perms",
-                            });
-                            return;
+                            if (!userVoiceChannelID) {
+                                reply({ ok: false, reason: "not_in_vc" });
+                                return;
+                            }
+
+                            // ...and the bot must be able to join that channel.
+                            if (!botHasVoicePermissions(userVoiceChannelID)) {
+                                reply({
+                                    ok: false,
+                                    reason: "bot_no_voice_perms",
+                                });
+                                return;
+                            }
+
+                            startVoiceChannelID = userVoiceChannelID;
                         }
 
                         const messageContext = new MessageContext(
-                            startArgs.textChannelID,
+                            isWebStart ? "" : startArgs.textChannelID,
                             new KmqMember(startArgs.userID),
                             startArgs.guildID,
                         );
@@ -731,23 +764,41 @@ function ensureWorkerHandlerRegistered(): void {
                             // slash command's default `new_clip` is false, but
                             // for the lobby-less Activity a new song per round
                             // matches every other mode's behaviour).
-                            const gameSession = new GameSession(
-                                guildPreference,
-                                startArgs.textChannelID,
-                                startVoiceChannelID,
-                                startArgs.guildID,
-                                gameOwner,
-                                startArgs.gameType,
-                                startArgs.gameType === GameType.ELIMINATION
-                                    ? startArgs.eliminationLives
-                                    : undefined,
-                                startArgs.gameType === GameType.CLIP
-                                    ? startArgs.clipDuration
-                                    : undefined,
-                                startArgs.gameType === GameType.CLIP
-                                    ? true
-                                    : undefined,
-                            );
+                            const gameSession = isWebStart
+                                ? new WebGameSession(
+                                      guildPreference,
+                                      startArgs.guildID,
+                                      gameOwner,
+                                      startArgs.gameType,
+                                      startArgs.gameType ===
+                                          GameType.ELIMINATION
+                                          ? startArgs.eliminationLives
+                                          : undefined,
+                                      startArgs.gameType === GameType.CLIP
+                                          ? startArgs.clipDuration
+                                          : undefined,
+                                      startArgs.gameType === GameType.CLIP
+                                          ? true
+                                          : undefined,
+                                  )
+                                : new GameSession(
+                                      guildPreference,
+                                      startArgs.textChannelID,
+                                      startVoiceChannelID,
+                                      startArgs.guildID,
+                                      gameOwner,
+                                      startArgs.gameType,
+                                      startArgs.gameType ===
+                                          GameType.ELIMINATION
+                                          ? startArgs.eliminationLives
+                                          : undefined,
+                                      startArgs.gameType === GameType.CLIP
+                                          ? startArgs.clipDuration
+                                          : undefined,
+                                      startArgs.gameType === GameType.CLIP
+                                          ? true
+                                          : undefined,
+                                  );
 
                             // Swap out any stale non-initialized session
                             // (mirrors the slash-command path).
@@ -812,13 +863,7 @@ function ensureWorkerHandlerRegistered(): void {
                             return;
                         }
 
-                        if (
-                            !userInVoiceChannel(
-                                skipArgs.guildID,
-                                skipArgs.userID,
-                                session.voiceChannelID,
-                            )
-                        ) {
+                        if (!userCanActInSession(session, skipArgs.userID)) {
                             reply({ ok: false, reason: "not_in_vc" });
                             return;
                         }
@@ -835,7 +880,7 @@ function ensureWorkerHandlerRegistered(): void {
                             // After the await, the round may have transitioned
                             // (skipped or naturally ended). Compare by identity.
                             const currentRound = session.round;
-                            const threshold = getMajorityCount(session.guildID);
+                            const threshold = session.getVoteMajorityCount();
 
                             if (currentRound === originalRound) {
                                 pushEvent(session.guildID, {
@@ -888,13 +933,7 @@ function ensureWorkerHandlerRegistered(): void {
                             return;
                         }
 
-                        if (
-                            !userInVoiceChannel(
-                                hintArgs.guildID,
-                                hintArgs.userID,
-                                session.voiceChannelID,
-                            )
-                        ) {
+                        if (!userCanActInSession(session, hintArgs.userID)) {
                             reply({ ok: false, reason: "not_in_vc" });
                             return;
                         }
@@ -920,7 +959,7 @@ function ensureWorkerHandlerRegistered(): void {
                             }
 
                             const requesters = currentRound.getHintRequests();
-                            const threshold = getMajorityCount(session.guildID);
+                            const threshold = session.getVoteMajorityCount();
 
                             pushEvent(session.guildID, {
                                 type: "hintProgress",
@@ -983,13 +1022,7 @@ function ensureWorkerHandlerRegistered(): void {
                         return;
                     }
 
-                    if (
-                        !userInVoiceChannel(
-                            emoteArgs.guildID,
-                            emoteArgs.userID,
-                            session.voiceChannelID,
-                        )
-                    ) {
+                    if (!userCanActInSession(session, emoteArgs.userID)) {
                         reply({ ok: false, reason: "not_in_vc" });
                         return;
                     }
@@ -1047,11 +1080,7 @@ function ensureWorkerHandlerRegistered(): void {
                         const session = Session.getSession(optionArgs.guildID);
                         if (
                             session &&
-                            !userInVoiceChannel(
-                                optionArgs.guildID,
-                                optionArgs.userID,
-                                session.voiceChannelID,
-                            )
+                            !userCanActInSession(session, optionArgs.userID)
                         ) {
                             reply({ ok: false, reason: "not_in_vc" });
                             return;
@@ -1433,13 +1462,7 @@ function ensureWorkerHandlerRegistered(): void {
                         // Any member of the game's voice channel may end it
                         // (matches the relaxed /end command, which has no owner
                         // check) — but they must actually be in that channel.
-                        if (
-                            !userInVoiceChannel(
-                                endArgs.guildID,
-                                endArgs.userID,
-                                session.voiceChannelID,
-                            )
-                        ) {
+                        if (!userCanActInSession(session, endArgs.userID)) {
                             reply({ ok: false, reason: "not_in_vc" });
                             return;
                         }
@@ -1459,6 +1482,56 @@ function ensureWorkerHandlerRegistered(): void {
                             );
                             reply({ ok: false, reason: "internal" });
                         }
+                    });
+                    return;
+                }
+
+                case "webRoomMembership": {
+                    const memberArgs = args as ActivityWebRoomMembershipArgs;
+                    const reply = (payload: ActivityGuessResponse): void => {
+                        State.ipc.sendToAdmiral(ACTIVITY_IPC_REPLY, {
+                            cid,
+                            payload,
+                        });
+                    };
+
+                    runLocked(memberArgs.guildID, async () => {
+                        const session = Session.getSession(memberArgs.guildID);
+
+                        // Empty membership = the room closed (or its last
+                        // member timed out); tear the game down.
+                        if (memberArgs.members.length === 0) {
+                            clearWebRoomMembers(memberArgs.guildID);
+                            if (session && !session.finished) {
+                                await session.endSession(
+                                    "Web room closed",
+                                    false,
+                                );
+                            }
+
+                            reply({ ok: true });
+                            return;
+                        }
+
+                        setWebRoomMembers(
+                            memberArgs.guildID,
+                            memberArgs.members,
+                        );
+
+                        // The web analog of the voiceChannelJoin/Leave
+                        // handlers: keep the scoreboard's in/out flags and
+                        // the owner in step with the room.
+                        if (
+                            session &&
+                            !session.finished &&
+                            session.isWebSession() &&
+                            session.isGameSession()
+                        ) {
+                            await session.syncAllVoiceMembers();
+                            await session.updateOwner();
+                        }
+
+                        reply({ ok: true });
                     });
                     return;
                 }
@@ -1485,11 +1558,7 @@ function ensureWorkerHandlerRegistered(): void {
 
                     if (
                         presetSession &&
-                        !userInVoiceChannel(
-                            presetArgs.guildID,
-                            presetArgs.userID,
-                            presetSession.voiceChannelID,
-                        )
+                        !userCanActInSession(presetSession, presetArgs.userID)
                     ) {
                         reply({ ok: false, reason: "not_in_vc" });
                         return;
@@ -1893,6 +1962,20 @@ export function attachActivityBridge(session: GameSession): void {
             choices: payload.choices,
         });
     });
+
+    // Web sessions only: the playback spec for the round's audio. The hub
+    // intercepts this, mints an opaque streaming token, and fans out a
+    // client-safe audio URL — the spec itself (which names the song) must
+    // never reach clients before the reveal.
+    session.on(
+        "roundAudio",
+        (payload: Omit<ActivityEvent & { type: "roundAudio" }, "type">) => {
+            pushEvent(guildID, {
+                type: "roundAudio",
+                ...payload,
+            });
+        },
+    );
 
     // Shared identity lookup. KmqMember instances on round results are bare
     // (id only); names come from the scoreboard's Player objects (populated

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -17,11 +17,8 @@ import {
 import {
     clickableSlashCommand,
     fetchUser,
-    getCurrentVoiceMembers,
     getDebugLogHeader,
     getGameInfoMessage,
-    getMajorityCount,
-    getNumParticipants,
     getUserVoiceChannel,
     sendInfoMessage,
     sendPaginationedEmbed,
@@ -355,9 +352,8 @@ export default class GameSession extends Session {
         createdAt: number,
     ): Promise<void> {
         // Allow clip mode guesses in between clip replays
-        if (!this.isClipMode()) {
-            if (!this.connection) return;
-            if (this.connection.listenerCount("end") === 0) return;
+        if (!this.isClipMode() && !this.isPlaybackActive()) {
+            return;
         }
 
         if (!this.round) return;
@@ -437,13 +433,7 @@ export default class GameSession extends Session {
             // If hidden or multiple choice, everyone guessed and no one was right
             if (
                 setDifference(
-                    [
-                        ...new Set(
-                            getCurrentVoiceMembers(this.voiceChannelID).map(
-                                (x) => x.id,
-                            ),
-                        ),
-                    ],
+                    [...new Set(this.getParticipantIDs())],
                     [...incorrectGuessers],
                 ).size === 0
             ) {
@@ -495,11 +485,12 @@ export default class GameSession extends Session {
             return;
         }
 
-        const voiceMembers = getCurrentVoiceMembers(this.voiceChannelID).filter(
-            (x) => x.id !== process.env.BOT_CLIENT_ID,
+        const voiceMemberIDs = new Set(
+            this.getParticipantIDs().filter(
+                (x) => x !== process.env.BOT_CLIENT_ID,
+            ),
         );
 
-        const voiceMemberIDs = new Set(voiceMembers.map((x) => x.id));
         if (voiceMemberIDs.has(this.owner.id) || voiceMemberIDs.size === 0) {
             return;
         }
@@ -557,9 +548,7 @@ export default class GameSession extends Session {
                         guildID,
                         "command.skip.success.description",
                         {
-                            skipCounter: `${round.getSkipCount()}/${getMajorityCount(
-                                guildID,
-                            )}`,
+                            skipCounter: `${round.getSkipCount()}/${this.getVoteMajorityCount()}`,
                         },
                     ),
                 );
@@ -571,9 +560,7 @@ export default class GameSession extends Session {
                     interaction,
                     i18n.translate(guildID, "command.skip.vote.title"),
                     i18n.translate(guildID, "command.skip.vote.description", {
-                        skipCounter: `${round.getSkipCount()}/${getMajorityCount(
-                            guildID,
-                        )}`,
+                        skipCounter: `${round.getSkipCount()}/${this.getVoteMajorityCount()}`,
                     }),
                 );
 
@@ -754,9 +741,7 @@ export default class GameSession extends Session {
      * Sequential iteration prevents concurrent addPlayer/setPlayerInVC interleaving.
      */
     async syncAllVoiceMembers(): Promise<void> {
-        const currentVoiceMemberIds = getCurrentVoiceMembers(
-            this.voiceChannelID,
-        ).map((x) => x.id);
+        const currentVoiceMemberIds = this.getParticipantIDs();
 
         const departedPlayers = this.scoreboard
             .getPlayerIDs()
@@ -779,7 +764,14 @@ export default class GameSession extends Session {
             // eslint-disable-next-line no-await-in-loop
             const firstGameOfDay = await isFirstGameOfDay(playerId);
             // eslint-disable-next-line no-await-in-loop
-            const player = (await fetchUser(playerId)) as Eris.User;
+            const player = await fetchUser(playerId);
+            if (!player) {
+                logger.warn(
+                    `gid: ${this.guildID} | Couldn't fetch user ${playerId} for scoreboard, skipping`,
+                );
+                continue;
+            }
+
             this.scoreboard.addPlayer(
                 this.gameType === GameType.ELIMINATION
                     ? EliminationPlayer.fromUser(
@@ -1778,14 +1770,7 @@ export default class GameSession extends Session {
         messageContext: MessageContext,
         createdAt: number,
     ): boolean {
-        const userVoiceChannel = getUserVoiceChannel(messageContext);
-        // if user isn't in the same voice channel
-        if (!userVoiceChannel || userVoiceChannel.id !== this.voiceChannelID) {
-            return false;
-        }
-
-        // if message isn't in the active game session's text channel
-        if (messageContext.textChannelID !== this.textChannelID) {
+        if (!this.guesserInSessionChannels(messageContext)) {
             return false;
         }
 
@@ -2198,8 +2183,32 @@ export default class GameSession extends Session {
         return expBase + expJitter;
     }
 
+    /**
+     * Transport hook: whether the guesser is in the session's channels
+     * (Discord: same voice + text channel; web: a room member).
+     * @param messageContext - The context of the guess
+     * @returns whether the guess comes from inside the session
+     */
+    // eslint-disable-next-line @typescript-eslint/member-ordering
+    protected guesserInSessionChannels(
+        messageContext: MessageContext,
+    ): boolean {
+        const userVoiceChannel = getUserVoiceChannel(messageContext);
+        // if user isn't in the same voice channel
+        if (!userVoiceChannel || userVoiceChannel.id !== this.voiceChannelID) {
+            return false;
+        }
+
+        // if message isn't in the active game session's text channel
+        if (messageContext.textChannelID !== this.textChannelID) {
+            return false;
+        }
+
+        return true;
+    }
+
     private multiguessDelayIsActive(guildPreference: GuildPreference): boolean {
-        const playerIsAlone = getNumParticipants(this.voiceChannelID) === 1;
+        const playerIsAlone = this.getParticipantCount() === 1;
         return (
             guildPreference.gameOptions.multiGuessType === MultiGuessType.ON &&
             !playerIsAlone &&
@@ -2224,7 +2233,7 @@ export default class GameSession extends Session {
                 const expGain = await ExpCommand.calculateTotalRoundExp(
                     guildPreference,
                     round,
-                    getNumParticipants(this.voiceChannelID),
+                    this.getParticipantCount(),
                     idx === 0 ? lastGuesserStreak : 0,
                     round.getTimeToGuessMs(correctGuesser.id, isHidden),
                     guessPosition,

--- a/src/structures/game_session.ts
+++ b/src/structures/game_session.ts
@@ -31,6 +31,7 @@ import {
     isFirstGameOfDay,
     userBonusIsActive,
 } from "../helpers/game_utils";
+import { isGuestUserID } from "../helpers/web_session_manager";
 import State from "../state";
 import dbContext from "../database_context";
 
@@ -708,29 +709,39 @@ export default class GameSession extends Session {
      * @param inVC - Whether the player is currently in the voice channel
      */
     async setPlayerInVC(userID: string, inVC: boolean): Promise<void> {
-        const user = await fetchUser(userID);
         if (
             inVC &&
             !this.scoreboard.getPlayerIDs().includes(userID) &&
             this.gameType !== GameType.TEAMS
         ) {
-            this.scoreboard.addPlayer(
-                this.gameType === GameType.ELIMINATION
-                    ? EliminationPlayer.fromUser(
-                          user as Eris.User,
-                          this.guildID,
-                          (
-                              this.scoreboard as EliminationScoreboard
-                          ).getLivesOfWeakestPlayer(),
-                          await isFirstGameOfDay(userID),
-                      )
-                    : Player.fromUser(
-                          user as Eris.User,
-                          this.guildID,
-                          0,
-                          await isFirstGameOfDay(userID),
-                      ),
-            );
+            const profile = await this.resolveParticipantProfile(userID);
+            if (!profile) {
+                logger.warn(
+                    `gid: ${this.guildID} | Couldn't resolve participant ${userID} for scoreboard, skipping`,
+                );
+            } else {
+                this.scoreboard.addPlayer(
+                    this.gameType === GameType.ELIMINATION
+                        ? new EliminationPlayer(
+                              userID,
+                              this.guildID,
+                              profile.avatarUrl,
+                              (
+                                  this.scoreboard as EliminationScoreboard
+                              ).getLivesOfWeakestPlayer(),
+                              profile.username,
+                              await isFirstGameOfDay(userID),
+                          )
+                        : new Player(
+                              userID,
+                              this.guildID,
+                              profile.avatarUrl,
+                              0,
+                              profile.username,
+                              await isFirstGameOfDay(userID),
+                          ),
+                );
+            }
         }
 
         this.scoreboard.setInVC(userID, inVC);
@@ -764,24 +775,33 @@ export default class GameSession extends Session {
             // eslint-disable-next-line no-await-in-loop
             const firstGameOfDay = await isFirstGameOfDay(playerId);
             // eslint-disable-next-line no-await-in-loop
-            const player = await fetchUser(playerId);
-            if (!player) {
+            const profile = await this.resolveParticipantProfile(playerId);
+            if (!profile) {
                 logger.warn(
-                    `gid: ${this.guildID} | Couldn't fetch user ${playerId} for scoreboard, skipping`,
+                    `gid: ${this.guildID} | Couldn't resolve participant ${playerId} for scoreboard, skipping`,
                 );
                 continue;
             }
 
             this.scoreboard.addPlayer(
                 this.gameType === GameType.ELIMINATION
-                    ? EliminationPlayer.fromUser(
-                          player,
+                    ? new EliminationPlayer(
+                          playerId,
                           this.guildID,
+                          profile.avatarUrl,
                           (this.scoreboard as EliminationScoreboard)
                               .startingLives,
+                          profile.username,
                           firstGameOfDay,
                       )
-                    : Player.fromUser(player, this.guildID, 0, firstGameOfDay),
+                    : new Player(
+                          playerId,
+                          this.guildID,
+                          profile.avatarUrl,
+                          0,
+                          profile.username,
+                          firstGameOfDay,
+                      ),
             );
         }
     }
@@ -1060,6 +1080,23 @@ export default class GameSession extends Session {
     /** @returns if clip mode is active */
     isClipMode(): boolean {
         return this.gameType === GameType.CLIP;
+    }
+
+    /**
+     * Transport hook: resolves a participant's display identity for the
+     * scoreboard. Discord fetches the user; web sessions read the pushed
+     * room membership instead (whose guest members carry synthetic IDs that
+     * don't exist on Discord at all).
+     * @param userID - the participant to resolve
+     * @returns the identity, or null when unresolvable (player is skipped)
+     */
+    protected async resolveParticipantProfile(
+        userID: string,
+    ): Promise<{ username: string; avatarUrl: string | null } | null> {
+        const user = await fetchUser(userID);
+        return user
+            ? { username: user.username, avatarUrl: user.avatarURL }
+            : null;
     }
 
     /**
@@ -2093,56 +2130,63 @@ export default class GameSession extends Session {
             return [];
         }
 
-        // commit player stats
+        // commit player stats — except for website guests, whose synthetic
+        // IDs are orphaned on logout: persisting them would only pollute the
+        // per-player tables (player_stats, player_servers, per-session
+        // leaderboards) with rows no one can ever log back into. Their score
+        // and EXP live in the in-memory scoreboard for the session only.
         await Promise.allSettled(
-            this.scoreboard.getPlayerIDs().map(async (participant) => {
-                const isFirstGame = await isFirstGameOfDay(participant);
-                await this.ensurePlayerStat(participant);
-                await this.incrementPlayerGamesPlayed(participant);
-                const playerCorrectGuessCount =
-                    this.scoreboard.getPlayerCorrectGuessCount(participant);
+            this.scoreboard
+                .getPlayerIDs()
+                .filter((participant) => !isGuestUserID(participant))
+                .map(async (participant) => {
+                    const isFirstGame = await isFirstGameOfDay(participant);
+                    await this.ensurePlayerStat(participant);
+                    await this.incrementPlayerGamesPlayed(participant);
+                    const playerCorrectGuessCount =
+                        this.scoreboard.getPlayerCorrectGuessCount(participant);
 
-                if (playerCorrectGuessCount > 0) {
-                    await this.incrementPlayerSongsGuessed(
+                    if (playerCorrectGuessCount > 0) {
+                        await this.incrementPlayerSongsGuessed(
+                            participant,
+                            playerCorrectGuessCount,
+                        );
+                    }
+
+                    const playerExpGain =
+                        this.scoreboard.getPlayerExpGain(participant);
+
+                    let levelUpResult: LevelUpResult | null = null;
+                    if (playerExpGain > 0) {
+                        levelUpResult = await this.incrementPlayerExp(
+                            participant,
+                            playerExpGain,
+                        );
+                        if (levelUpResult) {
+                            leveledUpPlayers.push(levelUpResult);
+                        }
+                    }
+
+                    await this.insertPerSessionStats(
                         participant,
                         playerCorrectGuessCount,
-                    );
-                }
-
-                const playerExpGain =
-                    this.scoreboard.getPlayerExpGain(participant);
-
-                let levelUpResult: LevelUpResult | null = null;
-                if (playerExpGain > 0) {
-                    levelUpResult = await this.incrementPlayerExp(
-                        participant,
                         playerExpGain,
+                        levelUpResult
+                            ? levelUpResult.endLevel - levelUpResult.startLevel
+                            : 0,
                     );
-                    if (levelUpResult) {
-                        leveledUpPlayers.push(levelUpResult);
-                    }
-                }
 
-                await this.insertPerSessionStats(
-                    participant,
-                    playerCorrectGuessCount,
-                    playerExpGain,
-                    levelUpResult
-                        ? levelUpResult.endLevel - levelUpResult.startLevel
-                        : 0,
-                );
-
-                // if game ended erroneously during player's FGOTD, mark it as errored to allow
-                // for bonus to continue next game
-                await dbContext.kmq
-                    .updateTable("player_stats")
-                    .where("player_id", "=", participant)
-                    .set({
-                        last_game_played_errored:
-                            isFirstGame && endedDueToError ? 1 : 0,
-                    })
-                    .execute();
-            }),
+                    // if game ended erroneously during player's FGOTD, mark it as errored to allow
+                    // for bonus to continue next game
+                    await dbContext.kmq
+                        .updateTable("player_stats")
+                        .where("player_id", "=", participant)
+                        .set({
+                            last_game_played_errored:
+                                isFirstGame && endedDueToError ? 1 : 0,
+                        })
+                        .execute();
+                }),
         );
 
         return leveledUpPlayers;

--- a/src/structures/session.ts
+++ b/src/structures/session.ts
@@ -17,6 +17,7 @@ import {
     getAverageVolume,
     getCurrentVoiceMembers,
     getDebugLogHeader,
+    getMajorityCount,
     sendBookmarkedSongs,
     sendErrorMessage,
     sendInfoMessage,
@@ -58,10 +59,26 @@ import type KmqMember from "./kmq_member";
 import type ListeningSession from "./listening_session";
 import type QueriedSong from "./queried_song";
 import type Round from "./round";
+import type SpecialType from "../enums/option_types/special_type";
 
 import { SessionState, SessionStateMachine } from "./session_state";
 
 const logger = new IPCLogger("session");
+
+/**
+ * The fully resolved audio parameters for one playback, as computed by
+ * playSong: everything a transport needs to actually produce sound (Discord:
+ * ffmpeg args into the voice connection; web: an audio stream spec).
+ */
+export interface PlaybackSpec {
+    songLocation: string;
+    seekLocation: number;
+    songDuration: number;
+    inputArgs: string[];
+    encoderArgs: { [arg: string]: Array<string> };
+    isClipMode: boolean;
+    specialType: SpecialType | null;
+}
 
 export default abstract class Session extends EventEmitter {
     /** The ID of text channel in which the Session was started in, and will be active in */
@@ -303,86 +320,7 @@ export default abstract class Session extends EventEmitter {
         const round = this.prepareRound(randomSong);
         this.round = round;
 
-        const voiceChannel = State.client.getChannel(
-            this.voiceChannelID,
-        ) as Eris.VoiceChannel | null;
-
-        if (!voiceChannel || voiceChannel.voiceMembers.size === 0) {
-            await this.endSessionFromLifecycle(
-                "Voice channel is empty, during startRound",
-                false,
-            );
-            return null;
-        }
-
-        // join voice channel and start round
-        try {
-            await this.ensureVoiceConnection(State.client);
-            // TODO: fix status update
-            // if (!voiceChannel.status) {
-            //     try {
-            //         await State.client.setVoiceChannelStatus(
-            //             this.voiceChannelID,
-            //             KMQ_EMOJI,
-            //         );
-            //     } catch (e) {
-            //         logger.debug(
-            //             `${getDebugLogHeader(messageContext)} Couldn't set voice channel status for ${voiceChannel.id}. e = ${e}`,
-            //         );
-            //     }
-            // }
-        } catch (err) {
-            await this.endSessionFromLifecycle(
-                "Unable to obtain voice connection",
-                true,
-            );
-            if (err instanceof Error) {
-                const knownErrorStrings = [
-                    "Voice connection timeout",
-                    "Disconnected",
-                    "Insufficient permission to connect to voice channel",
-                ];
-
-                let isError = true;
-                if (
-                    knownErrorStrings.some((x) =>
-                        (err as Error).message.includes(x),
-                    )
-                ) {
-                    isError = false;
-                }
-
-                if (isError) {
-                    logger.error(
-                        `${getDebugLogHeader(
-                            messageContext,
-                        )} | Error obtaining voice connection. err = ${extractErrorString(err)}`,
-                    );
-                } else {
-                    logger.warn(
-                        `${getDebugLogHeader(
-                            messageContext,
-                        )} | Error obtaining voice connection. err = ${extractErrorString(err)}`,
-                    );
-                }
-            } else {
-                logger.error(
-                    `${getDebugLogHeader(
-                        messageContext,
-                    )} | Error obtaining voice connection. Unexpected error type. err = ${err.toString()}`,
-                );
-            }
-
-            await sendErrorMessage(messageContext, {
-                title: i18n.translate(
-                    this.guildID,
-                    "misc.failure.vcJoin.title",
-                ),
-                description: i18n.translate(
-                    this.guildID,
-                    "misc.failure.vcJoin.description",
-                ),
-            });
+        if (!(await this.preparePlaybackChannel(messageContext))) {
             return null;
         }
 
@@ -790,6 +728,128 @@ export default abstract class Session extends EventEmitter {
      */
     protected abstract prepareRound(randomSong: QueriedSong): Round;
 
+    /** @returns whether this session plays to a web room instead of a Discord VC */
+    // eslint-disable-next-line @typescript-eslint/member-ordering
+    isWebSession(): boolean {
+        return false;
+    }
+
+    /**
+     * Transport hook: the users participating in this session (Discord: VC
+     * members, bots and banned players excluded; web: room members).
+     * @returns participant user IDs
+     */
+    protected getParticipantIDs(): string[] {
+        return getCurrentVoiceMembers(this.voiceChannelID).map((x) => x.id);
+    }
+
+    /** @returns the number of session participants */
+    protected getParticipantCount(): number {
+        return this.getParticipantIDs().length;
+    }
+
+    /** @returns votes needed for a skip/hint to pass (majority of participants) */
+    // eslint-disable-next-line @typescript-eslint/member-ordering
+    getVoteMajorityCount(): number {
+        return getMajorityCount(this.guildID);
+    }
+
+    /**
+     * Transport hook: readies the playback channel before a round starts
+     * (Discord: requires a non-empty VC and joins it). On failure the session
+     * has already been ended / the error reported.
+     * @param messageContext - An object containing relevant parts of Eris.Message
+     * @returns whether the round may proceed
+     */
+    protected async preparePlaybackChannel(
+        messageContext: MessageContext,
+    ): Promise<boolean> {
+        const voiceChannel = State.client.getChannel(
+            this.voiceChannelID,
+        ) as Eris.VoiceChannel | null;
+
+        if (!voiceChannel || voiceChannel.voiceMembers.size === 0) {
+            await this.endSessionFromLifecycle(
+                "Voice channel is empty, during startRound",
+                false,
+            );
+            return false;
+        }
+
+        // join voice channel and start round
+        try {
+            await this.ensureVoiceConnection(State.client);
+            // TODO: fix status update
+            // if (!voiceChannel.status) {
+            //     try {
+            //         await State.client.setVoiceChannelStatus(
+            //             this.voiceChannelID,
+            //             KMQ_EMOJI,
+            //         );
+            //     } catch (e) {
+            //         logger.debug(
+            //             `${getDebugLogHeader(messageContext)} Couldn't set voice channel status for ${voiceChannel.id}. e = ${e}`,
+            //         );
+            //     }
+            // }
+        } catch (err) {
+            await this.endSessionFromLifecycle(
+                "Unable to obtain voice connection",
+                true,
+            );
+            if (err instanceof Error) {
+                const knownErrorStrings = [
+                    "Voice connection timeout",
+                    "Disconnected",
+                    "Insufficient permission to connect to voice channel",
+                ];
+
+                let isError = true;
+                if (
+                    knownErrorStrings.some((x) =>
+                        (err as Error).message.includes(x),
+                    )
+                ) {
+                    isError = false;
+                }
+
+                if (isError) {
+                    logger.error(
+                        `${getDebugLogHeader(
+                            messageContext,
+                        )} | Error obtaining voice connection. err = ${extractErrorString(err)}`,
+                    );
+                } else {
+                    logger.warn(
+                        `${getDebugLogHeader(
+                            messageContext,
+                        )} | Error obtaining voice connection. err = ${extractErrorString(err)}`,
+                    );
+                }
+            } else {
+                logger.error(
+                    `${getDebugLogHeader(
+                        messageContext,
+                    )} | Error obtaining voice connection. Unexpected error type. err = ${err.toString()}`,
+                );
+            }
+
+            await sendErrorMessage(messageContext, {
+                title: i18n.translate(
+                    this.guildID,
+                    "misc.failure.vcJoin.title",
+                ),
+                description: i18n.translate(
+                    this.guildID,
+                    "misc.failure.vcJoin.description",
+                ),
+            });
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Begin playing the Round's song in the VoiceChannel, listen on VoiceConnection events
      * @param messageContext - An object containing relevant parts of Eris.Message
@@ -807,12 +867,7 @@ export default abstract class Session extends EventEmitter {
             return false;
         }
 
-        if (!this.connection) {
-            logger.error(
-                `${getDebugLogHeader(
-                    messageContext,
-                )} | Unexpectedly null connection in playSong. clipAction = ${clipAction}`,
-            );
+        if (!this.playbackChannelReady(messageContext, clipAction)) {
             return false;
         }
 
@@ -873,7 +928,7 @@ export default abstract class Session extends EventEmitter {
             }. clip mode = ${isClipMode}. clip action = ${clipAction}.`,
         );
 
-        this.connection.stopPlaying();
+        this.stopPlayback();
 
         try {
             let inputArgs = ["-ss", seekLocation.toString()];
@@ -976,26 +1031,18 @@ export default abstract class Session extends EventEmitter {
                 });
             }
 
-            await this.ensureConnectionReady();
-
-            let voiceDataTimeout: number | undefined;
-            if (isClipMode) {
-                voiceDataTimeout = CLIP_VC_END_TIMEOUT_MS;
-            } else if (specialType) {
-                voiceDataTimeout = 7500;
-            } else {
-                voiceDataTimeout = 2000;
-            }
-
-            this.connection.play(songLocation, {
-                inputArgs,
-                encoderArgs: Object.entries(encoderArgs).flatMap((x) => [
-                    x[0],
-                    x[1].join(","),
-                ]),
-                // opusPassthrough: specialType === null && !isClipMode,
-                voiceDataTimeout,
-            });
+            await this.beginPlayback(
+                {
+                    songLocation,
+                    seekLocation,
+                    songDuration,
+                    inputArgs,
+                    encoderArgs,
+                    isClipMode,
+                    specialType,
+                },
+                round,
+            );
         } catch (e) {
             if (e instanceof Error) {
                 if (e.message.includes("Not ready yet")) {
@@ -1019,7 +1066,95 @@ export default abstract class Session extends EventEmitter {
 
         this.startGuessTimeout(messageContext);
 
-        this.connection.once("end", async () => {
+        this.armPlaybackEnd(messageContext, round, clipAction);
+
+        return true;
+    }
+
+    /**
+     * Transport hook: whether playback can proceed at all (Discord: the voice
+     * connection exists). Runs before any per-round work.
+     * @param messageContext - An object containing relevant parts of Eris.Message
+     * @param clipAction - The clip action, for logging
+     * @returns whether playback can proceed
+     */
+    protected playbackChannelReady(
+        messageContext: MessageContext,
+        clipAction: ClipAction | null,
+    ): boolean {
+        if (!this.connection) {
+            logger.error(
+                `${getDebugLogHeader(
+                    messageContext,
+                )} | Unexpectedly null connection in playSong. clipAction = ${clipAction}`,
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    /** Transport hook: halts any in-flight playback (Discord: the encoder). */
+    protected stopPlayback(): void {
+        this.connection?.stopPlaying();
+    }
+
+    /**
+     * Transport hook: whether a song is currently playing with round-end
+     * handling armed (Discord: the connection's "end" listener; web: the
+     * round-end timer).
+     * @returns whether playback is active
+     */
+    protected isPlaybackActive(): boolean {
+        return !!this.connection && this.connection.listenerCount("end") > 0;
+    }
+
+    /**
+     * Transport hook: starts playing the computed audio (Discord: ffmpeg into
+     * the voice connection). Throwing here restarts the round.
+     * @param spec - The resolved audio parameters for this playback
+     * @param _round - The round being played (used by the web transport)
+     */
+    protected async beginPlayback(
+        spec: PlaybackSpec,
+        _round: Round,
+    ): Promise<void> {
+        await this.ensureConnectionReady();
+
+        let voiceDataTimeout: number | undefined;
+        if (spec.isClipMode) {
+            voiceDataTimeout = CLIP_VC_END_TIMEOUT_MS;
+        } else if (spec.specialType) {
+            voiceDataTimeout = 7500;
+        } else {
+            voiceDataTimeout = 2000;
+        }
+
+        this.connection!.play(spec.songLocation, {
+            inputArgs: spec.inputArgs,
+            encoderArgs: Object.entries(spec.encoderArgs).flatMap((x) => [
+                x[0],
+                x[1].join(","),
+            ]),
+            // opusPassthrough: specialType === null && !isClipMode,
+            voiceDataTimeout,
+        });
+    }
+
+    /**
+     * Transport hook: arranges for handlePlaybackEnd to run when playback
+     * finishes (Discord: the voice connection's end/error events; both are
+     * disarmed by the next round's ensureVoiceConnection listener reset).
+     * @param messageContext - An object containing relevant parts of Eris.Message
+     * @param round - The round being played
+     * @param clipAction - The clip action the playback was started with
+     */
+    protected armPlaybackEnd(
+        messageContext: MessageContext,
+        round: Round,
+        clipAction: ClipAction | null,
+    ): void {
+        this.connection!.once("end", async () => {
             // replace listener with no-op to catch any exceptions thrown after this event
             if (this.connection) {
                 this.connection.removeAllListeners("end");
@@ -1033,51 +1168,10 @@ export default abstract class Session extends EventEmitter {
                 }
             }
 
-            this.stopGuessTimeout();
-
-            if (clipAction === ClipAction.END_ROUND) {
-                // The end round clip doesn't deal with round state, it just plays and ends
-                return;
-            }
-
-            if (this.isGameSession() && this.isClipMode()) {
-                const clipGameRound = round as ClipGameRound;
-                if (!round.finished) {
-                    if (
-                        clipGameRound.getReplayCount() < CLIP_MAX_REPLAY_COUNT
-                    ) {
-                        clipGameRound.incrementReplays();
-                        await this.playSong(
-                            messageContext,
-                            round,
-                            this.clipPlayNewClip
-                                ? ClipAction.NEW_CLIP
-                                : ClipAction.REPLAY,
-                        );
-                        return;
-                    } else {
-                        // Give some time to guess the song after the last replay has happened
-                        // In addition to the time to receive this "end" event defined by CLIP_VC_END_TIMEOUT_MS
-                        await delay(CLIP_LAST_REPLAY_DELAY_MS);
-                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                        if (round.finished) {
-                            // The round was ended by a guess while we were waiting, so don't try to end the round, as
-                            // the next round will be started by the guess
-                            return;
-                        }
-                    }
-                }
-            }
-
-            await this.endRound(
-                false,
-                new MessageContext(this.textChannelID, null, this.guildID),
-            );
-
-            await this.startRound(messageContext);
+            await this.handlePlaybackEnd(messageContext, round, clipAction);
         });
 
-        this.connection.once("error", async (err) => {
+        this.connection!.once("error", async (err) => {
             if (clipAction === ClipAction.END_ROUND) {
                 // Don't restart the round if the end round clip failed to play
                 return;
@@ -1099,8 +1193,60 @@ export default abstract class Session extends EventEmitter {
 
             await this.errorRestartRound();
         });
+    }
 
-        return true;
+    /**
+     * Shared end-of-playback lifecycle, identical across transports: replay
+     * clips while allowed, then end the round and start the next one.
+     * @param messageContext - An object containing relevant parts of Eris.Message
+     * @param round - The round whose playback ended
+     * @param clipAction - The clip action the playback was started with
+     */
+    protected async handlePlaybackEnd(
+        messageContext: MessageContext,
+        round: Round,
+        clipAction: ClipAction | null,
+    ): Promise<void> {
+        this.stopGuessTimeout();
+
+        if (clipAction === ClipAction.END_ROUND) {
+            // The end round clip doesn't deal with round state, it just plays and ends
+            return;
+        }
+
+        if (this.isGameSession() && this.isClipMode()) {
+            const clipGameRound = round as ClipGameRound;
+            if (!round.finished) {
+                if (clipGameRound.getReplayCount() < CLIP_MAX_REPLAY_COUNT) {
+                    clipGameRound.incrementReplays();
+                    await this.playSong(
+                        messageContext,
+                        round,
+                        this.clipPlayNewClip
+                            ? ClipAction.NEW_CLIP
+                            : ClipAction.REPLAY,
+                    );
+                    return;
+                } else {
+                    // Give some time to guess the song after the last replay has happened
+                    // In addition to the time to receive this "end" event defined by CLIP_VC_END_TIMEOUT_MS
+                    await delay(CLIP_LAST_REPLAY_DELAY_MS);
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                    if (round.finished) {
+                        // The round was ended by a guess while we were waiting, so don't try to end the round, as
+                        // the next round will be started by the guess
+                        return;
+                    }
+                }
+            }
+        }
+
+        await this.endRound(
+            false,
+            new MessageContext(this.textChannelID, null, this.guildID),
+        );
+
+        await this.startRound(messageContext);
     }
 
     protected getSongCount(): {

--- a/src/structures/web_game_session.ts
+++ b/src/structures/web_game_session.ts
@@ -1,0 +1,200 @@
+import { IPCLogger } from "../logger";
+import { getWebRoomMembers } from "./web_room_state";
+import GameSession from "./game_session";
+import type { PlaybackSpec } from "./session";
+import type ClipAction from "../enums/clip_action";
+import type GameType from "../enums/game_type";
+import type GuildPreference from "./guild_preference";
+import type KmqMember from "./kmq_member";
+import type MessageContext from "./message_context";
+import type Round from "./round";
+
+const logger = new IPCLogger("web_game_session");
+
+// Extra time past the audio's nominal end before the round is ended, mirroring
+// the lag between a song finishing and Eris delivering the "end" event.
+const WEB_PLAYBACK_END_GRACE_SEC = 1;
+
+/**
+ * A GameSession that plays to a standalone-website room instead of a Discord
+ * voice channel. Same game logic end to end — participants come from the
+ * pushed room membership, playback becomes a `roundAudio` event that the
+ * admiral turns into a browser audio stream, and the round-end trigger is a
+ * timer standing in for the voice connection's "end" event. Embeds are
+ * silently dropped by the empty text channel ID at the sendMessage guard.
+ */
+export default class WebGameSession extends GameSession {
+    /** Stands in for the voice connection's "end" event. */
+    private playbackEndTimer: NodeJS.Timeout | null = null;
+
+    /** Duration of the most recently computed playback, for the timer. */
+    private pendingPlaybackDurationSec: number | null = null;
+
+    /**
+     * True from beginPlayback until the next round's stopPlayback. Outlives
+     * the end timer on purpose: Discord keeps a noop "end" listener after a
+     * song finishes, so guesses stay eligible through the multiguess window
+     * between playback end and round end — this flag mirrors that.
+     */
+    private playbackStarted = false;
+
+    constructor(
+        guildPreference: GuildPreference,
+        roomGuildID: string,
+        gameSessionCreator: KmqMember,
+        gameType: GameType,
+        eliminationLives?: number,
+        clipDurationLength?: number,
+        clipPlayNewClip?: boolean,
+    ) {
+        // Empty text/voice channel IDs: every embed send is null-guarded at
+        // sendMessage, and no voice code path runs (all transport hooks are
+        // overridden below).
+        super(
+            guildPreference,
+            "",
+            "",
+            roomGuildID,
+            gameSessionCreator,
+            gameType,
+            eliminationLives,
+            clipDurationLength,
+            clipPlayNewClip,
+        );
+    }
+
+    isWebSession(): boolean {
+        return true;
+    }
+
+    sessionName(): string {
+        return "Web Game Session";
+    }
+
+    protected getParticipantIDs(): string[] {
+        return getWebRoomMembers(this.guildID).map((m) => m.id);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/member-ordering
+    getVoteMajorityCount(): number {
+        return Math.floor(this.getParticipantCount() * 0.5) + 1;
+    }
+
+    /**
+     * Web rooms have no VC to join; just require someone to be present.
+     * @param _messageContext - Unused
+     * @returns whether the round may proceed
+     */
+    protected async preparePlaybackChannel(
+        _messageContext: MessageContext,
+    ): Promise<boolean> {
+        if (this.getParticipantCount() === 0) {
+            await this.endSessionFromLifecycle(
+                "Web room is empty, during startRound",
+                false,
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    protected playbackChannelReady(
+        _messageContext: MessageContext,
+        _clipAction: ClipAction | null,
+    ): boolean {
+        return true;
+    }
+
+    protected stopPlayback(): void {
+        this.playbackStarted = false;
+        if (this.playbackEndTimer) {
+            clearTimeout(this.playbackEndTimer);
+            this.playbackEndTimer = null;
+        }
+    }
+
+    protected isPlaybackActive(): boolean {
+        return this.playbackStarted;
+    }
+
+    /**
+     * "Plays" by broadcasting the audio spec; the admiral converts it into an
+     * opaque streaming URL for the room's browsers (Phase 4).
+     * @param spec - The resolved audio parameters
+     * @param round - The round being played
+     */
+    // eslint-disable-next-line @typescript-eslint/require-await
+    protected async beginPlayback(
+        spec: PlaybackSpec,
+        round: Round,
+    ): Promise<void> {
+        const limitArg = spec.encoderArgs["-t"]?.[0];
+        const limitSec = limitArg ? parseFloat(limitArg) : NaN;
+
+        this.pendingPlaybackDurationSec = Number.isFinite(limitSec)
+            ? limitSec
+            : Math.max(5, spec.songDuration - spec.seekLocation);
+
+        this.playbackStarted = true;
+        this.emit("roundAudio", {
+            youtubeLink: round.song.youtubeLink,
+            songLocation: spec.songLocation,
+            seekLocation: spec.seekLocation,
+            songDuration: spec.songDuration,
+            inputArgs: spec.inputArgs,
+            encoderArgs: Object.entries(spec.encoderArgs).flatMap((x) => [
+                x[0],
+                x[1].join(","),
+            ]),
+            playbackDurationSec: this.pendingPlaybackDurationSec,
+            songStartedAt: round.songStartedAt,
+        });
+    }
+
+    /**
+     * Timer analog of the voice connection's "end" event. The pending timer
+     * is cleared by the next playback's stopPlayback (the analog of the
+     * listener reset in ensureVoiceConnection) and on session end.
+     * @param messageContext - An object containing relevant parts of Eris.Message
+     * @param round - The round being played
+     * @param clipAction - The clip action the playback was started with
+     */
+    protected armPlaybackEnd(
+        messageContext: MessageContext,
+        round: Round,
+        clipAction: ClipAction | null,
+    ): void {
+        const durationSec =
+            (this.pendingPlaybackDurationSec ?? 5) + WEB_PLAYBACK_END_GRACE_SEC;
+
+        // Replace (never stack) a pending timer, without touching the
+        // playback-active flag beginPlayback just set.
+        if (this.playbackEndTimer) {
+            clearTimeout(this.playbackEndTimer);
+        }
+
+        this.playbackEndTimer = setTimeout(() => {
+            this.playbackEndTimer = null;
+            this.handlePlaybackEnd(messageContext, round, clipAction).catch(
+                (e) => {
+                    logger.error(
+                        `gid: ${this.guildID} | Error in web playback end. err = ${e}`,
+                    );
+                },
+            );
+        }, durationSec * 1000);
+    }
+
+    protected guesserInSessionChannels(
+        messageContext: MessageContext,
+    ): boolean {
+        return this.getParticipantIDs().includes(messageContext.author.id);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/member-ordering
+    async endSession(reason: string, endedDueToError: boolean): Promise<void> {
+        this.stopPlayback();
+        await super.endSession(reason, endedDueToError);
+    }
+}

--- a/src/structures/web_game_session.ts
+++ b/src/structures/web_game_session.ts
@@ -75,6 +75,25 @@ export default class WebGameSession extends GameSession {
         return getWebRoomMembers(this.guildID).map((m) => m.id);
     }
 
+    /**
+     * Scoreboard identities come from the pushed room membership — never
+     * from Discord, whose API can't resolve guest members' synthetic IDs.
+     * @param userID - the participant to resolve
+     * @returns the identity, or null if they already left the room
+     */
+    // eslint-disable-next-line @typescript-eslint/require-await
+    protected async resolveParticipantProfile(
+        userID: string,
+    ): Promise<{ username: string; avatarUrl: string | null } | null> {
+        const member = getWebRoomMembers(this.guildID).find(
+            (m) => m.id === userID,
+        );
+
+        return member
+            ? { username: member.username, avatarUrl: member.avatarUrl }
+            : null;
+    }
+
     // eslint-disable-next-line @typescript-eslint/member-ordering
     getVoteMajorityCount(): number {
         return Math.floor(this.getParticipantCount() * 0.5) + 1;

--- a/src/structures/web_room_state.ts
+++ b/src/structures/web_room_state.ts
@@ -1,0 +1,56 @@
+import { WEB_ROOM_ID_FLAG } from "../constants";
+
+/** A web room member as pushed from the admiral's WebRoomManager. */
+export interface WebRoomMemberInfo {
+    id: string;
+    username: string;
+    avatarUrl: string | null;
+}
+
+// Worker-side mirror of web room membership, keyed by the room's synthetic
+// guild ID. Pushed by the admiral (on join/leave/sweep and embedded in
+// startGame args, so a fresh session never races the first push); read by
+// WebGameSession as its participant source.
+const roomMembers = new Map<string, WebRoomMemberInfo[]>();
+
+/**
+ * @param guildID - a guild ID from any transport
+ * @returns whether it's a web room's synthetic guild ID (bit 62 set —
+ * unreachable by real Discord snowflakes until ~2049)
+ */
+// eslint-disable-next-line import/no-unused-modules
+export function isWebRoomGuildID(guildID: string): boolean {
+    try {
+        return (BigInt(guildID) & WEB_ROOM_ID_FLAG) !== 0n;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Replaces the membership snapshot for a room.
+ * @param roomGuildID - the room's synthetic guild ID
+ * @param members - the current members
+ */
+export function setWebRoomMembers(
+    roomGuildID: string,
+    members: WebRoomMemberInfo[],
+): void {
+    roomMembers.set(roomGuildID, members);
+}
+
+/**
+ * @param roomGuildID - the room's synthetic guild ID
+ * @returns the last pushed membership (empty if unknown)
+ */
+export function getWebRoomMembers(roomGuildID: string): WebRoomMemberInfo[] {
+    return roomMembers.get(roomGuildID) ?? [];
+}
+
+/**
+ * Drops a room's membership mirror (room closed).
+ * @param roomGuildID - the room's synthetic guild ID
+ */
+export function clearWebRoomMembers(roomGuildID: string): void {
+    roomMembers.delete(roomGuildID);
+}

--- a/src/test/unit_tests/ci/activity_hub.test.ts
+++ b/src/test/unit_tests/ci/activity_hub.test.ts
@@ -281,6 +281,87 @@ describe("ActivityHub", () => {
         });
     });
 
+    describe("restart notice", () => {
+        it("broadcasts the warning (and its retraction) to subscribers in every guild", async () => {
+            const { hub } = makeHub(TWO_CLUSTERS);
+            await hub.start();
+
+            const g1: string[] = [];
+            const g2: string[] = [];
+            hub.subscribe("g1", {
+                id: "1",
+                send: (d) => g1.push(d),
+                close: () => undefined,
+            });
+
+            hub.subscribe("g2", {
+                id: "2",
+                send: (d) => g2.push(d),
+                close: () => undefined,
+            });
+
+            const restartsAt = Date.now() + 5 * 60 * 1000;
+            hub.setRestartNotice(restartsAt);
+
+            const warning = JSON.stringify({
+                type: "restartWarning",
+                restartsAtEpochMs: restartsAt,
+            });
+
+            assert.deepStrictEqual(g1, [warning]);
+            assert.deepStrictEqual(g2, [warning]);
+
+            hub.setRestartNotice(null);
+            const retraction = JSON.stringify({
+                type: "restartWarning",
+                restartsAtEpochMs: null,
+            });
+
+            assert.deepStrictEqual(g1, [warning, retraction]);
+            assert.deepStrictEqual(g2, [warning, retraction]);
+        });
+
+        it("decorates snapshots while a future restart is pending", async () => {
+            const { hub, fleet } = makeHub(TWO_CLUSTERS);
+            await hub.start();
+
+            fleet.autoReply = (payload) => {
+                fleet.emit(ACTIVITY_IPC_REPLY, {
+                    cid: payload.cid,
+                    payload: { ...emptySnapshot },
+                });
+            };
+
+            const restartsAt = Date.now() + 5 * 60 * 1000;
+            hub.setRestartNotice(restartsAt);
+
+            const withNotice = await hub.requestSnapshot("0");
+            assert.deepStrictEqual(withNotice.restartWarning, {
+                restartsAtEpochMs: restartsAt,
+            });
+
+            hub.setRestartNotice(null);
+            const cleared = await hub.requestSnapshot("0");
+            assert.strictEqual(cleared.restartWarning, undefined);
+        });
+
+        it("stops decorating snapshots once the deadline has passed", async () => {
+            const { hub, fleet } = makeHub(TWO_CLUSTERS);
+            await hub.start();
+
+            fleet.autoReply = (payload) => {
+                fleet.emit(ACTIVITY_IPC_REPLY, {
+                    cid: payload.cid,
+                    payload: { ...emptySnapshot },
+                });
+            };
+
+            hub.setRestartNotice(Date.now() - 1000);
+            const snapshot = await hub.requestSnapshot("0");
+            assert.strictEqual(snapshot.restartWarning, undefined);
+        });
+    });
+
     describe("request / reply correlation", () => {
         it("sends a correlated request to the owning cluster and resolves on reply", async () => {
             const { hub, fleet } = makeHub(TWO_CLUSTERS);

--- a/src/test/unit_tests/ci/web_audio_registry.test.ts
+++ b/src/test/unit_tests/ci/web_audio_registry.test.ts
@@ -1,0 +1,236 @@
+import {
+    WEB_AUDIO_TOKEN_TTL_BUFFER_MS,
+    specialFfmpegArgs,
+} from "../../../constants";
+import {
+    WebAudioRegistry,
+    buildAudioStreamArgs,
+    remainingPlaybackSec,
+} from "../../../web_audio_registry";
+import { describe } from "mocha";
+import SpecialType from "../../../enums/option_types/special_type";
+import assert from "assert";
+import type { WebAudioSpec } from "../../../web_audio_registry";
+
+const GUILD_ID = "4611686018427387905";
+const NOW = 1_750_000_000_000;
+
+function spec(overrides: Partial<WebAudioSpec> = {}): WebAudioSpec {
+    return {
+        songLocation: "/songs/dQw4w9WgXcQ.ogg",
+        inputArgs: ["-ss", "30"],
+        encoderArgs: [],
+        playbackDurationSec: 180,
+        ...overrides,
+    };
+}
+
+describe("web audio registry", () => {
+    let registry: WebAudioRegistry;
+
+    beforeEach(() => {
+        registry = new WebAudioRegistry();
+    });
+
+    describe("mint", () => {
+        it("should be retrievable by token until expiry", () => {
+            const entry = registry.mint(GUILD_ID, spec(), NOW);
+            assert.strictEqual(registry.get(entry.token, NOW), entry);
+            assert.strictEqual(
+                entry.expiresAt,
+                NOW + 180 * 1000 + WEB_AUDIO_TOKEN_TTL_BUFFER_MS,
+            );
+
+            assert.strictEqual(
+                registry.get(entry.token, entry.expiresAt),
+                null,
+            );
+        });
+
+        it("should replace the guild's previous entry", () => {
+            const first = registry.mint(GUILD_ID, spec(), NOW);
+            const second = registry.mint(GUILD_ID, spec(), NOW + 1000);
+            assert.notStrictEqual(first.token, second.token);
+            assert.strictEqual(registry.get(first.token, NOW + 1000), null);
+            assert.strictEqual(registry.size(), 1);
+            assert.strictEqual(
+                registry.currentForGuild(GUILD_ID, NOW + 1000),
+                second,
+            );
+        });
+    });
+
+    describe("currentForGuild", () => {
+        it("should return null once playback has (nearly) ended", () => {
+            registry.mint(GUILD_ID, spec({ playbackDurationSec: 20 }), NOW);
+            assert.ok(registry.currentForGuild(GUILD_ID, NOW + 19_000));
+            assert.strictEqual(
+                registry.currentForGuild(GUILD_ID, NOW + 19_600),
+                null,
+            );
+        });
+    });
+
+    describe("clearGuild", () => {
+        it("should drop the token too", () => {
+            const entry = registry.mint(GUILD_ID, spec(), NOW);
+            registry.clearGuild(GUILD_ID);
+            assert.strictEqual(registry.get(entry.token, NOW), null);
+            assert.strictEqual(registry.size(), 0);
+        });
+    });
+
+    describe("sweep", () => {
+        it("should evict only expired entries", () => {
+            const shortLived = registry.mint(
+                "1",
+                spec({ playbackDurationSec: 10 }),
+                NOW,
+            );
+
+            const longLived = registry.mint(
+                "2",
+                spec({ playbackDurationSec: 600 }),
+                NOW,
+            );
+
+            registry.sweep(NOW + 10 * 1000 + WEB_AUDIO_TOKEN_TTL_BUFFER_MS);
+            assert.strictEqual(registry.size(), 1);
+            assert.strictEqual(
+                registry.get(
+                    shortLived.token,
+                    NOW + 10 * 1000 + WEB_AUDIO_TOKEN_TTL_BUFFER_MS,
+                ),
+                null,
+            );
+
+            assert.ok(
+                registry.get(
+                    longLived.token,
+                    NOW + 10 * 1000 + WEB_AUDIO_TOKEN_TTL_BUFFER_MS,
+                ),
+            );
+        });
+    });
+});
+
+describe("buildAudioStreamArgs", () => {
+    const registry = new WebAudioRegistry();
+
+    it("should preserve the original input seek and add a bounding -t", () => {
+        const entry = registry.mint(GUILD_ID, spec(), NOW);
+        const args = buildAudioStreamArgs(entry, NOW)!;
+        assert.deepStrictEqual(args.slice(0, 7), [
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-ss",
+            "30",
+            "-i",
+            "/songs/dQw4w9WgXcQ.ogg",
+        ]);
+
+        // At t=0 there's no catch-up seek, just the duration bound.
+        assert.deepStrictEqual(args.slice(7), [
+            "-t",
+            "180.000",
+            "-vn",
+            "-map_metadata",
+            "-1",
+            "-c:a",
+            "libmp3lame",
+            "-b:a",
+            "128k",
+            "-f",
+            "mp3",
+            "pipe:1",
+        ]);
+    });
+
+    it("should seek output-side by wall-clock elapsed for late joiners", () => {
+        const entry = registry.mint(GUILD_ID, spec(), NOW);
+        const args = buildAudioStreamArgs(entry, NOW + 42_500)!;
+
+        // Output -ss comes after -i: it trims the *filtered* stream, which is
+        // in wall time for every special mode (tempo changes, reverse).
+        const iIndex = args.indexOf("-i");
+        const ssIndex = args.lastIndexOf("-ss");
+        assert.ok(ssIndex > iIndex);
+        assert.strictEqual(args[ssIndex + 1], "42.500");
+
+        // Remaining duration shrinks by the elapsed time.
+        const tIndex = args.indexOf("-t");
+        assert.strictEqual(args[tIndex + 1], "137.500");
+    });
+
+    it("should skip the output seek for near-zero elapsed", () => {
+        const entry = registry.mint(GUILD_ID, spec(), NOW);
+        const args = buildAudioStreamArgs(entry, NOW + 200)!;
+        assert.strictEqual(args.lastIndexOf("-ss"), args.indexOf("-ss"));
+    });
+
+    it("should rewrite an existing clip -t to the remaining duration", () => {
+        const entry = registry.mint(
+            GUILD_ID,
+            spec({
+                encoderArgs: ["-t", "20"],
+                playbackDurationSec: 20,
+            }),
+            NOW,
+        );
+
+        const args = buildAudioStreamArgs(entry, NOW + 5_000)!;
+        const tIndex = args.indexOf("-t");
+        assert.strictEqual(args[tIndex + 1], "15.000");
+        assert.strictEqual(args.indexOf("-t", tIndex + 2), -1);
+    });
+
+    it("should keep special-mode filters intact (REVERSE)", () => {
+        // Matches WebGameSession's emit: specialFfmpegArgs' encoderArgs are
+        // flattened with filter chains joined by commas.
+        const reverse = specialFfmpegArgs[SpecialType.REVERSE](30, 210);
+        const entry = registry.mint(
+            GUILD_ID,
+            spec({
+                inputArgs: reverse.inputArgs,
+                encoderArgs: Object.entries(reverse.encoderArgs).flatMap(
+                    (x) => [x[0], x[1].join(",")],
+                ),
+                playbackDurationSec: 180,
+            }),
+            NOW,
+        );
+
+        const args = buildAudioStreamArgs(entry, NOW + 10_000)!;
+        const afIndex = args.indexOf("-af");
+        assert.strictEqual(args[afIndex + 1], "atrim=end=180,areverse");
+
+        // REVERSE has no input seek; the only -ss is the output-side one.
+        assert.strictEqual(args.indexOf("-ss"), args.lastIndexOf("-ss"));
+        assert.ok(args.indexOf("-ss") > args.indexOf("-i"));
+        assert.strictEqual(args[args.indexOf("-ss") + 1], "10.000");
+    });
+
+    it("should return null when playback has ended", () => {
+        const entry = registry.mint(
+            GUILD_ID,
+            spec({ playbackDurationSec: 20 }),
+            NOW,
+        );
+
+        assert.strictEqual(buildAudioStreamArgs(entry, NOW + 19_700), null);
+    });
+});
+
+describe("remainingPlaybackSec", () => {
+    it("should measure from mint time", () => {
+        const registry = new WebAudioRegistry();
+        const entry = registry.mint(
+            GUILD_ID,
+            spec({ playbackDurationSec: 60 }),
+            NOW,
+        );
+
+        assert.strictEqual(remainingPlaybackSec(entry, NOW + 15_000), 45);
+    });
+});

--- a/src/test/unit_tests/ci/web_game_session.test.ts
+++ b/src/test/unit_tests/ci/web_game_session.test.ts
@@ -1,0 +1,313 @@
+import {
+    clearWebRoomMembers,
+    getWebRoomMembers,
+    isWebRoomGuildID,
+    setWebRoomMembers,
+} from "../../../structures/web_room_state";
+import { describe } from "mocha";
+import GameType from "../../../enums/game_type";
+import GuildPreference from "../../../structures/guild_preference";
+import KmqMember from "../../../structures/kmq_member";
+import MessageContext from "../../../structures/message_context";
+import OstPreference from "../../../enums/option_types/ost_preference";
+import ReleaseType from "../../../enums/option_types/release_type";
+import SkipCommand from "../../../commands/game_commands/skip";
+import State from "../../../state";
+import SubunitsPreference from "../../../enums/option_types/subunit_preference";
+import WebGameSession from "../../../structures/web_game_session";
+import WebRoomManager from "../../../web_room_manager";
+import assert from "assert";
+import sinon from "sinon";
+import type { PlaybackSpec } from "../../../structures/session";
+import type Round from "../../../structures/round";
+
+const OWNER_ID = "111111111111111111";
+const MEMBER_ID = "222222222222222222";
+const ROOM_ID = WebRoomManager.roomIDForOwner(OWNER_ID);
+
+async function getMockGuildPreference(): Promise<GuildPreference> {
+    const guildPreference = new GuildPreference(ROOM_ID);
+    sinon.stub(guildPreference, "updateGuildPreferences");
+    await guildPreference.setSubunitPreference(SubunitsPreference.EXCLUDE);
+    await guildPreference.setLimit(0, 99999);
+    await guildPreference.setOstPreference(OstPreference.INCLUDE);
+    await guildPreference.setReleaseType(ReleaseType.ALL);
+    return guildPreference;
+}
+
+function fakeRound(): Round {
+    return {
+        song: { youtubeLink: "dQw4w9WgXcQ" },
+        songStartedAt: 1_000,
+        finished: false,
+    } as unknown as Round;
+}
+
+function playbackSpec(overrides: Partial<PlaybackSpec> = {}): PlaybackSpec {
+    return {
+        songLocation: "/songs/dQw4w9WgXcQ.ogg",
+        seekLocation: 30,
+        songDuration: 210,
+        inputArgs: ["-ss", "30"],
+        encoderArgs: {},
+        isClipMode: false,
+        specialType: null,
+        ...overrides,
+    };
+}
+
+describe("web game session", () => {
+    const sandbox = sinon.createSandbox();
+    let session: WebGameSession;
+
+    beforeEach(async () => {
+        clearWebRoomMembers(ROOM_ID);
+        session = new WebGameSession(
+            await getMockGuildPreference(),
+            ROOM_ID,
+            new KmqMember(OWNER_ID),
+            GameType.CLASSIC,
+        );
+
+        setWebRoomMembers(ROOM_ID, [
+            { id: OWNER_ID, username: "alice", avatarUrl: null },
+            { id: MEMBER_ID, username: "bob", avatarUrl: null },
+        ]);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        clearWebRoomMembers(ROOM_ID);
+        // Drop the session without running the full end-session flow.
+        const SessionClass = Object.getPrototypeOf(
+            Object.getPrototypeOf(Object.getPrototypeOf(session)),
+        ).constructor;
+
+        SessionClass.deleteSession(ROOM_ID);
+    });
+
+    describe("web room state", () => {
+        it("identifies synthetic room guild IDs", () => {
+            assert.strictEqual(isWebRoomGuildID(ROOM_ID), true);
+            assert.strictEqual(isWebRoomGuildID(OWNER_ID), false);
+            assert.strictEqual(isWebRoomGuildID("not-a-number"), false);
+        });
+
+        it("mirrors pushed membership", () => {
+            assert.deepStrictEqual(
+                getWebRoomMembers(ROOM_ID).map((m) => m.id),
+                [OWNER_ID, MEMBER_ID],
+            );
+
+            clearWebRoomMembers(ROOM_ID);
+            assert.deepStrictEqual(getWebRoomMembers(ROOM_ID), []);
+        });
+    });
+
+    describe("transport overrides", () => {
+        it("identifies as a web session with room participants", () => {
+            assert.strictEqual(session.isWebSession(), true);
+            assert.deepStrictEqual((session as any).getParticipantIDs(), [
+                OWNER_ID,
+                MEMBER_ID,
+            ]);
+        });
+
+        it("derives vote majority from room membership", () => {
+            assert.strictEqual(session.getVoteMajorityCount(), 2);
+
+            setWebRoomMembers(ROOM_ID, [
+                { id: OWNER_ID, username: "alice", avatarUrl: null },
+            ]);
+
+            assert.strictEqual(session.getVoteMajorityCount(), 1);
+        });
+
+        it("accepts guesses only from room members", () => {
+            const memberContext = new MessageContext(
+                "",
+                new KmqMember(MEMBER_ID),
+                ROOM_ID,
+            );
+
+            const strangerContext = new MessageContext(
+                "",
+                new KmqMember("333333333333333333"),
+                ROOM_ID,
+            );
+
+            assert.strictEqual(
+                (session as any).guesserInSessionChannels(memberContext),
+                true,
+            );
+
+            assert.strictEqual(
+                (session as any).guesserInSessionChannels(strangerContext),
+                false,
+            );
+        });
+
+        it("allows playback while members remain and ends the session when empty", async () => {
+            const messageContext = new MessageContext(
+                "",
+                new KmqMember(OWNER_ID),
+                ROOM_ID,
+            );
+
+            assert.strictEqual(
+                await (session as any).preparePlaybackChannel(messageContext),
+                true,
+            );
+
+            const endStub = sandbox
+                .stub(session, "endSessionFromLifecycle" as any)
+                .resolves();
+
+            setWebRoomMembers(ROOM_ID, []);
+            assert.strictEqual(
+                await (session as any).preparePlaybackChannel(messageContext),
+                false,
+            );
+
+            assert.strictEqual(endStub.calledOnce, true);
+        });
+
+        it("counts skip votes without a voice-channel check", async () => {
+            // Regression: executeSkip used to hard-require the user and bot
+            // to share a VC, which silently swallowed every web skip.
+            State.gameSessions[ROOM_ID] = session;
+            // The non-majority path formats a (suppressed) embed that reads
+            // the bot's voice connections; give it the worker's empty map.
+            sandbox.stub(State, "client").value({
+                voiceConnections: new Map(),
+            });
+
+            const skippers = new Set<string>();
+            (session as any).round = {
+                song: { youtubeLink: "dQw4w9WgXcQ" },
+                songStartedAt: 1_000,
+                finished: false,
+                skipAchieved: false,
+                userSkipped: (id: string) => skippers.add(id),
+                getSkipCount: () => skippers.size,
+            };
+
+            await SkipCommand.executeSkip(
+                new MessageContext("", new KmqMember(OWNER_ID), ROOM_ID),
+            );
+
+            assert.deepStrictEqual([...skippers], [OWNER_ID]);
+        });
+    });
+
+    describe("playback", () => {
+        it("emits roundAudio with the stream spec and duration", async () => {
+            const events: any[] = [];
+            session.on("roundAudio", (payload) => events.push(payload));
+
+            await (session as any).beginPlayback(playbackSpec(), fakeRound());
+
+            assert.strictEqual(events.length, 1);
+            assert.strictEqual(events[0].youtubeLink, "dQw4w9WgXcQ");
+            assert.strictEqual(events[0].seekLocation, 30);
+            // No -t limit: plays out the rest of the song.
+            assert.strictEqual(events[0].playbackDurationSec, 180);
+            assert.strictEqual(events[0].songStartedAt, 1_000);
+        });
+
+        it("prefers the ffmpeg -t limit for the playback duration", async () => {
+            const events: any[] = [];
+            session.on("roundAudio", (payload) => events.push(payload));
+
+            await (session as any).beginPlayback(
+                playbackSpec({ encoderArgs: { "-t": ["12.5"] } }),
+                fakeRound(),
+            );
+
+            assert.strictEqual(events[0].playbackDurationSec, 12.5);
+            assert.deepStrictEqual(events[0].encoderArgs, ["-t", "12.5"]);
+        });
+
+        it("ends the round via timer after the playback duration", async () => {
+            const clock = sandbox.useFakeTimers();
+            const handleEnd = sandbox
+                .stub(session, "handlePlaybackEnd" as any)
+                .resolves();
+
+            const messageContext = new MessageContext(
+                "",
+                new KmqMember(OWNER_ID),
+                ROOM_ID,
+            );
+
+            const round = fakeRound();
+            await (session as any).beginPlayback(
+                playbackSpec({ encoderArgs: { "-t": ["10"] } }),
+                round,
+            );
+
+            (session as any).armPlaybackEnd(messageContext, round, null);
+
+            // 10s playback + 1s grace: not yet...
+            await clock.tickAsync(10_500);
+            assert.strictEqual(handleEnd.called, false);
+
+            // ...now.
+            await clock.tickAsync(600);
+            assert.strictEqual(handleEnd.calledOnce, true);
+        });
+
+        it("stopPlayback disarms the pending round-end timer", async () => {
+            const clock = sandbox.useFakeTimers();
+            const handleEnd = sandbox
+                .stub(session, "handlePlaybackEnd" as any)
+                .resolves();
+
+            const messageContext = new MessageContext(
+                "",
+                new KmqMember(OWNER_ID),
+                ROOM_ID,
+            );
+
+            const round = fakeRound();
+            await (session as any).beginPlayback(
+                playbackSpec({ encoderArgs: { "-t": ["10"] } }),
+                round,
+            );
+
+            (session as any).armPlaybackEnd(messageContext, round, null);
+
+            // The guess/skip path starts the next round, whose playSong stops
+            // the previous playback — the old timer must never fire.
+            (session as any).stopPlayback();
+
+            await clock.tickAsync(60_000);
+            assert.strictEqual(handleEnd.called, false);
+        });
+
+        it("re-arming replaces the previous timer instead of stacking", async () => {
+            const clock = sandbox.useFakeTimers();
+            const handleEnd = sandbox
+                .stub(session, "handlePlaybackEnd" as any)
+                .resolves();
+
+            const messageContext = new MessageContext(
+                "",
+                new KmqMember(OWNER_ID),
+                ROOM_ID,
+            );
+
+            const round = fakeRound();
+            await (session as any).beginPlayback(
+                playbackSpec({ encoderArgs: { "-t": ["10"] } }),
+                round,
+            );
+
+            (session as any).armPlaybackEnd(messageContext, round, null);
+            (session as any).armPlaybackEnd(messageContext, round, null);
+
+            await clock.tickAsync(60_000);
+            assert.strictEqual(handleEnd.calledOnce, true);
+        });
+    });
+});

--- a/src/test/unit_tests/ci/web_game_session.test.ts
+++ b/src/test/unit_tests/ci/web_game_session.test.ts
@@ -17,12 +17,15 @@ import SubunitsPreference from "../../../enums/option_types/subunit_preference";
 import WebGameSession from "../../../structures/web_game_session";
 import WebRoomManager from "../../../web_room_manager";
 import assert from "assert";
+import dbContext from "../../../database_context";
 import sinon from "sinon";
 import type { PlaybackSpec } from "../../../structures/session";
 import type Round from "../../../structures/round";
 
 const OWNER_ID = "111111111111111111";
 const MEMBER_ID = "222222222222222222";
+// A website guest: synthetic ID (bits 62+61) that doesn't exist on Discord.
+const GUEST_ID = ((1n << 62n) | (1n << 61n) | 42n).toString();
 const ROOM_ID = WebRoomManager.roomIDForOwner(OWNER_ID);
 
 async function getMockGuildPreference(): Promise<GuildPreference> {
@@ -170,6 +173,78 @@ describe("web game session", () => {
             );
 
             assert.strictEqual(endStub.calledOnce, true);
+        });
+
+        it("builds scoreboard players from room membership, guests included", async () => {
+            // Regression: player identities used to come from Discord's API
+            // (fetchUser), which 404s for guests' synthetic IDs — the guest
+            // never made it onto the scoreboard, showing as a raw numeric ID
+            // in the client and blowing up the correct-guess round-end flow.
+            setWebRoomMembers(ROOM_ID, [
+                { id: OWNER_ID, username: "alice", avatarUrl: null },
+                { id: GUEST_ID, username: "Guesty", avatarUrl: null },
+            ]);
+
+            // getName consults the guild nickname cache before falling back
+            // to the stored username; web rooms have no guild entry.
+            sandbox.stub(State, "client").value({ guilds: new Map() });
+
+            await session.syncAllVoiceMembers();
+
+            const players = (session as any).scoreboard.getPlayers();
+            assert.deepStrictEqual(
+                players.map((p: any) => [p.id, p.getName()]).sort(),
+                [
+                    [OWNER_ID, "alice"],
+                    [GUEST_ID, "Guesty"],
+                ],
+            );
+        });
+
+        it("scoreboard.update tolerates a guesser missing from the scoreboard", () => {
+            // Regression: the missing-player warn log resolved the session's
+            // voice channel — empty for web sessions, which made Eris throw
+            // ("Invalid channel ID:") and abort the round-end mid-flight.
+            (session as any).scoreboard.update([
+                { userID: "333333333333333333", pointsEarned: 1, expGain: 10 },
+            ]);
+        });
+
+        it("does not persist stats rows for guests", async () => {
+            setWebRoomMembers(ROOM_ID, [
+                { id: OWNER_ID, username: "alice", avatarUrl: null },
+                { id: GUEST_ID, username: "Guesty", avatarUrl: null },
+            ]);
+
+            await session.syncAllVoiceMembers();
+            await (session as any).updatePlayerStats(false);
+
+            const rows = await dbContext.kmq
+                .selectFrom("player_stats")
+                .select("player_id")
+                .where("player_id", "in", [OWNER_ID, GUEST_ID])
+                .execute();
+
+            // The Discord-account member persists; the guest never does.
+            assert.deepStrictEqual(
+                rows.map((r) => r.player_id),
+                [OWNER_ID],
+            );
+
+            await Promise.all(
+                (
+                    [
+                        "player_stats",
+                        "player_servers",
+                        "player_game_session_stats",
+                    ] as const
+                ).map((table) =>
+                    dbContext.kmq
+                        .deleteFrom(table)
+                        .where("player_id", "=", OWNER_ID)
+                        .execute(),
+                ),
+            );
         });
 
         it("counts skip votes without a voice-channel check", async () => {

--- a/src/test/unit_tests/ci/web_room_manager.test.ts
+++ b/src/test/unit_tests/ci/web_room_manager.test.ts
@@ -1,0 +1,267 @@
+import {
+    WEB_ROOM_DISCONNECT_GRACE_MS,
+    WEB_ROOM_ID_FLAG,
+    WEB_ROOM_MAX_MEMBERS,
+} from "../../../constants";
+import { describe } from "mocha";
+import WebRoomManager from "../../../web_room_manager";
+import assert from "assert";
+import type { WebRoomMemberIdentity } from "../../../web_room_manager";
+
+const user = (n: number): WebRoomMemberIdentity => ({
+    id: (100000000000000000n + BigInt(n)).toString(),
+    username: `user${n}`,
+    avatarUrl: null,
+});
+
+describe("web room manager", () => {
+    let clock: { now: number };
+    let closed: Array<{ roomID: string; lastMemberID: string }>;
+    let manager: WebRoomManager;
+
+    beforeEach(() => {
+        clock = { now: 1_000_000 };
+        closed = [];
+        manager = new WebRoomManager({
+            now: () => clock.now,
+            onRoomClosed: (roomID, lastMemberID) => {
+                closed.push({ roomID, lastMemberID });
+            },
+        });
+    });
+
+    describe("room IDs", () => {
+        it("derives a synthetic guild ID above the snowflake range", () => {
+            const roomID = WebRoomManager.roomIDForOwner(user(1).id);
+            assert.strictEqual(BigInt(roomID) & WEB_ROOM_ID_FLAG, 1n << 62n);
+            assert.strictEqual(
+                BigInt(roomID) & ~WEB_ROOM_ID_FLAG,
+                BigInt(user(1).id),
+            );
+        });
+
+        it("is deterministic per owner", () => {
+            const first = manager.createRoom(user(1));
+            assert.ok("room" in first);
+            const { roomID } = first.room;
+            manager.leaveRoom(user(1).id);
+
+            const second = manager.createRoom(user(1));
+            assert.ok("room" in second);
+            assert.strictEqual(second.room.roomID, roomID);
+            // But the invite code rotates with each new room.
+            assert.notStrictEqual(second.room.code, first.room.code);
+        });
+    });
+
+    describe("create/join/leave", () => {
+        it("creates a room with the creator as sole member and owner", () => {
+            const result = manager.createRoom(user(1));
+            assert.ok("room" in result);
+            assert.strictEqual(result.room.ownerID, user(1).id);
+            assert.deepStrictEqual(
+                [...result.room.members.keys()],
+                [user(1).id],
+            );
+
+            assert.strictEqual(
+                manager.getRoomByCode(result.room.code),
+                result.room,
+            );
+
+            assert.strictEqual(manager.getRoomForUser(user(1).id), result.room);
+        });
+
+        it("joins by code and rejects unknown codes", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+
+            const joined = manager.joinRoom(created.room.code, user(2));
+            assert.ok("room" in joined);
+            assert.strictEqual(joined.room.members.size, 2);
+
+            assert.deepStrictEqual(manager.joinRoom("nope", user(3)), {
+                error: "not_found",
+            });
+        });
+
+        it("enforces the member cap", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            for (let i = 2; i <= WEB_ROOM_MAX_MEMBERS; i++) {
+                assert.ok(
+                    "room" in manager.joinRoom(created.room.code, user(i)),
+                );
+            }
+
+            assert.deepStrictEqual(
+                manager.joinRoom(created.room.code, user(99)),
+                { error: "full" },
+            );
+
+            // Existing members can still "re-join" (identity refresh).
+            assert.ok("room" in manager.joinRoom(created.room.code, user(2)));
+        });
+
+        it("moves a user between rooms on join", () => {
+            const first = manager.createRoom(user(1));
+            const second = manager.createRoom(user(2));
+            assert.ok("room" in first && "room" in second);
+
+            assert.ok("room" in manager.joinRoom(first.room.code, user(3)));
+            assert.ok("room" in manager.joinRoom(second.room.code, user(3)));
+
+            assert.strictEqual(first.room.members.has(user(3).id), false);
+            assert.strictEqual(second.room.members.has(user(3).id), true);
+            assert.strictEqual(manager.getRoomForUser(user(3).id), second.room);
+        });
+
+        it("transfers ownership to the longest-standing member on owner leave", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            manager.joinRoom(created.room.code, user(2));
+            manager.joinRoom(created.room.code, user(3));
+
+            manager.leaveRoom(user(1).id);
+            assert.strictEqual(created.room.ownerID, user(2).id);
+            assert.strictEqual(closed.length, 0);
+        });
+
+        it("closes the room when the last member leaves", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            manager.leaveRoom(user(1).id);
+
+            assert.strictEqual(
+                manager.getRoomByCode(created.room.code),
+                undefined,
+            );
+
+            assert.deepStrictEqual(closed, [
+                { roomID: created.room.roomID, lastMemberID: user(1).id },
+            ]);
+        });
+
+        it("rejoins the creator's still-alive room instead of colliding room IDs", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            manager.joinRoom(created.room.code, user(2));
+
+            // Creator leaves; the room lives on under user 2.
+            manager.leaveRoom(user(1).id);
+            assert.strictEqual(created.room.ownerID, user(2).id);
+
+            // "Create" now lands them back in that room — two rooms can
+            // never share the creator-derived room ID.
+            const again = manager.createRoom(user(1));
+            assert.ok("room" in again);
+            assert.strictEqual(again.room, created.room);
+            assert.strictEqual(again.room.members.size, 2);
+        });
+    });
+
+    describe("presence and sweep", () => {
+        it("marks members connected/disconnected by socket count", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            const { code } = created.room;
+
+            let serialized = manager.serializeRoom(created.room);
+            assert.strictEqual(serialized.members[0]!.connected, false);
+
+            // Two tabs open, one closes: still connected.
+            manager.memberConnected(code, user(1).id);
+            manager.memberConnected(code, user(1).id);
+            manager.memberDisconnected(code, user(1).id);
+            serialized = manager.serializeRoom(created.room);
+            assert.strictEqual(serialized.members[0]!.connected, true);
+
+            manager.memberDisconnected(code, user(1).id);
+            serialized = manager.serializeRoom(created.room);
+            assert.strictEqual(serialized.members[0]!.connected, false);
+        });
+
+        it("sweeps members disconnected past the grace period", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            const { code } = created.room;
+            manager.memberConnected(code, user(1).id);
+            manager.joinRoom(code, user(2));
+            manager.memberConnected(code, user(2).id);
+            manager.memberDisconnected(code, user(2).id);
+
+            // Within grace: nothing happens.
+            clock.now += WEB_ROOM_DISCONNECT_GRACE_MS - 1;
+            manager.sweep();
+            assert.strictEqual(created.room.members.size, 2);
+
+            // Past grace: the disconnected member is dropped.
+            clock.now += 2;
+            manager.sweep();
+            assert.strictEqual(created.room.members.size, 1);
+            assert.strictEqual(created.room.members.has(user(1).id), true);
+        });
+
+        it("sweeps members who joined but never connected", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            manager.memberConnected(created.room.code, user(1).id);
+            manager.joinRoom(created.room.code, user(2));
+
+            clock.now += WEB_ROOM_DISCONNECT_GRACE_MS + 1;
+            manager.sweep();
+            assert.strictEqual(created.room.members.has(user(2).id), false);
+        });
+
+        it("closes an all-disconnected room via sweep", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            const { code, roomID } = created.room;
+            manager.memberConnected(code, user(1).id);
+            manager.memberDisconnected(code, user(1).id);
+
+            clock.now += WEB_ROOM_DISCONNECT_GRACE_MS + 1;
+            manager.sweep();
+
+            assert.strictEqual(manager.getRoomByCode(code), undefined);
+            assert.strictEqual(closed.length, 1);
+            assert.strictEqual(closed[0]!.roomID, roomID);
+        });
+
+        it("a reconnect within grace clears the disconnect timer", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            const { code } = created.room;
+            manager.memberConnected(code, user(1).id);
+            manager.memberDisconnected(code, user(1).id);
+
+            clock.now += WEB_ROOM_DISCONNECT_GRACE_MS - 1;
+            manager.memberConnected(code, user(1).id);
+
+            clock.now += WEB_ROOM_DISCONNECT_GRACE_MS * 5;
+            manager.sweep();
+            assert.strictEqual(created.room.members.has(user(1).id), true);
+        });
+    });
+
+    describe("serialization", () => {
+        it("exposes only client-safe member fields", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+
+            const serialized = manager.serializeRoom(created.room);
+            assert.deepStrictEqual(serialized, {
+                code: created.room.code,
+                ownerID: user(1).id,
+                members: [
+                    {
+                        id: user(1).id,
+                        username: "user1",
+                        avatarUrl: null,
+                        connected: false,
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/src/test/unit_tests/ci/web_session.test.ts
+++ b/src/test/unit_tests/ci/web_session.test.ts
@@ -1,0 +1,162 @@
+import {
+    WEB_SESSION_TOKEN_PREFIX,
+    WEB_SESSION_TTL_MS,
+} from "../../../constants";
+import {
+    createWebSession,
+    deleteWebSession,
+    hashWebSessionToken,
+    isWebSessionToken,
+    resolveWebSession,
+} from "../../../helpers/web_session_manager";
+import { describe } from "mocha";
+import assert from "assert";
+import dbContext from "../../../database_context";
+
+const TEST_USER = {
+    id: "123456789012345678",
+    username: "tester",
+    avatarUrl: "https://cdn.discordapp.com/avatars/1/2.png",
+    locale: "ko",
+};
+
+describe("web session manager", () => {
+    beforeEach(async () => {
+        await dbContext.kmq.deleteFrom("web_sessions").execute();
+    });
+
+    describe("token classification", () => {
+        it("identifies web session tokens by prefix", () => {
+            assert.strictEqual(
+                isWebSessionToken(`${WEB_SESSION_TOKEN_PREFIX}abc`),
+                true,
+            );
+
+            // Discord OAuth access tokens (Activity path) must not match.
+            assert.strictEqual(isWebSessionToken("abc123"), false);
+            assert.strictEqual(isWebSessionToken(""), false);
+        });
+
+        it("hashes deterministically to sha256 hex", () => {
+            const hash = hashWebSessionToken("web_sometoken");
+            assert.strictEqual(hash, hashWebSessionToken("web_sometoken"));
+            assert.match(hash, /^[0-9a-f]{64}$/);
+            assert.notStrictEqual(hash, hashWebSessionToken("web_other"));
+        });
+    });
+
+    describe("createWebSession", () => {
+        it("returns a prefixed token and stores only its hash", async () => {
+            const token = await createWebSession(TEST_USER);
+            assert.ok(token.startsWith(WEB_SESSION_TOKEN_PREFIX));
+
+            const rows = await dbContext.kmq
+                .selectFrom("web_sessions")
+                .selectAll()
+                .execute();
+
+            assert.strictEqual(rows.length, 1);
+            assert.strictEqual(rows[0]!.token_hash, hashWebSessionToken(token));
+            assert.strictEqual(rows[0]!.user_id, TEST_USER.id);
+            // Raw token must never be persisted.
+            assert.notStrictEqual(rows[0]!.token_hash, token);
+        });
+    });
+
+    describe("resolveWebSession", () => {
+        it("round-trips a created session to its user", async () => {
+            const token = await createWebSession(TEST_USER);
+            const user = await resolveWebSession(token);
+            assert.deepStrictEqual(user, TEST_USER);
+        });
+
+        it("returns null for non-web tokens without touching the DB", async () => {
+            assert.strictEqual(await resolveWebSession("discordtoken"), null);
+        });
+
+        it("returns null for unknown tokens", async () => {
+            assert.strictEqual(
+                await resolveWebSession(`${WEB_SESSION_TOKEN_PREFIX}unknown`),
+                null,
+            );
+        });
+
+        it("deletes and rejects expired sessions", async () => {
+            const token = await createWebSession(TEST_USER);
+            await dbContext.kmq
+                .updateTable("web_sessions")
+                .set({ expires_at: new Date(Date.now() - 1000) })
+                .execute();
+
+            assert.strictEqual(await resolveWebSession(token), null);
+
+            const rows = await dbContext.kmq
+                .selectFrom("web_sessions")
+                .selectAll()
+                .execute();
+
+            assert.strictEqual(rows.length, 0);
+        });
+
+        it("slides expiry forward when last use is stale", async () => {
+            const token = await createWebSession(TEST_USER);
+            const staleDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+            const nearExpiry = new Date(Date.now() + 60_000);
+            await dbContext.kmq
+                .updateTable("web_sessions")
+                .set({ last_used_at: staleDate, expires_at: nearExpiry })
+                .execute();
+
+            assert.ok(await resolveWebSession(token));
+
+            const row = await dbContext.kmq
+                .selectFrom("web_sessions")
+                .selectAll()
+                .executeTakeFirstOrThrow();
+
+            // Full TTL restored (allow generous slop for MySQL second
+            // truncation and test latency).
+            const expectedMin = Date.now() + WEB_SESSION_TTL_MS - 5 * 60 * 1000;
+
+            assert.ok(row.expires_at.getTime() > expectedMin);
+            assert.ok(row.last_used_at.getTime() > staleDate.getTime());
+        });
+
+        it("does not write on every resolve for hot sessions", async () => {
+            const token = await createWebSession(TEST_USER);
+            const before = await dbContext.kmq
+                .selectFrom("web_sessions")
+                .selectAll()
+                .executeTakeFirstOrThrow();
+
+            assert.ok(await resolveWebSession(token));
+
+            const after = await dbContext.kmq
+                .selectFrom("web_sessions")
+                .selectAll()
+                .executeTakeFirstOrThrow();
+
+            assert.strictEqual(
+                after.last_used_at.getTime(),
+                before.last_used_at.getTime(),
+            );
+
+            assert.strictEqual(
+                after.expires_at.getTime(),
+                before.expires_at.getTime(),
+            );
+        });
+    });
+
+    describe("deleteWebSession", () => {
+        it("invalidates the session (logout)", async () => {
+            const token = await createWebSession(TEST_USER);
+            await deleteWebSession(token);
+            assert.strictEqual(await resolveWebSession(token), null);
+        });
+
+        it("is a no-op for unknown tokens", async () => {
+            await deleteWebSession(`${WEB_SESSION_TOKEN_PREFIX}unknown`);
+        });
+    });
+});

--- a/src/test/unit_tests/ci/web_session.test.ts
+++ b/src/test/unit_tests/ci/web_session.test.ts
@@ -1,4 +1,5 @@
 import {
+    WEB_GUEST_ID_FLAG,
     WEB_SESSION_TOKEN_PREFIX,
     WEB_SESSION_TTL_MS,
 } from "../../../constants";
@@ -6,10 +7,14 @@ import {
     createWebSession,
     deleteWebSession,
     hashWebSessionToken,
+    isGuestUserID,
     isWebSessionToken,
+    mintGuestUserID,
     resolveWebSession,
+    sanitizeGuestUsername,
 } from "../../../helpers/web_session_manager";
 import { describe } from "mocha";
+import WebRoomManager from "../../../web_room_manager";
 import assert from "assert";
 import dbContext from "../../../database_context";
 
@@ -157,6 +162,63 @@ describe("web session manager", () => {
 
         it("is a no-op for unknown tokens", async () => {
             await deleteWebSession(`${WEB_SESSION_TOKEN_PREFIX}unknown`);
+        });
+    });
+
+    describe("guest identities", () => {
+        it("mints numeric IDs carrying both guest flag bits", () => {
+            const id = mintGuestUserID();
+            assert.match(id, /^\d+$/);
+            assert.strictEqual(
+                BigInt(id) & WEB_GUEST_ID_FLAG,
+                WEB_GUEST_ID_FLAG,
+            );
+
+            // Effectively unique: 60 random bits.
+            assert.notStrictEqual(id, mintGuestUserID());
+        });
+
+        it("classifies guest IDs apart from snowflakes and room IDs", () => {
+            assert.strictEqual(isGuestUserID(mintGuestUserID()), true);
+
+            // Real Discord snowflake.
+            assert.strictEqual(isGuestUserID("123456789012345678"), false);
+            // Room guild ID (bit 62 only).
+            assert.strictEqual(
+                isGuestUserID(WebRoomManager.roomIDForOwner("123456789")),
+                false,
+            );
+            assert.strictEqual(isGuestUserID("not-a-number"), false);
+        });
+
+        it("round-trips a guest session like any other", async () => {
+            const guest = {
+                id: mintGuestUserID(),
+                username: "guesty",
+                avatarUrl: null,
+                locale: "en-US",
+            };
+
+            const token = await createWebSession(guest);
+            assert.deepStrictEqual(await resolveWebSession(token), guest);
+        });
+
+        it("sanitizes self-chosen guest names", () => {
+            assert.strictEqual(sanitizeGuestUsername("  bob  "), "bob");
+            // Control characters stripped, whitespace collapsed.
+            assert.strictEqual(
+                sanitizeGuestUsername("a\u0000b\u001fc  d"),
+                "abc d",
+            );
+
+            assert.strictEqual(
+                sanitizeGuestUsername("x".repeat(100)).length,
+                32,
+            );
+
+            assert.strictEqual(sanitizeGuestUsername("   "), "Guest");
+            assert.strictEqual(sanitizeGuestUsername(undefined), "Guest");
+            assert.strictEqual(sanitizeGuestUsername(42), "Guest");
         });
     });
 });

--- a/src/typings/kmq_db.d.ts
+++ b/src/typings/kmq_db.d.ts
@@ -262,6 +262,17 @@ export interface TopGgUserVotes {
     user_id: string;
 }
 
+export interface WebSessions {
+    avatar_url: string | null;
+    created_at: Generated<Date>;
+    expires_at: Date;
+    last_used_at: Generated<Date>;
+    locale: Generated<string>;
+    token_hash: string;
+    user_id: string;
+    username: string;
+}
+
 export interface KmqDB {
     "kpop_videos.app_kpop": AppKpop;
     "kpop_videos.app_kpop_agrelation": AppKpopAgrelation;
@@ -306,4 +317,5 @@ export interface KmqDB {
     song_metadata: SongMetadata;
     system_stats: SystemStats;
     top_gg_user_votes: TopGgUserVotes;
+    web_sessions: WebSessions;
 }

--- a/src/web_audio_registry.ts
+++ b/src/web_audio_registry.ts
@@ -1,0 +1,215 @@
+import * as uuid from "uuid";
+import { WEB_AUDIO_TOKEN_TTL_BUFFER_MS } from "./constants";
+
+// Late joiners closer than this to the playback's end get a 410 instead of a
+// sliver of audio; below it there's nothing worth hearing.
+const MIN_STREAMABLE_REMAINING_SEC = 0.5;
+
+// Elapsed times under this skip the output-side seek entirely: the listener
+// connected essentially at round start, and a sub-quarter-second trim costs
+// more in decode work than it buys in sync.
+const MIN_SEEKABLE_ELAPSED_SEC = 0.25;
+
+/** The playback parameters carried by a worker's roundAudio event. */
+export interface WebAudioSpec {
+    /** Absolute path of the source audio file. */
+    songLocation: string;
+    /** ffmpeg args preceding `-i` (input seek, or empty for REVERSE). */
+    inputArgs: string[];
+    /** Flattened output args (`["-t", "20", "-af", "..."]`). */
+    encoderArgs: string[];
+    /** Nominal wall-clock playback length in seconds. */
+    playbackDurationSec: number;
+}
+
+export interface WebAudioEntry extends WebAudioSpec {
+    token: string;
+    guildID: string;
+    /**
+     * When the hub received the roundAudio event — the wall-clock reference
+     * all listeners sync to. Deliberately not the worker's songStartedAt:
+     * clip replays re-emit with the original round timestamp, but the replay
+     * audibly starts now.
+     */
+    mintedAt: number;
+    expiresAt: number;
+}
+
+/**
+ * Seconds of audible playback left, measured against the mint time.
+ * @param entry - the registry entry
+ * @param now - current epoch ms
+ * @returns remaining seconds (may be negative once playback has ended)
+ */
+export function remainingPlaybackSec(
+    entry: WebAudioEntry,
+    now: number,
+): number {
+    return entry.playbackDurationSec - (now - entry.mintedAt) / 1000;
+}
+
+/**
+ * Admiral-side registry mapping opaque audio tokens to playback specs. The
+ * spec names the song (file path), so it must never reach clients pre-reveal;
+ * browsers only ever see `/api/web/audio/<token>`. One live entry per guild —
+ * each new playback (next round, clip replay, answer clip) replaces the last.
+ */
+export class WebAudioRegistry {
+    private byToken: Map<string, WebAudioEntry> = new Map();
+
+    private byGuild: Map<string, WebAudioEntry> = new Map();
+
+    /**
+     * Registers a new playback for the guild, replacing any previous one.
+     * @param guildID - the (synthetic) guild the audio belongs to
+     * @param spec - the playback parameters from the worker's roundAudio event
+     * @param now - current epoch ms
+     * @returns the newly minted entry
+     */
+    mint(guildID: string, spec: WebAudioSpec, now: number): WebAudioEntry {
+        this.clearGuild(guildID);
+        const entry: WebAudioEntry = {
+            ...spec,
+            token: uuid.v4(),
+            guildID,
+            mintedAt: now,
+            expiresAt:
+                now +
+                spec.playbackDurationSec * 1000 +
+                WEB_AUDIO_TOKEN_TTL_BUFFER_MS,
+        };
+
+        this.byToken.set(entry.token, entry);
+        this.byGuild.set(guildID, entry);
+        return entry;
+    }
+
+    /**
+     * Looks up an entry by token.
+     * @param token - the opaque token from the audio URL
+     * @param now - current epoch ms
+     * @returns the entry, or null if unknown or expired
+     */
+    get(token: string, now: number): WebAudioEntry | null {
+        const entry = this.byToken.get(token);
+        if (!entry) return null;
+        if (entry.expiresAt <= now) {
+            this.removeEntry(entry);
+            return null;
+        }
+
+        return entry;
+    }
+
+    /**
+     * The guild's live playback, for decorating snapshots so late joiners and
+     * reconnects hear the current song.
+     * @param guildID - the (synthetic) guild
+     * @param now - current epoch ms
+     * @returns the entry, or null if none or already past its audible end
+     */
+    currentForGuild(guildID: string, now: number): WebAudioEntry | null {
+        const entry = this.byGuild.get(guildID);
+        if (!entry) return null;
+        if (remainingPlaybackSec(entry, now) <= MIN_STREAMABLE_REMAINING_SEC) {
+            return null;
+        }
+
+        return entry;
+    }
+
+    /**
+     * Drops the guild's live entry (session ended / room closed).
+     * @param guildID - the (synthetic) guild
+     */
+    clearGuild(guildID: string): void {
+        const entry = this.byGuild.get(guildID);
+        if (entry) {
+            this.removeEntry(entry);
+        }
+    }
+
+    /**
+     * Evicts expired entries.
+     * @param now - current epoch ms
+     */
+    sweep(now: number): void {
+        for (const entry of this.byToken.values()) {
+            if (entry.expiresAt <= now) {
+                this.removeEntry(entry);
+            }
+        }
+    }
+
+    /** @returns number of live entries */
+    size(): number {
+        return this.byToken.size;
+    }
+
+    private removeEntry(entry: WebAudioEntry): void {
+        this.byToken.delete(entry.token);
+        if (this.byGuild.get(entry.guildID) === entry) {
+            this.byGuild.delete(entry.guildID);
+        }
+    }
+}
+
+/**
+ * Builds the full ffmpeg argv streaming this entry as chunked MP3, seeked to
+ * wherever playback is *right now* so every listener hears the same moment.
+ *
+ * The catch-up seek is output-side (`-ss` after `-i`): the original input
+ * args and filters run untouched, and the first `elapsed` seconds of the
+ * *filtered* output are decoded and discarded. Input-side seeking would be
+ * cheaper but wrong for the special modes — rubberband tempo changes and
+ * areverse change the mapping between song time and wall time, while the
+ * filtered output is by definition in wall time for every mode.
+ * @param entry - the registry entry
+ * @param now - current epoch ms
+ * @returns the argv, or null when playback has (nearly) ended → 410
+ */
+export function buildAudioStreamArgs(
+    entry: WebAudioEntry,
+    now: number,
+): string[] | null {
+    const elapsedSec = (now - entry.mintedAt) / 1000;
+    const remainingSec = remainingPlaybackSec(entry, now);
+    if (remainingSec <= MIN_STREAMABLE_REMAINING_SEC) {
+        return null;
+    }
+
+    // The worker's -t (clip length) was relative to playback start; ours is
+    // relative to the output seek point, so it shrinks to what's left. Also
+    // set it when the worker had none — it bounds the encode at the same
+    // point the round timer will fire anyway.
+    const encoderArgs = [...entry.encoderArgs];
+    const tIndex = encoderArgs.indexOf("-t");
+    if (tIndex !== -1 && tIndex + 1 < encoderArgs.length) {
+        encoderArgs[tIndex + 1] = remainingSec.toFixed(3);
+    } else {
+        encoderArgs.push("-t", remainingSec.toFixed(3));
+    }
+
+    return [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        ...entry.inputArgs,
+        "-i",
+        entry.songLocation,
+        ...encoderArgs,
+        ...(elapsedSec > MIN_SEEKABLE_ELAPSED_SEC
+            ? ["-ss", elapsedSec.toFixed(3)]
+            : []),
+        "-vn",
+        "-map_metadata",
+        "-1",
+        "-c:a",
+        "libmp3lame",
+        "-b:a",
+        "128k",
+        "-f",
+        "mp3",
+        "pipe:1",
+    ];
+}

--- a/src/web_room_manager.ts
+++ b/src/web_room_manager.ts
@@ -69,6 +69,12 @@ interface WebRoomManagerOptions {
      */
     onRoomClosed?: (roomID: string, lastMemberID: string) => void;
 
+    /**
+     * Called when a room's member set changes (create/join/leave) — the hook
+     * that mirrors membership to the worker owning the room's guild ID.
+     */
+    onRoomChanged?: (room: WebRoom) => void;
+
     /** Clock override for tests. */
     now?: () => number;
 }
@@ -87,10 +93,13 @@ export default class WebRoomManager {
 
     private onRoomClosed: (roomID: string, lastMemberID: string) => void;
 
+    private onRoomChanged: (room: WebRoom) => void;
+
     private now: () => number;
 
     constructor(options: WebRoomManagerOptions = {}) {
         this.onRoomClosed = options.onRoomClosed ?? ((): void => {});
+        this.onRoomChanged = options.onRoomChanged ?? ((): void => {});
         this.now = options.now ?? ((): number => Date.now());
     }
 
@@ -132,6 +141,7 @@ export default class WebRoomManager {
         this.roomsByCode.set(room.code, room);
         this.roomCodeByRoomID.set(roomID, room.code);
         this.roomCodeByUserID.set(user.id, room.code);
+        this.onRoomChanged(room);
         return { room };
     }
 
@@ -162,6 +172,7 @@ export default class WebRoomManager {
         this.leaveRoom(user.id);
         room.members.set(user.id, this.newMember(user));
         this.roomCodeByUserID.set(user.id, code);
+        this.onRoomChanged(room);
         return { room };
     }
 
@@ -188,6 +199,8 @@ export default class WebRoomManager {
         if (room.ownerID === userID) {
             room.ownerID = room.members.keys().next().value as string;
         }
+
+        this.onRoomChanged(room);
     }
 
     /**

--- a/src/web_room_manager.ts
+++ b/src/web_room_manager.ts
@@ -1,0 +1,294 @@
+import {
+    WEB_ROOM_DISCONNECT_GRACE_MS,
+    WEB_ROOM_ID_FLAG,
+    WEB_ROOM_MAX_MEMBERS,
+} from "./constants";
+import crypto from "crypto";
+
+/** Identity of a room member, as resolved from their bearer token. */
+export interface WebRoomMemberIdentity {
+    id: string;
+    username: string;
+    avatarUrl: string | null;
+}
+
+interface WebRoomMember extends WebRoomMemberIdentity {
+    /**
+     * Open websockets for this member (one per tab). Presence is derived:
+     * connected means at least one open socket.
+     */
+    connections: number;
+
+    /**
+     * When connections last dropped to zero; members disconnected past the
+     * grace period are removed by sweep(). Set at join time too, so a member
+     * who never opens a websocket doesn't linger forever.
+     */
+    disconnectedAt: number | null;
+}
+
+// eslint-disable-next-line import/no-unused-modules
+export interface WebRoom {
+    /** Shareable, unguessable invite code; doubles as the instance_id. */
+    code: string;
+
+    /** Synthetic guild ID; see WEB_ROOM_ID_FLAG. */
+    roomID: string;
+
+    ownerID: string;
+
+    createdAt: number;
+
+    /** Keyed by user ID; insertion order determines owner succession. */
+    members: Map<string, WebRoomMember>;
+}
+
+/** Room shape sent to clients. */
+// eslint-disable-next-line import/no-unused-modules
+export interface SerializedWebRoom {
+    code: string;
+    ownerID: string;
+    members: Array<{
+        id: string;
+        username: string;
+        avatarUrl: string | null;
+        connected: boolean;
+    }>;
+}
+
+// eslint-disable-next-line import/no-unused-modules
+export type WebRoomJoinResult =
+    | { room: WebRoom }
+    | { error: "not_found" | "full" };
+
+interface WebRoomManagerOptions {
+    /**
+     * Called when a room's last member is gone (explicit leave or sweep) —
+     * the hook that ends any game running against the room's synthetic
+     * guild ID.
+     */
+    onRoomClosed?: (roomID: string, lastMemberID: string) => void;
+
+    /** Clock override for tests. */
+    now?: () => number;
+}
+
+/**
+ * Admiral-side registry of standalone-website multiplayer rooms. Rooms are
+ * in-memory only: an admiral restart drops them (members just recreate/rejoin;
+ * game options and presets survive via the deterministic room ID).
+ */
+export default class WebRoomManager {
+    private roomsByCode: Map<string, WebRoom> = new Map();
+
+    private roomCodeByRoomID: Map<string, string> = new Map();
+
+    private roomCodeByUserID: Map<string, string> = new Map();
+
+    private onRoomClosed: (roomID: string, lastMemberID: string) => void;
+
+    private now: () => number;
+
+    constructor(options: WebRoomManagerOptions = {}) {
+        this.onRoomClosed = options.onRoomClosed ?? ((): void => {});
+        this.now = options.now ?? ((): number => Date.now());
+    }
+
+    /**
+     * @param ownerID - the creating user's Discord ID
+     * @returns the synthetic guild ID for that user's room
+     */
+    static roomIDForOwner(ownerID: string): string {
+        return (WEB_ROOM_ID_FLAG | BigInt(ownerID)).toString();
+    }
+
+    /**
+     * Creates a room owned by the user, leaving any room they're currently
+     * in. If the room they created earlier is still alive (possible after
+     * they left it and ownership transferred), they rejoin it instead —
+     * room IDs are deterministic per creator, so two live rooms can never
+     * share one.
+     * @param user - the creating user
+     * @returns the created (or rejoined) room
+     */
+    createRoom(user: WebRoomMemberIdentity): WebRoomJoinResult {
+        const roomID = WebRoomManager.roomIDForOwner(user.id);
+        const existingCode = this.roomCodeByRoomID.get(roomID);
+        if (existingCode) {
+            return this.joinRoom(existingCode, user);
+        }
+
+        this.leaveRoom(user.id);
+
+        const room: WebRoom = {
+            code: crypto.randomBytes(9).toString("base64url"),
+            roomID,
+            ownerID: user.id,
+            createdAt: this.now(),
+            members: new Map(),
+        };
+
+        room.members.set(user.id, this.newMember(user));
+        this.roomsByCode.set(room.code, room);
+        this.roomCodeByRoomID.set(roomID, room.code);
+        this.roomCodeByUserID.set(user.id, room.code);
+        return { room };
+    }
+
+    /**
+     * Joins a room by invite code, leaving any current room first. Joining a
+     * room the user is already in just refreshes their identity fields.
+     * @param code - the invite code
+     * @param user - the joining user
+     * @returns the room, or why the join failed
+     */
+    joinRoom(code: string, user: WebRoomMemberIdentity): WebRoomJoinResult {
+        const room = this.roomsByCode.get(code);
+        if (!room) {
+            return { error: "not_found" };
+        }
+
+        const existing = room.members.get(user.id);
+        if (existing) {
+            existing.username = user.username;
+            existing.avatarUrl = user.avatarUrl;
+            return { room };
+        }
+
+        if (room.members.size >= WEB_ROOM_MAX_MEMBERS) {
+            return { error: "full" };
+        }
+
+        this.leaveRoom(user.id);
+        room.members.set(user.id, this.newMember(user));
+        this.roomCodeByUserID.set(user.id, code);
+        return { room };
+    }
+
+    /**
+     * Removes the user from whatever room they're in. Ownership passes to the
+     * longest-standing remaining member; an emptied room is closed.
+     * @param userID - the leaving user
+     */
+    leaveRoom(userID: string): void {
+        const code = this.roomCodeByUserID.get(userID);
+        if (!code) return;
+
+        const room = this.roomsByCode.get(code);
+        this.roomCodeByUserID.delete(userID);
+        if (!room) return;
+
+        room.members.delete(userID);
+
+        if (room.members.size === 0) {
+            this.closeRoom(room, userID);
+            return;
+        }
+
+        if (room.ownerID === userID) {
+            room.ownerID = room.members.keys().next().value as string;
+        }
+    }
+
+    /**
+     * @param code - the invite code
+     * @returns the room, if it exists
+     */
+    getRoomByCode(code: string): WebRoom | undefined {
+        return this.roomsByCode.get(code);
+    }
+
+    /**
+     * @param userID - the user
+     * @returns the room the user is currently in, if any
+     */
+    getRoomForUser(userID: string): WebRoom | undefined {
+        const code = this.roomCodeByUserID.get(userID);
+        return code ? this.roomsByCode.get(code) : undefined;
+    }
+
+    /**
+     * Records a websocket open for a room member.
+     * @param code - the room's invite code
+     * @param userID - the member
+     */
+    memberConnected(code: string, userID: string): void {
+        const member = this.roomsByCode.get(code)?.members.get(userID);
+        if (!member) return;
+        member.connections++;
+        member.disconnectedAt = null;
+    }
+
+    /**
+     * Records a websocket close for a room member; the grace period starts
+     * when their last socket closes.
+     * @param code - the room's invite code
+     * @param userID - the member
+     */
+    memberDisconnected(code: string, userID: string): void {
+        const member = this.roomsByCode.get(code)?.members.get(userID);
+        if (!member) return;
+        member.connections = Math.max(0, member.connections - 1);
+        if (member.connections === 0) {
+            member.disconnectedAt = this.now();
+        }
+    }
+
+    /**
+     * Drops members whose disconnect grace period has lapsed, transferring
+     * ownership or closing rooms as needed. Called on an interval by the
+     * web server.
+     */
+    sweep(): void {
+        const cutoff = this.now() - WEB_ROOM_DISCONNECT_GRACE_MS;
+        const expired: string[] = [];
+        for (const room of this.roomsByCode.values()) {
+            for (const member of room.members.values()) {
+                if (
+                    member.connections === 0 &&
+                    member.disconnectedAt !== null &&
+                    member.disconnectedAt <= cutoff
+                ) {
+                    expired.push(member.id);
+                }
+            }
+        }
+
+        for (const userID of expired) {
+            this.leaveRoom(userID);
+        }
+    }
+
+    /**
+     * @param room - the room
+     * @returns the client-facing room shape
+     */
+    serializeRoom(room: WebRoom): SerializedWebRoom {
+        return {
+            code: room.code,
+            ownerID: room.ownerID,
+            members: [...room.members.values()].map((m) => ({
+                id: m.id,
+                username: m.username,
+                avatarUrl: m.avatarUrl,
+                connected: m.connections > 0,
+            })),
+        };
+    }
+
+    private newMember(user: WebRoomMemberIdentity): WebRoomMember {
+        return {
+            id: user.id,
+            username: user.username,
+            avatarUrl: user.avatarUrl,
+            connections: 0,
+            disconnectedAt: this.now(),
+        };
+    }
+
+    private closeRoom(room: WebRoom, lastMemberID: string): void {
+        this.roomsByCode.delete(room.code);
+        this.roomCodeByRoomID.delete(room.roomID);
+        this.onRoomClosed(room.roomID, lastMemberID);
+    }
+}


### PR DESCRIPTION
Ports the Discord Activity into a full standalone website, stacked as one commit per phase:

1. **Web OAuth login + platform adapter** — Discord OAuth redirect flow issuing opaque `web_` bearer tokens (`web_sessions` table, hashed, 30-day sliding TTL); the client gains a platform layer so the same bundle runs embedded and standalone.
2. **Multiplayer rooms** — invite-code rooms mapping to synthetic guild IDs (`(1 << 62) | ownerUserID`, deterministic per owner so options/presets/shuffle history persist across recreations); presence from WS lifecycle; 8-member cap.
3. **Headless GameSessions** — transport hooks extracted from `Session`/`GameSession` (pure refactor on the Discord path) with a `WebGameSession` that replaces voice playback with a `roundAudio` event and a round-end timer. Full EXP/stats parity.
4. **Browser audio streaming** — the playback spec stops at the admiral; browsers get an opaque single-playback token URL. Each GET spawns ffmpeg seeked to the wall-clock live position (exact for tempo/reverse special modes), chunked MP3 out. Autoplay unlock on any interaction; volume/mute persisted.
5. **Lifecycle hardening + docs** — silent reconnect with backoff, direct-YouTube thumbnails on web, `docs/WEB.md` (portal config, env, launch, analytics, troubleshooting).
6. **Guests** — play without a Discord account under a self-chosen nickname: synthetic numeric IDs (bits 62+61, disjoint from snowflakes and room IDs), join-only (hosting requires Discord), zero durable stat writes (ephemeral by design), separate `webGuestsEnabled` kill switch.

Also included: dark theme + KMQ-logo favicon on the landing page, and an impending-restart warning banner (live countdown, both embedded and web) driven by `/announce-restart`.

**Rollout:** everything is dark behind `webModeEnabled` (+ `webGuestsEnabled`) in `data/feature_switch_config.json` (hot-reloadable). Launch needs `WEB_PUBLIC_BASE_URL` and the `<origin>/api/web/callback` OAuth redirect registered in the portal — see `docs/WEB.md`.

**Testing:** 528 unit tests passing (the 5 song_selector failures are pre-existing on master); live E2E of login/rooms/audio/guests during development; Discord Activity + slash-command paths regression-tested per phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
