### PR TITLE
Add public/private lobbies with optional passwords (web only)

### DIFF
--- a/activity/src/platform/webPlatform.ts
+++ b/activity/src/platform/webPlatform.ts
@@ -182,15 +182,35 @@ export interface WebRoomMemberView {
     connected: boolean;
 }
 
+export type WebRoomVisibility = "public" | "private";
+
 export interface WebRoomView {
     code: string;
     ownerID: string;
+    visibility: WebRoomVisibility;
+    hasPassword: boolean;
     members: WebRoomMemberView[];
+}
+
+/** A public-lobby list entry (never includes the roster or password). */
+export interface PublicRoomSummaryView {
+    code: string;
+    ownerUsername: string;
+    memberCount: number;
+    maxMembers: number;
+    hasPassword: boolean;
 }
 
 export type WebRoomResult =
     | { room: WebRoomView }
-    | { error: "not_found" | "full" | "unauthorized" | "unavailable" };
+    | {
+          error:
+              | "not_found"
+              | "full"
+              | "wrong_password"
+              | "unauthorized"
+              | "unavailable";
+      };
 
 async function roomRequest(
     session: WebSession,
@@ -210,10 +230,17 @@ async function roomRequest(
         return { error: "unavailable" };
     }
 
-    if (resp.status === 401 || resp.status === 403) {
-        return { error: "unauthorized" };
+    // A locked room answers 403 with error:"wrong_password"; a real auth
+    // failure is a bare 403/401.
+    if (resp.status === 403) {
+        const reason = await readErrorReason(resp);
+        return {
+            error:
+                reason === "wrong_password" ? "wrong_password" : "unauthorized",
+        };
     }
 
+    if (resp.status === 401) return { error: "unauthorized" };
     if (resp.status === 404) return { error: "not_found" };
     if (resp.status === 409) return { error: "full" };
     if (!resp.ok) return { error: "unavailable" };
@@ -223,18 +250,59 @@ async function roomRequest(
     return { room: body.room };
 }
 
-export async function createRoom(session: WebSession): Promise<WebRoomResult> {
-    return roomRequest(session, "/api/web/room", { method: "POST" });
+async function readErrorReason(resp: Response): Promise<string | null> {
+    try {
+        const body = (await resp.json()) as { error?: string };
+        return body?.error ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export async function createRoom(
+    session: WebSession,
+    options: { visibility: WebRoomVisibility; password?: string } = {
+        visibility: "private",
+    },
+): Promise<WebRoomResult> {
+    return roomRequest(session, "/api/web/room", {
+        method: "POST",
+        body: JSON.stringify({
+            visibility: options.visibility,
+            password: options.password || null,
+        }),
+    });
 }
 
 export async function joinRoom(
     session: WebSession,
     code: string,
+    password?: string,
 ): Promise<WebRoomResult> {
     return roomRequest(session, "/api/web/room/join", {
         method: "POST",
-        body: JSON.stringify({ code }),
+        body: JSON.stringify({ code, password: password || null }),
     });
+}
+
+/**
+ * @param session - the web session
+ * @returns the public lobby list, or null on any error (caller shows empty)
+ */
+export async function listPublicRooms(
+    session: WebSession,
+): Promise<PublicRoomSummaryView[] | null> {
+    try {
+        const resp = await fetch("/api/web/rooms", {
+            headers: { Authorization: `Bearer ${session.token}` },
+        });
+
+        if (!resp.ok) return null;
+        const body = (await resp.json()) as { rooms?: PublicRoomSummaryView[] };
+        return body?.rooms ?? [];
+    } catch {
+        return null;
+    }
 }
 
 /**

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -3694,6 +3694,119 @@ fieldset.options-override:disabled .options-group {
     line-height: 1.45;
 }
 
+/* Create-room controls: visibility toggle + optional password. */
+.kmq-web-landing-create {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.kmq-web-landing-visibility {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    overflow: hidden;
+}
+
+.kmq-web-landing-toggle {
+    padding: 8px 20px;
+    border: none;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.kmq-web-landing-toggle[data-active="true"] {
+    background: var(--red-primary);
+    color: #ffffff;
+}
+
+.kmq-web-landing-hint {
+    margin: 0;
+    max-width: 300px;
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+}
+
+.kmq-web-landing-password {
+    flex-direction: column;
+    align-items: stretch;
+    width: min(90vw, 300px);
+}
+
+/* Stretch the password field to the form width so it lines up with the
+   full-width Join button below it (overrides the fixed input width). */
+.kmq-web-landing-password .kmq-web-landing-input {
+    width: auto;
+}
+
+/* Public lobby list. */
+.kmq-web-landing-lobby {
+    width: min(92vw, 360px);
+    margin-top: 20px;
+}
+
+.kmq-web-landing-lobby-title {
+    margin: 0 0 8px;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.kmq-web-landing-lobby-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    /* Cap the visible height so a large lobby scrolls within a fixed box
+       instead of stretching the whole page. ~6 rooms show before scrolling.
+       padding-right keeps rows clear of the scrollbar when it appears. */
+    max-height: 320px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.kmq-web-landing-lobby-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+}
+
+.kmq-web-landing-lobby-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-align: left;
+}
+
+.kmq-web-landing-lobby-count {
+    color: var(--text-tertiary);
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.kmq-web-landing-lobby-row .kmq-web-landing-button {
+    margin-top: 0;
+    padding: 6px 16px;
+    font-size: 0.85rem;
+}
+
 /* Floating room widget (standalone website): invite link, presence, leave.
    Fixed overlay so it never disturbs the game layout underneath. */
 .kmq-room-bar {

--- a/activity/src/web/LandingPage.tsx
+++ b/activity/src/web/LandingPage.tsx
@@ -8,6 +8,7 @@ import {
     guestLogin,
     joinRoom,
     leaveRoom,
+    listPublicRooms,
     logout,
     roomCodeFromLocation,
     roomPath,
@@ -16,7 +17,12 @@ import {
 import App from "../App";
 import RoomBar from "./RoomBar";
 import kmqLogoUrl from "../assets/kmq_logo.png";
-import type { WebRoomView, WebSession } from "../platform/webPlatform";
+import type {
+    PublicRoomSummaryView,
+    WebRoomView,
+    WebRoomVisibility,
+    WebSession,
+} from "../platform/webPlatform";
 
 type LandingState =
     | { phase: "loading" }
@@ -24,17 +30,74 @@ type LandingState =
     | { phase: "loggedIn"; session: WebSession; error: string | null }
     | { phase: "inRoom"; session: WebSession; room: WebRoomView };
 
+const PUBLIC_ROOMS_POLL_MS = 8_000;
+
 function roomErrorText(error: string): string {
     switch (error) {
         case "not_found":
             return "That room doesn't exist (or everyone left).";
         case "full":
             return "That room is full.";
+        case "wrong_password":
+            return "Wrong password. Please try again.";
         case "unauthorized":
             return "Your login expired. Please log in again.";
         default:
             return "Something went wrong. Please try again.";
     }
+}
+
+/** The browse-a-public-lobby list shown to logged-in users not yet in a room. */
+function PublicRoomList({
+    rooms,
+    busy,
+    onJoin,
+}: {
+    rooms: PublicRoomSummaryView[] | null;
+    busy: boolean;
+    onJoin: (room: PublicRoomSummaryView) => void;
+}): JSX.Element | null {
+    // null = not loaded yet / unavailable; render nothing so the lobby doesn't
+    // flash an empty state on every poll blip.
+    if (rooms === null) return null;
+
+    return (
+        <div className="kmq-web-landing-lobby">
+            <p className="kmq-web-landing-lobby-title">Public rooms</p>
+            {rooms.length === 0 ? (
+                <p className="kmq-web-landing-note">
+                    No public rooms right now — create one above!
+                </p>
+            ) : (
+                <ul className="kmq-web-landing-lobby-list">
+                    {rooms.map((room) => (
+                        <li
+                            key={room.code}
+                            className="kmq-web-landing-lobby-row"
+                        >
+                            <span className="kmq-web-landing-lobby-name">
+                                {room.ownerUsername}&apos;s room
+                                {room.hasPassword ? " 🔒" : ""}
+                            </span>
+                            <span className="kmq-web-landing-lobby-count">
+                                {room.memberCount}/{room.maxMembers}
+                            </span>
+                            <button
+                                type="button"
+                                className="kmq-web-landing-button kmq-web-landing-button-secondary"
+                                disabled={
+                                    busy || room.memberCount >= room.maxMembers
+                                }
+                                onClick={() => onJoin(room)}
+                            >
+                                Join
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
 }
 
 /**
@@ -49,6 +112,19 @@ export default function LandingPage(): JSX.Element {
     const [joinCode, setJoinCode] = useState("");
     const [guestName, setGuestName] = useState("");
     const [busy, setBusy] = useState(false);
+    // Create-room form: visibility toggle + optional join password.
+    const [visibility, setVisibility] = useState<WebRoomVisibility>("public");
+    const [createPassword, setCreatePassword] = useState("");
+    // Public lobby list (null = not loaded / unavailable).
+    const [publicRooms, setPublicRooms] = useState<
+        PublicRoomSummaryView[] | null
+    >(null);
+    // A locked room awaiting a password entry (set when a join needs one).
+    const [pendingJoin, setPendingJoin] = useState<{
+        code: string;
+        error: string | null;
+    } | null>(null);
+    const [joinPassword, setJoinPassword] = useState("");
 
     useEffect(() => {
         let cancelled = false;
@@ -82,6 +158,14 @@ export default function LandingPage(): JSX.Element {
                     );
 
                     setState({ phase: "inRoom", session, room: result.room });
+                    return;
+                }
+
+                // A locked invite room: keep the invite URL and prompt for the
+                // password rather than bouncing to the lobby.
+                if (inviteCode && result.error === "wrong_password") {
+                    setPendingJoin({ code: inviteCode, error: null });
+                    setState({ phase: "loggedIn", session, error: null });
                     return;
                 }
 
@@ -122,11 +206,84 @@ export default function LandingPage(): JSX.Element {
         setState({ phase: "loggedIn", session, error });
     };
 
+    const refreshPublicRooms = async (session: WebSession): Promise<void> => {
+        const rooms = await listPublicRooms(session);
+        setPublicRooms(rooms);
+    };
+
+    // Load the public lobby list whenever the user is logged in but not yet in
+    // a room, and refresh it on an interval so it stays roughly live.
+    useEffect(() => {
+        if (state.phase !== "loggedIn") return undefined;
+        const { session } = state;
+        void refreshPublicRooms(session);
+        const id = window.setInterval(
+            () => void refreshPublicRooms(session),
+            PUBLIC_ROOMS_POLL_MS,
+        );
+
+        return () => window.clearInterval(id);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [state.phase]);
+
+    /**
+     * Joins a room, surfacing a password prompt when the room is locked. A
+     * `wrong_password` result (whether from a missing or incorrect password)
+     * parks on the pending-join prompt instead of the generic error line.
+     */
+    const attemptJoin = async (
+        session: WebSession,
+        code: string,
+        password?: string,
+    ): Promise<void> => {
+        setBusy(true);
+        try {
+            const result = await joinRoom(session, code, password);
+            if ("room" in result) {
+                setPendingJoin(null);
+                setJoinPassword("");
+                setJoinCode("");
+                enterRoom(session, result.room);
+                return;
+            }
+
+            if (result.error === "wrong_password") {
+                setPendingJoin({
+                    code,
+                    // Only show "wrong password" once they've actually tried
+                    // one; the first prompt is just a request.
+                    error: password ? roomErrorText("wrong_password") : null,
+                });
+
+                setState((prev) =>
+                    prev.phase === "inRoom"
+                        ? prev
+                        : { phase: "loggedIn", session, error: null },
+                );
+                return;
+            }
+
+            setPendingJoin(null);
+            setState({
+                phase: "loggedIn",
+                session,
+                error: roomErrorText(result.error),
+            });
+        } finally {
+            setBusy(false);
+        }
+    };
+
     const handleCreate = async (session: WebSession): Promise<void> => {
         setBusy(true);
         try {
-            const result = await createRoom(session);
+            const result = await createRoom(session, {
+                visibility,
+                password: createPassword.trim() || undefined,
+            });
+
             if ("room" in result) {
+                setCreatePassword("");
                 enterRoom(session, result.room);
             } else {
                 setState({
@@ -146,23 +303,7 @@ export default function LandingPage(): JSX.Element {
         const fromUrl = /\/play\/r\/([^/\s?#]+)/.exec(raw);
         const code = fromUrl ? decodeURIComponent(fromUrl[1]!) : raw;
         if (!code) return;
-
-        setBusy(true);
-        try {
-            const result = await joinRoom(session, code);
-            if ("room" in result) {
-                setJoinCode("");
-                enterRoom(session, result.room);
-            } else {
-                setState({
-                    phase: "loggedIn",
-                    session,
-                    error: roomErrorText(result.error),
-                });
-            }
-        } finally {
-            setBusy(false);
-        }
+        await attemptJoin(session, code);
     };
 
     const handleGuestLogin = async (): Promise<void> => {
@@ -177,26 +318,15 @@ export default function LandingPage(): JSX.Element {
                 return;
             }
 
-            // A guest arriving on an invite link goes straight into the room;
-            // otherwise they land on the join form (guests can't host).
+            setState({ phase: "loggedIn", session, error: null });
+
+            // A guest arriving on an invite link goes straight into the room
+            // (or a password prompt); otherwise they land on the lobby (guests
+            // can't host, but can browse + join public rooms).
             const inviteCode = roomCodeFromLocation();
             if (inviteCode) {
-                const result = await joinRoom(session, inviteCode);
-                if ("room" in result) {
-                    enterRoom(session, result.room);
-                    return;
-                }
-
-                window.history.replaceState(null, "", "/play");
-                setState({
-                    phase: "loggedIn",
-                    session,
-                    error: roomErrorText(result.error),
-                });
-                return;
+                await attemptJoin(session, inviteCode);
             }
-
-            setState({ phase: "loggedIn", session, error: null });
         } finally {
             setBusy(false);
         }
@@ -327,45 +457,170 @@ export default function LandingPage(): JSX.Element {
                         <p className="kmq-web-landing-error">{state.error}</p>
                     )}
 
-                    {state.session.user.guest ? (
-                        <p className="kmq-web-landing-note">
-                            You&apos;re playing as a guest — join a room with an
-                            invite code. Log in with Discord to host your own
-                            and keep your stats.
-                        </p>
+                    {pendingJoin ? (
+                        <form
+                            className="kmq-web-landing-join kmq-web-landing-password"
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                void attemptJoin(
+                                    state.session,
+                                    pendingJoin.code,
+                                    joinPassword,
+                                );
+                            }}
+                        >
+                            <p className="kmq-web-landing-note">
+                                This room requires a password.
+                            </p>
+                            {pendingJoin.error && (
+                                <p className="kmq-web-landing-error">
+                                    {pendingJoin.error}
+                                </p>
+                            )}
+                            <input
+                                className="kmq-web-landing-input"
+                                type="password"
+                                value={joinPassword}
+                                // eslint-disable-next-line jsx-a11y/no-autofocus
+                                autoFocus
+                                onChange={(e) =>
+                                    setJoinPassword(e.target.value)
+                                }
+                                placeholder="Password"
+                                aria-label="Room password"
+                            />
+                            <button
+                                type="submit"
+                                className="kmq-web-landing-button"
+                                disabled={busy || !joinPassword}
+                            >
+                                Join
+                            </button>
+                            <button
+                                type="button"
+                                className="kmq-web-landing-button kmq-web-landing-button-secondary"
+                                onClick={() => {
+                                    setPendingJoin(null);
+                                    setJoinPassword("");
+                                }}
+                            >
+                                Cancel
+                            </button>
+                        </form>
                     ) : (
-                        <button
-                            type="button"
-                            className="kmq-web-landing-button"
-                            disabled={busy}
-                            onClick={() => void handleCreate(state.session)}
-                        >
-                            Create a room
-                        </button>
-                    )}
+                        <>
+                            {state.session.user.guest ? (
+                                <p className="kmq-web-landing-note">
+                                    You&apos;re playing as a guest — browse a
+                                    public room below or join with an invite
+                                    code. Log in with Discord to host your own
+                                    and keep your stats.
+                                </p>
+                            ) : (
+                                <div className="kmq-web-landing-create">
+                                    <div
+                                        className="kmq-web-landing-visibility"
+                                        role="group"
+                                        aria-label="Room visibility"
+                                    >
+                                        <button
+                                            type="button"
+                                            className="kmq-web-landing-toggle"
+                                            data-active={
+                                                visibility === "public"
+                                            }
+                                            onClick={() =>
+                                                setVisibility("public")
+                                            }
+                                        >
+                                            Public
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className="kmq-web-landing-toggle"
+                                            data-active={
+                                                visibility === "private"
+                                            }
+                                            onClick={() =>
+                                                setVisibility("private")
+                                            }
+                                        >
+                                            Private
+                                        </button>
+                                    </div>
+                                    <p className="kmq-web-landing-hint">
+                                        {visibility === "public"
+                                            ? "Anyone can find this room in the lobby list."
+                                            : "Only people with the invite link can join."}
+                                    </p>
+                                    <input
+                                        className="kmq-web-landing-input"
+                                        type="password"
+                                        value={createPassword}
+                                        maxLength={128}
+                                        onChange={(e) =>
+                                            setCreatePassword(e.target.value)
+                                        }
+                                        placeholder="Password (optional)"
+                                        aria-label="Room password (optional)"
+                                    />
+                                    <button
+                                        type="button"
+                                        className="kmq-web-landing-button"
+                                        disabled={busy}
+                                        onClick={() =>
+                                            void handleCreate(state.session)
+                                        }
+                                    >
+                                        Create a room
+                                    </button>
+                                </div>
+                            )}
 
-                    <form
-                        className="kmq-web-landing-join"
-                        onSubmit={(e) => {
-                            e.preventDefault();
-                            void handleJoin(state.session);
-                        }}
-                    >
-                        <input
-                            className="kmq-web-landing-input"
-                            value={joinCode}
-                            onChange={(e) => setJoinCode(e.target.value)}
-                            placeholder="Invite code or link"
-                            aria-label="Invite code or link"
-                        />
-                        <button
-                            type="submit"
-                            className="kmq-web-landing-button kmq-web-landing-button-secondary"
-                            disabled={busy || !joinCode.trim()}
-                        >
-                            Join
-                        </button>
-                    </form>
+                            <form
+                                className="kmq-web-landing-join"
+                                onSubmit={(e) => {
+                                    e.preventDefault();
+                                    void handleJoin(state.session);
+                                }}
+                            >
+                                <input
+                                    className="kmq-web-landing-input"
+                                    value={joinCode}
+                                    onChange={(e) =>
+                                        setJoinCode(e.target.value)
+                                    }
+                                    placeholder="Invite code or link"
+                                    aria-label="Invite code or link"
+                                />
+                                <button
+                                    type="submit"
+                                    className="kmq-web-landing-button kmq-web-landing-button-secondary"
+                                    disabled={busy || !joinCode.trim()}
+                                >
+                                    Join
+                                </button>
+                            </form>
+
+                            <PublicRoomList
+                                rooms={publicRooms}
+                                busy={busy}
+                                onJoin={(room) => {
+                                    if (room.hasPassword) {
+                                        setPendingJoin({
+                                            code: room.code,
+                                            error: null,
+                                        });
+                                    } else {
+                                        void attemptJoin(
+                                            state.session,
+                                            room.code,
+                                        );
+                                    }
+                                }}
+                            />
+                        </>
+                    )}
 
                     <button
                         type="button"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -427,6 +427,9 @@ export const WEB_GUEST_USERNAME_MAX_LENGTH = 32;
 // user ID so a recreated room keeps its game options and presets.
 export const WEB_ROOM_ID_FLAG = 1n << 62n;
 export const WEB_ROOM_MAX_MEMBERS = 8;
+// Cap the optional join-password length; rooms are ephemeral, this is only
+// abuse defense against a huge payload.
+export const WEB_ROOM_PASSWORD_MAX_LENGTH = 128;
 // A member with no open websocket is dropped from the room after this grace
 // period (survives refreshes and brief network blips); a room with no members
 // left is closed.

--- a/src/kmq_web_server.ts
+++ b/src/kmq_web_server.ts
@@ -29,6 +29,7 @@ import {
     WEB_LOGIN_CODE_TTL_MS,
     WEB_OAUTH_STATE_COOKIE,
     WEB_OAUTH_STATE_TTL_MS,
+    WEB_ROOM_PASSWORD_MAX_LENGTH,
     WEB_ROOM_SWEEP_INTERVAL_MS,
     discordAvatarUrl,
 } from "./constants";
@@ -2801,11 +2802,31 @@ export default class KmqWebServer {
                     return;
                 }
 
-                const result = this.webRoomManager!.createRoom({
-                    id: user.id,
-                    username: user.username,
-                    avatarUrl: user.avatarUrl,
-                });
+                const createBody = (request.body ?? {}) as {
+                    visibility?: unknown;
+                    password?: unknown;
+                };
+
+                // Default private (preserves the pre-lobbies behavior); only
+                // "public" opts into the browse list.
+                const visibility =
+                    createBody.visibility === "public" ? "public" : "private";
+
+                const password = this.parseRoomPassword(createBody.password);
+                if (password === undefined) {
+                    await reply.code(400).send({ error: "Invalid password" });
+                    return;
+                }
+
+                const result = this.webRoomManager!.createRoom(
+                    {
+                        id: user.id,
+                        username: user.username,
+                        avatarUrl: user.avatarUrl,
+                        isGuest: false,
+                    },
+                    { visibility, password },
+                );
 
                 if ("error" in result) {
                     // Only possible when rejoining one's own still-alive room
@@ -2827,21 +2848,44 @@ export default class KmqWebServer {
                 const user = await requireWebUser(request, reply);
                 if (!user) return;
 
-                const code = (request.body as { code?: string } | null)?.code;
+                const joinBody = (request.body ?? {}) as {
+                    code?: unknown;
+                    password?: unknown;
+                };
+
+                const code = joinBody.code;
                 if (!code || typeof code !== "string") {
                     await reply.code(400).send({ error: "Missing code" });
                     return;
                 }
 
-                const result = this.webRoomManager!.joinRoom(code, {
-                    id: user.id,
-                    username: user.username,
-                    avatarUrl: user.avatarUrl,
-                });
+                const password = this.parseRoomPassword(joinBody.password);
+                if (password === undefined) {
+                    await reply.code(400).send({ error: "Invalid password" });
+                    return;
+                }
+
+                const result = this.webRoomManager!.joinRoom(
+                    code,
+                    {
+                        id: user.id,
+                        username: user.username,
+                        avatarUrl: user.avatarUrl,
+                        isGuest: isGuestUserID(user.id),
+                    },
+                    password ?? undefined,
+                );
 
                 if ("error" in result) {
+                    // not_found → 404; wrong_password → 403; full → 409.
+                    const statusByError: Record<string, number> = {
+                        not_found: 404,
+                        wrong_password: 403,
+                        full: 409,
+                    };
+
                     await reply
-                        .code(result.error === "not_found" ? 404 : 409)
+                        .code(statusByError[result.error] ?? 409)
                         .send({ error: result.error });
                     return;
                 }
@@ -2895,6 +2939,44 @@ export default class KmqWebServer {
                 });
             },
         );
+
+        httpServer.get(
+            "/api/web/rooms",
+            limit(ACTIVITY_RATE_LIMIT_READ),
+            async (request, reply) => {
+                // Public lobby list — the "find a game" surface. Any web user
+                // (guest included) may browse it; it never leaks rosters or
+                // passwords (see WebRoomManager.listPublicRooms).
+                const user = await requireWebUser(request, reply);
+                if (!user) return;
+
+                await reply.code(200).send({
+                    rooms: this.webRoomManager!.listPublicRooms(),
+                });
+            },
+        );
+    }
+
+    /**
+     * Validates a client-supplied room password. Returns the trimmed password,
+     * null when none was supplied (open room), or `undefined` when the value
+     * is the wrong type or too long (the caller should 400).
+     * @param raw - the raw `password` field from the request body
+     * @returns the password, null, or undefined (invalid)
+     */
+    private parseRoomPassword(raw: unknown): string | null | undefined {
+        if (raw === undefined || raw === null || raw === "") {
+            return null;
+        }
+
+        if (
+            typeof raw !== "string" ||
+            raw.length > WEB_ROOM_PASSWORD_MAX_LENGTH
+        ) {
+            return undefined;
+        }
+
+        return raw;
     }
 
     /**

--- a/src/test/unit_tests/ci/web_room_manager.test.ts
+++ b/src/test/unit_tests/ci/web_room_manager.test.ts
@@ -8,10 +8,11 @@ import WebRoomManager from "../../../web_room_manager";
 import assert from "assert";
 import type { WebRoomMemberIdentity } from "../../../web_room_manager";
 
-const user = (n: number): WebRoomMemberIdentity => ({
+const user = (n: number, isGuest = false): WebRoomMemberIdentity => ({
     id: (100000000000000000n + BigInt(n)).toString(),
     username: `user${n}`,
     avatarUrl: null,
+    isGuest,
 });
 
 describe("web room manager", () => {
@@ -253,6 +254,8 @@ describe("web room manager", () => {
             assert.deepStrictEqual(serialized, {
                 code: created.room.code,
                 ownerID: user(1).id,
+                visibility: "private",
+                hasPassword: false,
                 members: [
                     {
                         id: user(1).id,
@@ -262,6 +265,108 @@ describe("web room manager", () => {
                     },
                 ],
             });
+        });
+    });
+
+    describe("visibility and public listing", () => {
+        it("defaults to a private, unlisted room", () => {
+            const created = manager.createRoom(user(1));
+            assert.ok("room" in created);
+            assert.strictEqual(created.room.visibility, "private");
+            assert.deepStrictEqual(manager.listPublicRooms(), []);
+        });
+
+        it("lists public rooms with owner name and counts, newest first", () => {
+            const a = manager.createRoom(user(1), { visibility: "public" });
+            assert.ok("room" in a);
+            manager.joinRoom(a.room.code, user(2));
+
+            clock.now += 1000;
+            const b = manager.createRoom(user(3), { visibility: "public" });
+            assert.ok("room" in b);
+
+            // A private room stays out of the list.
+            manager.createRoom(user(4), { visibility: "private" });
+
+            const list = manager.listPublicRooms();
+            assert.strictEqual(list.length, 2);
+            // Newest (user3's) first.
+            assert.strictEqual(list[0]!.code, b.room.code);
+            assert.strictEqual(list[0]!.ownerUsername, "user3");
+            assert.strictEqual(list[0]!.memberCount, 1);
+            assert.strictEqual(list[0]!.hasPassword, false);
+            assert.strictEqual(list[1]!.code, a.room.code);
+            assert.strictEqual(list[1]!.memberCount, 2);
+        });
+    });
+
+    describe("password-protected rooms", () => {
+        it("rejects a join with a wrong/missing password and accepts the right one", () => {
+            const created = manager.createRoom(user(1), {
+                visibility: "public",
+                password: "hunter2",
+            });
+
+            assert.ok("room" in created);
+            const { code } = created.room;
+
+            assert.deepStrictEqual(manager.joinRoom(code, user(2)), {
+                error: "wrong_password",
+            });
+
+            assert.deepStrictEqual(manager.joinRoom(code, user(2), "nope"), {
+                error: "wrong_password",
+            });
+
+            assert.ok("room" in manager.joinRoom(code, user(2), "hunter2"));
+            assert.strictEqual(created.room.members.size, 2);
+        });
+
+        it("surfaces the password requirement without leaking the password", () => {
+            const created = manager.createRoom(user(1), {
+                visibility: "public",
+                password: "secret",
+            });
+
+            assert.ok("room" in created);
+
+            const serialized = manager.serializeRoom(created.room);
+            assert.strictEqual(serialized.hasPassword, true);
+            assert.ok(!("passwordHash" in serialized));
+
+            const summary = manager.listPublicRooms()[0]!;
+            assert.strictEqual(summary.hasPassword, true);
+        });
+
+        it("lets an existing member reconnect without re-supplying the password", () => {
+            const created = manager.createRoom(user(1), {
+                password: "pw",
+            });
+
+            assert.ok("room" in created);
+            // The owner is already a member; a bare join refreshes identity.
+            assert.ok("room" in manager.joinRoom(created.room.code, user(1)));
+        });
+
+        it("re-applies visibility and password when the owner recreates the room", () => {
+            const created = manager.createRoom(user(1), {
+                visibility: "public",
+            });
+
+            assert.ok("room" in created);
+            manager.joinRoom(created.room.code, user(2));
+            manager.leaveRoom(user(1).id);
+
+            // Owner recreates → same room, now private + locked.
+            const again = manager.createRoom(user(1), {
+                visibility: "private",
+                password: "locked",
+            });
+
+            assert.ok("room" in again);
+            assert.strictEqual(again.room, created.room);
+            assert.strictEqual(again.room.visibility, "private");
+            assert.strictEqual(again.room.passwordHash !== null, true);
         });
     });
 });

--- a/src/web_room_manager.ts
+++ b/src/web_room_manager.ts
@@ -10,6 +10,8 @@ export interface WebRoomMemberIdentity {
     id: string;
     username: string;
     avatarUrl: string | null;
+    /** Whether this is a website guest (no Discord account). */
+    isGuest: boolean;
 }
 
 interface WebRoomMember extends WebRoomMemberIdentity {
@@ -27,6 +29,10 @@ interface WebRoomMember extends WebRoomMemberIdentity {
     disconnectedAt: number | null;
 }
 
+/** Room visibility: public rooms appear in the browse list, private don't. */
+// eslint-disable-next-line import/no-unused-modules
+export type WebRoomVisibility = "public" | "private";
+
 // eslint-disable-next-line import/no-unused-modules
 export interface WebRoom {
     /** Shareable, unguessable invite code; doubles as the instance_id. */
@@ -39,6 +45,20 @@ export interface WebRoom {
 
     createdAt: number;
 
+    /**
+     * Public rooms are listed in the browse lobby; private rooms are reachable
+     * by invite code/link only. Independent of the optional password.
+     */
+    visibility: WebRoomVisibility;
+
+    /**
+     * Optional join password (sha256 of salt+password) — enforced on join
+     * regardless of visibility, so an invite link to a locked room still
+     * prompts. Null when the room is open.
+     */
+    passwordHash: string | null;
+    passwordSalt: string | null;
+
     /** Keyed by user ID; insertion order determines owner succession. */
     members: Map<string, WebRoomMember>;
 }
@@ -48,6 +68,8 @@ export interface WebRoom {
 export interface SerializedWebRoom {
     code: string;
     ownerID: string;
+    visibility: WebRoomVisibility;
+    hasPassword: boolean;
     members: Array<{
         id: string;
         username: string;
@@ -56,10 +78,27 @@ export interface SerializedWebRoom {
     }>;
 }
 
+/** Public-lobby list entry (never leaks the member roster or the password). */
+// eslint-disable-next-line import/no-unused-modules
+export interface PublicRoomSummary {
+    code: string;
+    ownerUsername: string;
+    memberCount: number;
+    maxMembers: number;
+    hasPassword: boolean;
+}
+
 // eslint-disable-next-line import/no-unused-modules
 export type WebRoomJoinResult =
     | { room: WebRoom }
-    | { error: "not_found" | "full" };
+    | { error: "not_found" | "full" | "wrong_password" };
+
+/** Options for creating a room. */
+// eslint-disable-next-line import/no-unused-modules
+export interface CreateRoomOptions {
+    visibility?: WebRoomVisibility;
+    password?: string | null;
+}
 
 interface WebRoomManagerOptions {
     /**
@@ -118,22 +157,53 @@ export default class WebRoomManager {
      * room IDs are deterministic per creator, so two live rooms can never
      * share one.
      * @param user - the creating user
+     * @param options - visibility + optional join password
      * @returns the created (or rejoined) room
      */
-    createRoom(user: WebRoomMemberIdentity): WebRoomJoinResult {
+    createRoom(
+        user: WebRoomMemberIdentity,
+        options: CreateRoomOptions = {},
+    ): WebRoomJoinResult {
+        const visibility: WebRoomVisibility =
+            options.visibility === "public" ? "public" : "private";
+
         const roomID = WebRoomManager.roomIDForOwner(user.id);
         const existingCode = this.roomCodeByRoomID.get(roomID);
         if (existingCode) {
-            return this.joinRoom(existingCode, user);
+            // Recreating one's own still-alive room re-applies the new
+            // visibility/password (the owner reconfiguring it) and rejoins
+            // without a password prompt — it's their own room.
+            const existingRoom = this.roomsByCode.get(existingCode)!;
+            const { hash, salt } = WebRoomManager.hashPassword(
+                options.password,
+            );
+
+            existingRoom.visibility = visibility;
+            existingRoom.passwordHash = hash;
+            existingRoom.passwordSalt = salt;
+
+            if (existingRoom.members.size >= WEB_ROOM_MAX_MEMBERS) {
+                return { error: "full" };
+            }
+
+            this.leaveRoom(user.id);
+            existingRoom.members.set(user.id, this.newMember(user));
+            this.roomCodeByUserID.set(user.id, existingCode);
+            this.onRoomChanged(existingRoom);
+            return { room: existingRoom };
         }
 
         this.leaveRoom(user.id);
 
+        const { hash, salt } = WebRoomManager.hashPassword(options.password);
         const room: WebRoom = {
             code: crypto.randomBytes(9).toString("base64url"),
             roomID,
             ownerID: user.id,
             createdAt: this.now(),
+            visibility,
+            passwordHash: hash,
+            passwordSalt: salt,
             members: new Map(),
         };
 
@@ -150,9 +220,14 @@ export default class WebRoomManager {
      * room the user is already in just refreshes their identity fields.
      * @param code - the invite code
      * @param user - the joining user
+     * @param password - the supplied join password, if the room requires one
      * @returns the room, or why the join failed
      */
-    joinRoom(code: string, user: WebRoomMemberIdentity): WebRoomJoinResult {
+    joinRoom(
+        code: string,
+        user: WebRoomMemberIdentity,
+        password?: string,
+    ): WebRoomJoinResult {
         const room = this.roomsByCode.get(code);
         if (!room) {
             return { error: "not_found" };
@@ -160,9 +235,14 @@ export default class WebRoomManager {
 
         const existing = room.members.get(user.id);
         if (existing) {
+            // Already a member (reconnect/refresh): no password re-prompt.
             existing.username = user.username;
             existing.avatarUrl = user.avatarUrl;
             return { room };
+        }
+
+        if (!WebRoomManager.passwordMatches(room, password)) {
+            return { error: "wrong_password" };
         }
 
         if (room.members.size >= WEB_ROOM_MAX_MEMBERS) {
@@ -174,6 +254,25 @@ export default class WebRoomManager {
         this.roomCodeByUserID.set(user.id, code);
         this.onRoomChanged(room);
         return { room };
+    }
+
+    /**
+     * @returns browse-list summaries of every public room, newest first. The
+     * roster and password are never exposed — only the owner's name, the live
+     * member count, and whether a password is required.
+     */
+    listPublicRooms(): PublicRoomSummary[] {
+        return [...this.roomsByCode.values()]
+            .filter((room) => room.visibility === "public")
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .map((room) => ({
+                code: room.code,
+                ownerUsername:
+                    room.members.get(room.ownerID)?.username ?? "KMQ player",
+                memberCount: room.members.size,
+                maxMembers: WEB_ROOM_MAX_MEMBERS,
+                hasPassword: room.passwordHash !== null,
+            }));
     }
 
     /**
@@ -280,6 +379,8 @@ export default class WebRoomManager {
         return {
             code: room.code,
             ownerID: room.ownerID,
+            visibility: room.visibility,
+            hasPassword: room.passwordHash !== null,
             members: [...room.members.values()].map((m) => ({
                 id: m.id,
                 username: m.username,
@@ -289,11 +390,62 @@ export default class WebRoomManager {
         };
     }
 
+    /**
+     * @param password - the raw join password (or null/empty for no password)
+     * @returns the salt + sha256(salt+password) to store, or nulls when open.
+     * Rooms are ephemeral in-memory, so a fast salted hash is sufficient — it
+     * just keeps the plaintext out of memory dumps and the serialized shape.
+     */
+    private static hashPassword(password: string | null | undefined): {
+        hash: string | null;
+        salt: string | null;
+    } {
+        if (!password) {
+            return { hash: null, salt: null };
+        }
+
+        const salt = crypto.randomBytes(16).toString("hex");
+        const hash = crypto
+            .createHash("sha256")
+            .update(salt + password)
+            .digest("hex");
+
+        return { hash, salt };
+    }
+
+    /**
+     * @param room - the room whose password to check
+     * @param password - the supplied password (may be undefined)
+     * @returns whether the room is open or the password matches (timing-safe)
+     */
+    private static passwordMatches(
+        room: WebRoom,
+        password: string | undefined,
+    ): boolean {
+        if (!room.passwordHash || !room.passwordSalt) {
+            return true;
+        }
+
+        if (typeof password !== "string" || password.length === 0) {
+            return false;
+        }
+
+        const candidate = crypto
+            .createHash("sha256")
+            .update(room.passwordSalt + password)
+            .digest("hex");
+
+        const a = Buffer.from(candidate, "hex");
+        const b = Buffer.from(room.passwordHash, "hex");
+        return a.length === b.length && crypto.timingSafeEqual(a, b);
+    }
+
     private newMember(user: WebRoomMemberIdentity): WebRoomMember {
         return {
             id: user.id,
             username: user.username,
             avatarUrl: user.avatarUrl,
+            isGuest: user.isGuest,
             connections: 0,
             disconnectedAt: this.now(),
         };


### PR DESCRIPTION
Adds room discovery to the web port. Previously rooms were join-by-invite-code only, so a visitor with no friends online hit a dead end.

**Web port only** — all of this lives behind `webModeEnabled` + `WebRoomManager`, never the embedded Activity or legacy KMQ.

## Model
- `visibility` (`public`/`private`) **only** controls listing: public rooms appear in everyone's browse list; private rooms are invite-only. Default `private`.
- `password` is an **independent** optional layer on **both** kinds. Public-with-password shows a lock in the list and prompts on join; private-with-password prompts on invite join. An invite link to a password-protected room still requires the password.

## Changes
- `WebRoomManager`: `visibility` + salted-sha256 `passwordHash`/`passwordSalt` on rooms (timing-safe compare), `isGuest` on members, `createRoom(user, {visibility, password})`, `joinRoom(code, user, password?)` with new `wrong_password` error, `listPublicRooms()` → `{code, ownerUsername, memberCount, maxMembers, hasPassword}` (label = owner name + member count, sorted newest-first).
- Routes: create/join parse `{visibility?, password?}` / `{code, password?}`; new guest-allowed `GET /api/web/rooms`; `wrong_password` → 403.
- Frontend `LandingPage`: public/private toggle + optional password input, public-room browse list with Join, and a password prompt on protected rooms.
- Tests: visibility/public-listing and password (right/wrong/none) coverage in `web_room_manager.test.ts`.

Second of a 4-PR stack — **based on #2391**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)