### PR TITLE
Split multiple-choice options into even rows

### DIFF
--- a/activity/src/App.tsx
+++ b/activity/src/App.tsx
@@ -1962,7 +1962,18 @@ function MultipleChoiceInput({
                     {t("guessPlaceholderWaiting")}
                 </span>
             ) : (
-                <div className="mc-choices">
+                <div
+                    className="mc-choices"
+                    // Half the choices per row (medium 6 → 3+3, hard 8 → 4+4)
+                    // instead of packing as many as fit and orphaning the
+                    // remainder on a short second row. The grid still collapses
+                    // to fewer columns when the panel is too narrow.
+                    style={
+                        {
+                            "--mc-cols": Math.ceil(choices.length / 2),
+                        } as CSSProperties
+                    }
+                >
                     {choices.map((choice) => (
                         <button
                             key={choice.id}

--- a/activity/src/styles.css
+++ b/activity/src/styles.css
@@ -1308,10 +1308,22 @@ body::before {
     scroll-margin-bottom: 16px;
 }
 
+/* Balanced rows: exactly `--mc-cols` columns (set per round to half the
+   choices, so medium 6 → 3+3 and hard 8 → 4+4). A fixed count rather than
+   auto-fit, which packs as many as fit and orphans the remainder — 5+1 at full
+   width. Narrow panels drop to two columns, which stays even for every choice
+   count the game uses (4, 6, 8). */
 .mc-choices {
+    --mc-cols: 2;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(var(--mc-cols), minmax(0, 1fr));
     gap: 8px;
+}
+
+@media (max-width: 720px) {
+    .mc-choices {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 .mc-choice {


### PR DESCRIPTION
### Problem

The choice grid used `repeat(auto-fit, minmax(140px, 1fr))`, which packs as many columns as fit and orphans the remainder on a short last row. At full width that meant **medium 5+1** and **hard 5+3** instead of balanced halves.

### Change

Give the grid an explicit column count — `--mc-cols`, set per round to half the choice count:

| answer type | choices | layout |
|---|---|---|
| easy | 4 | 2 + 2 |
| medium | 6 | 3 + 3 |
| hard | 8 | 4 + 4 |

Under 720px it drops to two columns, which stays even for every count the game uses (4, 6, 8) — so no width produces a ragged last row.

Applies to the website and the embedded Activity alike; they share `MultipleChoiceInput`.

### Verification

`tsc`, `prettier` and `vite build` clean. Grid rendered and screenshotted at 1400 / 900 / 700 / 380px widths: even rows at every one.