### PR TITLE
Hide the /play hint in the web empty-state banner (web only)

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -1324,6 +1324,7 @@ function CurrentRound({
     noActiveGame,
     levelUps,
     viewerID,
+    isWeb,
     t,
 }: {
     round: ActivityRoundMeta | null;
@@ -1349,6 +1350,9 @@ function CurrentRound({
     levelUps: UiState["levelUps"];
     /** The viewer's Discord ID, to highlight their own level-up. */
     viewerID: string | null;
+    /** True on the standalone website, where there is no `/play` slash command
+     *  to point idle players at (the empty-state banner drops that clause). */
+    isWeb: boolean;
     t: Translator;
 }) {
     return (
@@ -1566,9 +1570,11 @@ function CurrentRound({
                                 </p>
                             ) : noActiveGame ? (
                                 <p className="empty">
-                                    {t("sessionEndedBanner", {
-                                        playSlash: "/play",
-                                    })}
+                                    {isWeb
+                                        ? t("sessionEndedBannerWeb")
+                                        : t("sessionEndedBanner", {
+                                              playSlash: "/play",
+                                          })}
                                 </p>
                             ) : (
                                 <p className="empty">
@@ -5314,6 +5320,7 @@ export default function App({ webAuth }: { webAuth?: WebAuth }) {
                             noActiveGame={ui.sessionEnded}
                             levelUps={ui.levelUps}
                             viewerID={authState?.userID ?? null}
+                            isWeb={!!webAuth}
                             t={t}
                             winnerText={
                                 ui.sessionEnded &&

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -278,6 +278,7 @@
             "title": "Ein Lied suchen"
         },
         "sessionEndedBanner": "Kein aktives Spiel — starte eines mit dem Button oben (oder {{playSlash}} in diesem Kanal).",
+        "sessionEndedBannerWeb": "Kein aktives Spiel — starte eines mit dem Button oben.",
         "sessionWinnerNone": "Spiel vorbei — keine Punkte erzielt.",
         "sessionWinnerSoloMany": "🏆 {{username}} gewinnt mit {{score}} Punkten!",
         "sessionWinnerSoloOne": "🏆 {{username}} gewinnt mit 1 Punkt!",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -278,6 +278,7 @@
             "title": "Look up a song"
         },
         "sessionEndedBanner": "No active game — start one with the button above (or {{playSlash}} in this channel).",
+        "sessionEndedBannerWeb": "No active game — start one with the button above.",
         "sessionWinnerNone": "Game over — no points scored.",
         "sessionWinnerSoloMany": "🏆 {{username}} wins with {{score}} points!",
         "sessionWinnerSoloOne": "🏆 {{username}} wins with 1 point!",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -278,6 +278,7 @@
             "title": "Buscar una canción"
         },
         "sessionEndedBanner": "No hay partida activa — inicia una con el botón de arriba (o {{playSlash}} en este canal).",
+        "sessionEndedBannerWeb": "No hay partida activa — inicia una con el botón de arriba.",
         "sessionWinnerNone": "Fin de la partida — no se anotaron puntos.",
         "sessionWinnerSoloMany": "🏆 ¡{{username}} gana con {{score}} puntos!",
         "sessionWinnerSoloOne": "🏆 ¡{{username}} gana con 1 punto!",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -278,6 +278,7 @@
             "title": "Rechercher une chanson"
         },
         "sessionEndedBanner": "Aucune partie active — démarrez-en une avec le bouton ci-dessus (ou {{playSlash}} dans ce salon).",
+        "sessionEndedBannerWeb": "Aucune partie active — démarrez-en une avec le bouton ci-dessus.",
         "sessionWinnerNone": "Partie terminée — aucun point marqué.",
         "sessionWinnerSoloMany": "🏆 {{username}} gagne avec {{score}} points !",
         "sessionWinnerSoloOne": "🏆 {{username}} gagne avec 1 point !",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -278,6 +278,7 @@
             "title": "एक गाना खोजें"
         },
         "sessionEndedBanner": "कोई सक्रिय खेल नहीं — ऊपर वाले बटन से शुरू करें (या इस चैनल में {{playSlash}} टाइप करें)।",
+        "sessionEndedBannerWeb": "कोई सक्रिय खेल नहीं — ऊपर वाले बटन से शुरू करें।",
         "sessionWinnerNone": "खेल समाप्त — कोई अंक नहीं मिले।",
         "sessionWinnerSoloMany": "🏆 {{username}} {{score}} अंकों के साथ जीते!",
         "sessionWinnerSoloOne": "🏆 {{username}} 1 अंक के साथ जीते!",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -278,6 +278,7 @@
             "title": "Cari lagu"
         },
         "sessionEndedBanner": "Tidak ada permainan aktif — mulai satu dengan tombol di atas (atau {{playSlash}} di channel ini).",
+        "sessionEndedBannerWeb": "Tidak ada permainan aktif — mulai satu dengan tombol di atas.",
         "sessionWinnerNone": "Permainan selesai — tidak ada poin.",
         "sessionWinnerSoloMany": "🏆 {{username}} menang dengan {{score}} poin!",
         "sessionWinnerSoloOne": "🏆 {{username}} menang dengan 1 poin!",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -278,6 +278,7 @@
             "title": "曲を検索する"
         },
         "sessionEndedBanner": "進行中のゲームがありません — 上のボタンから開始してください(またはこのチャンネルで {{playSlash}})。",
+        "sessionEndedBannerWeb": "進行中のゲームがありません — 上のボタンから開始してください。",
         "sessionWinnerNone": "ゲーム終了 — 得点なし。",
         "sessionWinnerSoloMany": "🏆 {{username}}が{{score}}点で優勝!",
         "sessionWinnerSoloOne": "🏆 {{username}}が1点で優勝!",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -278,6 +278,7 @@
             "title": "노래 찾아보기"
         },
         "sessionEndedBanner": "진행 중인 게임이 없습니다 — 위 버튼으로 시작하세요 (또는 이 채널에서 {{playSlash}}).",
+        "sessionEndedBannerWeb": "진행 중인 게임이 없습니다 — 위 버튼으로 시작하세요.",
         "sessionWinnerNone": "게임 종료 — 득점 없음.",
         "sessionWinnerSoloMany": "🏆 {{username}}님이 {{score}}점으로 우승!",
         "sessionWinnerSoloOne": "🏆 {{username}}님이 1점으로 우승!",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -278,6 +278,7 @@
             "title": "Zoek een lied op"
         },
         "sessionEndedBanner": "Geen actief spel — start er een met de knop hierboven (of {{playSlash}} in dit kanaal).",
+        "sessionEndedBannerWeb": "Geen actief spel — start er een met de knop hierboven.",
         "sessionWinnerNone": "Spel afgelopen — geen punten gescoord.",
         "sessionWinnerSoloMany": "🏆 {{username}} wint met {{score}} punten!",
         "sessionWinnerSoloOne": "🏆 {{username}} wint met 1 punt!",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -278,6 +278,7 @@
             "title": "Buscar uma música"
         },
         "sessionEndedBanner": "Nenhum jogo ativo — inicie um com o botão acima (ou {{playSlash}} neste canal).",
+        "sessionEndedBannerWeb": "Nenhum jogo ativo — inicie um com o botão acima.",
         "sessionWinnerNone": "Fim de jogo — nenhum ponto marcado.",
         "sessionWinnerSoloMany": "🏆 {{username}} vence com {{score}} pontos!",
         "sessionWinnerSoloOne": "🏆 {{username}} vence com 1 ponto!",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -278,6 +278,7 @@
             "title": "Найти песню"
         },
         "sessionEndedBanner": "Активной игры нет — запустите кнопкой сверху (или {{playSlash}} в этом канале).",
+        "sessionEndedBannerWeb": "Активной игры нет — запустите кнопкой сверху.",
         "sessionWinnerNone": "Игра окончена — очков не набрано.",
         "sessionWinnerSoloMany": "🏆 {{username}} побеждает с {{score}} очками!",
         "sessionWinnerSoloOne": "🏆 {{username}} побеждает с 1 очком!",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -278,6 +278,7 @@
             "title": "查找歌曲"
         },
         "sessionEndedBanner": "没有进行中的游戏 — 使用上方按钮开始(或在此频道使用 {{playSlash}})。",
+        "sessionEndedBannerWeb": "没有进行中的游戏 — 使用上方按钮开始。",
         "sessionWinnerNone": "游戏结束 — 未得分。",
         "sessionWinnerSoloMany": "🏆 {{username}} 以 {{score}} 分获胜!",
         "sessionWinnerSoloOne": "🏆 {{username}} 以 1 分获胜!",


### PR DESCRIPTION
The idle "no active game" banner points players at the `/play` slash command, which doesn't exist on the standalone website. This adds a web-specific banner string that drops the `… or /play in this channel` clause and selects it when running under `webAuth`.

The embedded Activity keeps the original banner — `/play` **is** a real command there — so this is web-only. All 12 locale variants are derived from each locale's existing translation (the clause removed), not re-translated.

## Verification
- Activity `tsc -b` + `vite build`, `lint-i18n-ci`, prettier: clean