### PR TITLE
Use look-alike-free invite codes (web only)

### DIFF
--- a/activity/src/web/LandingPage.tsx
+++ b/activity/src/web/LandingPage.tsx
@@ -327,10 +327,13 @@ export default function LandingPage(): JSX.Element {
     };
 
     const handleJoin = async (session: WebSession): Promise<void> => {
-        // Accept a pasted invite URL or a bare code.
+        // Accept a pasted invite URL or a bare code. Codes are uppercase-only,
+        // so normalize typed input — a hand-entered lowercase code still joins.
         const raw = joinCode.trim();
         const fromUrl = /\/play\/r\/([^/\s?#]+)/.exec(raw);
-        const code = fromUrl ? decodeURIComponent(fromUrl[1]!) : raw;
+        const code = (
+            fromUrl ? decodeURIComponent(fromUrl[1]!) : raw
+        ).toUpperCase();
         if (!code) return;
         await attemptJoin(session, code);
     };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -427,6 +427,13 @@ export const WEB_GUEST_USERNAME_MAX_LENGTH = 32;
 // user ID so a recreated room keeps its game options and presets.
 export const WEB_ROOM_ID_FLAG = 1n << 62n;
 export const WEB_ROOM_MAX_MEMBERS = 8;
+// Invite codes are shared in chat, typed by hand, and read aloud, so draw them
+// from an alphabet with no look-alike characters: the digits 0/1 and letters
+// O/I are excluded (L stays — nothing resembles it once 1 and I are gone), and
+// it's uppercase-only to avoid case confusion. 32 chars ^ 12 ≈ 60 bits, ample
+// for ephemeral, rate-limited rooms.
+export const WEB_ROOM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+export const WEB_ROOM_CODE_LENGTH = 12;
 // Cap the optional join-password length; rooms are ephemeral, this is only
 // abuse defense against a huge payload.
 export const WEB_ROOM_PASSWORD_MAX_LENGTH = 128;

--- a/src/test/unit_tests/ci/web_room_manager.test.ts
+++ b/src/test/unit_tests/ci/web_room_manager.test.ts
@@ -1,4 +1,6 @@
 import {
+    WEB_ROOM_CODE_ALPHABET,
+    WEB_ROOM_CODE_LENGTH,
     WEB_ROOM_DISCONNECT_GRACE_MS,
     WEB_ROOM_ID_FLAG,
     WEB_ROOM_MAX_GUESTS,
@@ -394,6 +396,27 @@ describe("web room manager", () => {
 
             // ...but a Discord (non-guest) user can still take the free slot.
             assert.ok("room" in manager.joinRoom(code, user(99, false)));
+        });
+    });
+
+    describe("invite codes", () => {
+        it("draws codes only from the look-alike-free alphabet", () => {
+            const allowed = new RegExp(
+                `^[${WEB_ROOM_CODE_ALPHABET}]{${WEB_ROOM_CODE_LENGTH}}$`,
+            );
+
+            const seen = new Set<string>();
+            for (let i = 0; i < 200; i++) {
+                const created = manager.createRoom(user(i));
+                assert.ok("room" in created);
+                const { code } = created.room;
+
+                assert.match(code, allowed);
+                // No 0/O or 1/I look-alikes ever appear.
+                assert.doesNotMatch(code, /[0O1I]/);
+                assert.strictEqual(seen.has(code), false);
+                seen.add(code);
+            }
         });
     });
 });

--- a/src/web_room_manager.ts
+++ b/src/web_room_manager.ts
@@ -1,4 +1,6 @@
 import {
+    WEB_ROOM_CODE_ALPHABET,
+    WEB_ROOM_CODE_LENGTH,
     WEB_ROOM_DISCONNECT_GRACE_MS,
     WEB_ROOM_ID_FLAG,
     WEB_ROOM_MAX_GUESTS,
@@ -198,7 +200,7 @@ export default class WebRoomManager {
 
         const { hash, salt } = WebRoomManager.hashPassword(options.password);
         const room: WebRoom = {
-            code: crypto.randomBytes(9).toString("base64url"),
+            code: this.generateRoomCode(),
             roomID,
             ownerID: user.id,
             createdAt: this.now(),
@@ -463,6 +465,27 @@ export default class WebRoomManager {
             connections: 0,
             disconnectedAt: this.now(),
         };
+    }
+
+    /**
+     * Generates an unguessable, human-readable invite code drawn from the
+     * look-alike-free alphabet (see WEB_ROOM_CODE_ALPHABET), retrying on the
+     * astronomically unlikely collision with a live room.
+     * @returns a fresh room code not currently in use
+     */
+    private generateRoomCode(): string {
+        for (;;) {
+            let code = "";
+            for (let i = 0; i < WEB_ROOM_CODE_LENGTH; i++) {
+                code += WEB_ROOM_CODE_ALPHABET.charAt(
+                    crypto.randomInt(WEB_ROOM_CODE_ALPHABET.length),
+                );
+            }
+
+            if (!this.roomsByCode.has(code)) {
+                return code;
+            }
+        }
     }
 
     private closeRoom(room: WebRoom, lastMemberID: string): void {


### PR DESCRIPTION
Room invite codes were `base64url`-encoded random bytes, whose alphabet mixes `0`/`O`, `1`/`I`/`l`, and upper/lowercase — easy to misread when a code is typed by hand or read aloud.

## Changes
- Generate codes from an unambiguous **uppercase** alphabet `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` (excludes `0`/`O` and `1`/`I`; `L` stays since nothing resembles it once `1`/`I` are gone), 12 chars ≈ 60 bits of entropy, with a collision-retry against live rooms.
- Normalize typed join input to uppercase so a hand-entered lowercase code still matches.
- Unit test asserting generated codes only use the alphabet, never contain `0/O/1/I`, and are unique.

Web-only: room codes are generated solely by `WebRoomManager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)