### PR TITLE
Move the language picker into the in-game toggle rail

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -4703,11 +4703,15 @@ function RestartBanner({
 export default function App({
     webAuth,
     localeOverride,
+    onChangeLocaleOverride,
 }: {
     webAuth?: WebAuth;
     /** Web only: the visitor's explicit language choice from the shell picker
      *  (null = follow the browser). Changing it live-swaps the game's bundle. */
     localeOverride?: string | null;
+    /** Web only: hands a language choice back to the shell, which owns the
+     *  cookie and re-renders itself plus the game in the new locale. */
+    onChangeLocaleOverride?: (tag: string) => void;
 }) {
     const [error, setError] = useState<ConnectionError | null>(null);
     const [ready, setReady] = useState(false);
@@ -4771,9 +4775,16 @@ export default function App({
         ? (localeOverride ?? null)
         : activityLocaleOverride;
 
-    // Persists and applies an Activity language choice; the live-swap effect
-    // re-fetches the bundle in response.
-    const changeActivityLocale = (tag: string): void => {
+    // Applies a language choice from the in-game picker. On the web the shell
+    // owns the override (cookie + its own re-render), so hand it up; in the
+    // Activity persist it here and let the live-swap effect re-fetch the
+    // bundle in response.
+    const changeLocale = (tag: string): void => {
+        if (webAuth) {
+            onChangeLocaleOverride?.(tag);
+            return;
+        }
+
         storeLocaleOverride(tag);
         setActivityLocaleOverride(tag);
     };
@@ -5327,6 +5338,17 @@ export default function App({
                 </button>
             )}
 
+            {/* Language picker — left cluster, below feedback. Sits with the
+                other global preferences (theme) rather than in the web room
+                widget, so it's reachable on every surface and never clipped by
+                a screen edge. */}
+            <LanguageSelect
+                value={localeTag}
+                onChange={changeLocale}
+                t={t}
+                className="kmq-lang-toggle sidebar-toggle left"
+            />
+
             <div
                 className={`kmq-layout ${historyOpen ? "left-open" : ""} ${
                     sidebarOpen ? "right-open" : ""
@@ -5841,17 +5863,6 @@ export default function App({
             />
 
             {webAuth && <SoundControls audio={roundAudio} t={t} />}
-
-            {/* Embedded Activity language picker. On the web the shell/room bar
-                own the picker instead, so this only renders inside Discord. */}
-            {!webAuth && authState && (
-                <LanguageSelect
-                    value={localeTag}
-                    onChange={changeActivityLocale}
-                    t={t}
-                    className="kmq-activity-lang"
-                />
-            )}
 
             {/* Player chat — web rooms and the embedded Activity alike. (In
                 Discord the channel has its own text chat, but this keeps the

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -3966,20 +3966,61 @@ fieldset.options-override:disabled .options-group {
     right: 16px;
 }
 
-/* Room bar: drop the picker onto its own row under the action buttons. */
-.kmq-room-bar-lang {
-    flex-basis: 100%;
-    justify-content: center;
-}
-
-/* Embedded Activity: float the picker in the bottom-left corner (the web-only
-   sound/room widgets that live there never render inside Discord). */
-.kmq-activity-lang {
+/* In-game: the last button of the left toggle rail (history → theme → profile
+   → lookup → feedback → language), on both the website and the Activity. Same
+   40px circle as its neighbours; the native <select> is stretched invisibly
+   over the whole circle so the entire target opens the list, and the emoji
+   underneath is what's actually seen. */
+.kmq-language-select.kmq-lang-toggle {
     position: fixed;
     left: 16px;
-    bottom: 16px;
+    top: 256px;
     z-index: 99;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    gap: 0;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid var(--border-red);
+    background: var(--bg-surface);
     box-shadow: var(--shadow-md);
+    transition: all 0.2s;
+}
+
+.kmq-language-select.kmq-lang-toggle:hover {
+    background: var(--red-light);
+    border-color: var(--red-primary);
+    box-shadow: var(--shadow-glow);
+    transform: scale(1.05);
+}
+
+.kmq-language-select.kmq-lang-toggle .kmq-language-select-icon {
+    font-size: 1.1rem;
+}
+
+.kmq-language-select.kmq-lang-toggle .kmq-language-select-input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    opacity: 0;
+}
+
+/* The <select> itself is invisible, so ring the circle instead. */
+.kmq-language-select.kmq-lang-toggle:focus-within {
+    outline: 2px solid var(--red-primary);
+    outline-offset: 2px;
+}
+
+/* Short viewports (small Activity frames, landscape phones): the rail would
+   run off the bottom, so tuck the picker beside the feedback toggle. */
+@media (max-height: 560px) {
+    .kmq-language-select.kmq-lang-toggle {
+        top: 208px;
+        left: 64px;
+    }
 }
 
 /* Floating sound widget (standalone website): autoplay unlock, mute, volume.

--- a/activity/src/web/LandingPage.tsx
+++ b/activity/src/web/LandingPage.tsx
@@ -427,6 +427,7 @@ export default function LandingPage(): JSX.Element {
                         guest: state.session.user.guest === true,
                     }}
                     localeOverride={localeOverride}
+                    onChangeLocaleOverride={changeLocale}
                 />
                 <RoomBar
                     session={state.session}
@@ -436,8 +437,6 @@ export default function LandingPage(): JSX.Element {
                         exitRoom(state.session, null);
                     }}
                     onEvicted={() => exitRoom(state.session, "removed")}
-                    currentLocale={resolvedLocale}
-                    onChangeLocale={changeLocale}
                     t={t}
                 />
             </>

--- a/activity/src/web/LanguageSelect.tsx
+++ b/activity/src/web/LanguageSelect.tsx
@@ -23,6 +23,7 @@ export default function LanguageSelect({
     return (
         <label
             className={`kmq-language-select${className ? ` ${className}` : ""}`}
+            title={t("web.language")}
         >
             <span className="kmq-language-select-icon" aria-hidden>
                 🌐

--- a/activity/src/web/RoomBar.tsx
+++ b/activity/src/web/RoomBar.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { fetchRoom, roomPath } from "../platform/webPlatform";
-import LanguageSelect from "./LanguageSelect";
 import type { Translator } from "../i18n/translator";
 import type { WebRoomView } from "../platform/webPlatform";
 import type { WebSession } from "../platform/webPlatform";
@@ -20,8 +19,6 @@ export default function RoomBar({
     room: initialRoom,
     onLeave,
     onEvicted,
-    currentLocale,
-    onChangeLocale,
     t,
 }: {
     session: WebSession;
@@ -29,10 +26,6 @@ export default function RoomBar({
     onLeave: () => void;
     /** Called when the server no longer recognizes us as a member. */
     onEvicted: () => void;
-    /** Resolved locale tag driving the in-room language picker. */
-    currentLocale: string;
-    /** Persists a language choice and re-renders the game + shell in it. */
-    onChangeLocale: (tag: string) => void;
     t: Translator;
 }): JSX.Element {
     const [room, setRoom] = useState<WebRoomView>(initialRoom);
@@ -170,12 +163,6 @@ export default function RoomBar({
                         >
                             {t("web.room.leave")}
                         </button>
-                        <LanguageSelect
-                            value={currentLocale}
-                            onChange={onChangeLocale}
-                            t={t}
-                            className="kmq-room-bar-lang"
-                        />
                     </div>
                 </div>
             )}


### PR DESCRIPTION
### Problem

On the website the language picker lived in the floating room widget's action row (`.kmq-room-bar-actions`), which is a `display: flex` row with **no** `flex-wrap`. Its `flex-basis: 100%` therefore collapsed it to a bare 🌐 squeezed next to "Copy invite link" and "Leave", inside a 240px box pinned to the bottom-right corner — a small target whose native dropdown opened against the screen edge.

### Change

Language is a global preference like the theme, not a room action, so it moves to where the theme toggle already lives: the left rail of circular toggles.

🎵 history → ☀/☾ theme → 👤 profile → 🔍 lookup → 💬 feedback → 🌐 **language**

- Same 40px circle as its neighbours, with the native `<select>` stretched invisibly across the whole circle so the entire target opens the list (keeps native mobile pickers and the `aria-label`).
- Replaces **both** the room-bar row and the embedded Activity's bottom-left pill, so web and Discord now match.
- Under 560px of viewport height it tucks beside the feedback toggle rather than running off the bottom.
- The web shell still owns the locale cookie; `App` hands a choice back up via a new `onChangeLocaleOverride` prop.

### Verification

`tsc`, `prettier`, and `vite build` clean. Rail rendered and screenshotted at 760px and 420px viewport heights (normal stacking and the short-viewport fallback).